### PR TITLE
update CSP to use new GA links

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -190,8 +190,9 @@ CSP_SCRIPT_SRC = (
     "eu.i.posthog.com",
     "eu-assets.i.posthog.com",
     "'sha256-RfLASrooywwZYqv6kr3TCnrZzfl6ZTfbpLBJOVR/Gt4='",
-    "https://tagmanager.google.com/",
-    "https://www.googletagmanager.com/",
+    "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
+    "'sha256-qmCu1kQifDfCnUd+L49nusp7+PeRl23639pzN5QF2WA='",
+    "https://*.googletagmanager.com",
 )
 CSP_OBJECT_SRC = ("'none'",)
 CSP_REQUIRE_TRUSTED_TYPES_FOR = ("'script'",)
@@ -203,7 +204,7 @@ CSP_FONT_SRC = (
 )
 CSP_STYLE_SRC = (
     "'self'",
-    "https://tagmanager.google.com/",
+    # "https://tagmanager.google.com/",
 )
 CSP_FRAME_ANCESTORS = ("'none'",)
 
@@ -213,9 +214,9 @@ CSP_CONNECT_SRC = [
     f"{WEBSOCKET_SCHEME}://{ENVIRONMENT.hosts[0]}/ws/chat/",
     "eu.i.posthog.com",
     "eu-assets.i.posthog.com",
-    "https://www.google-analytics.com/",
-    "https://region1.google-analytics.com/",
-    "https://www.googletagmanager.com/",
+    "https://*.google-analytics.com",
+    "https://*.analytics.google.com",
+    "https://*.googletagmanager.com",
 ]
 
 


### PR DESCRIPTION
Update CSP to use suggested links from google https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics 
