### PR TITLE
feat: api middleware integration and fetch all user history

### DIFF
--- a/django_app/redbox_app/redbox_core/serializers.py
+++ b/django_app/redbox_app/redbox_core/serializers.py
@@ -9,7 +9,7 @@ User = get_user_model()
 class FileSerializer(serializers.ModelSerializer):
     class Meta:
         model = File
-        fields = ("file_name",)
+        fields = ("file_name", "created_at")
 
 
 class ChatMessageTokenUseSerializer(serializers.ModelSerializer):
@@ -53,4 +53,4 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ("is_staff", "business_unit", "grade", "email", "ai_experience", "profession", "chats", "is_developer")
+        fields = ("id", "is_staff", "business_unit", "grade", "email", "ai_experience", "profession", "chats", "is_developer")

--- a/django_app/redbox_app/redbox_core/views/api_views.py
+++ b/django_app/redbox_app/redbox_core/views/api_views.py
@@ -1,18 +1,17 @@
 from django.contrib.auth import get_user_model
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
 
 from redbox_app.redbox_core.serializers import UserSerializer
 
 User = get_user_model()
 
-
 @api_view(["GET"])
-@permission_classes([IsAuthenticated])
+@permission_classes([IsAuthenticated, IsAdminUser])
 def user_view_pre_alpha(request):
     """this is for testing and evaluation only
     this *will* change so that not all data is returned!
     """
-    serializer = UserSerializer(request.user)
+    serializer = UserSerializer(User.objects.all(), many=True, read_only=True)
     return Response(serializer.data)

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     "import_export",
     "django_q",
     "rest_framework",
+    "rest_framework.authtoken",
     "django_plotly_dash.apps.DjangoPlotlyDashConfig",
     "adminplus",
     "waffle",
@@ -415,3 +416,15 @@ UNSTRUCTURED_HOST = env.str("UNSTRUCTURED_HOST")
 GOOGLE_ANALYTICS_TAG = env.str("GOOGLE_ANALYTICS_TAG", " ")
 GOOGLE_ANALYTICS_LINK = env.str("GOOGLE_ANALYTICS_LINK", " ")
 # TEST_SSO_PROVIDER_SET_RETURNED_ACCESS_TOKEN = 'someCode'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'redbox_app.redbox_core.middleware.APIKeyAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+}
+
+
+REDBOX_API_KEY = env.str("REDBOX_API_KEY")


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We would like to build a pipeline in data workspace that outputs all our redbox user data into a dataset. This is the json output that will hopefully allow us to move forward and build our pipeline.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
changing pre existing API to fetch all user data and setting up appropriate security middleware to prevent exposing user data without relevant authentication header


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check you're happy this is safe enough for our purposes.

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
