### PR TITLE
fix: add pagination to API

### DIFF
--- a/django_app/redbox_app/redbox_core/views/api_views.py
+++ b/django_app/redbox_app/redbox_core/views/api_views.py
@@ -1,17 +1,24 @@
 from django.contrib.auth import get_user_model
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from redbox_app.redbox_core.serializers import UserSerializer
 
 User = get_user_model()
 
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
 @api_view(["GET"])
 @permission_classes([IsAuthenticated, IsAdminUser])
 def user_view_pre_alpha(request):
-    """this is for testing and evaluation only
-    this *will* change so that not all data is returned!
-    """
-    serializer = UserSerializer(User.objects.all(), many=True, read_only=True)
-    return Response(serializer.data)
+    """Return paginated user data"""
+    paginator = StandardResultsSetPagination()
+    queryset = User.objects.all()
+    result_page = paginator.paginate_queryset(queryset, request)
+    serializer = UserSerializer(result_page, many=True, read_only=True)
+    return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We have way too much data on dev and prod for it to handle just a simple curl command.
## Changes proposed in this pull request
This allows pagination on the API in which lets us actually connect to our endpoint without a 504
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Check you're happy with my approach
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
