### PR TITLE
fix: rag experiments imports

### DIFF
--- a/redbox-core/redbox/api/format.py
+++ b/redbox-core/redbox/api/format.py
@@ -13,7 +13,7 @@ def format_documents(documents: list[Document]) -> str:
         doc_xml = (
             f"<Document>\n"
             f"\t<UUID>{parent_file_uuid}</UUID>\n"
-            f"\t<Filename>{d.metadata.get("file_name", "")}</Filename>\n"
+            f"\t<Filename>{d.metadata.get('file_name', '')}</Filename>\n"
             "\t<Content>\n"
             f"{d.page_content}\n"
             "\t</Content>\n"


### PR DESCRIPTION
## Context

After changing to 0.5 there are numerous imports that no longer work. This fixes it.

## Changes proposed in this pull request

Updating the imports and fixing a broken f string

## Guidance to review

Check it works for you

## Relevant links


## Things to check

- [X] I have added any new ENV vars in all deployed environments
- [X] I have tested any code added or changed
- [X] I have run integration tests
- [X] I have added/updated any DBT specific changes to .env.uktrade
