### PR TITLE
fix: include coach in tooltip

### DIFF
--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -18,7 +18,10 @@
           do Q&amp;A on them, extract information, summarise and more!</li>
         <li class="iai-chat-bubble__route-list-item">I can help you <strong>@search</strong> over selected documents and
           do Q&amp;A on them, with citations</li>
-      </ul>
+        <li class="iai-chat-bubble__route-list-item">I can help you <strong>@coach</strong> by analysing your current chat window and
+          giving targeted advice on how to use Redbox most effectively. I can see how you are using tools like <strong>@summarise</strong>,
+          <strong>@search</strong>, and <strong>@chat</strong> and give feedback to help you get more out of Redbox.</li>
+        </ul>
     </div>
   </tool-tip>
 </div>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We have added coach as a valid route for the chat, but we have not added it to the tooltip

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Adds the coach route to the tooltip

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Check I haven't made spelling mistakes etc.

