### PR TITLE
remove TBaseModel and add metadata tests

### DIFF
--- a/redbox-core/redbox/chains/parser.py
+++ b/redbox-core/redbox/chains/parser.py
@@ -4,18 +4,17 @@ import json
 import re
 from collections.abc import AsyncIterator
 from json import JSONDecodeError
-from typing import Any, Iterator, List, Optional, Type, TypeVar, Union
+from typing import Any, Iterator, List, Optional, Type, Union
 
 import jsonpatch  # type: ignore[import]
 import pydantic  # pydantic: ignore
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import BaseMessage, BaseMessageChunk
-from langchain_core.output_parsers import BaseCumulativeTransformOutputParser
 from langchain_core.output_parsers.format_instructions import JSON_FORMAT_INSTRUCTIONS
 from langchain_core.output_parsers.transform import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import ChatGenerationChunk, Generation, GenerationChunk
-from langchain_core.utils.json import parse_and_check_json_markdown, parse_json_markdown, parse_partial_json
+from langchain_core.utils.json import parse_json_markdown
 from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
 from pydantic import BaseModel
 
@@ -32,8 +31,8 @@ class ClaudeParser(BaseCumulativeTransformOutputParser[Any]):
     describing the difference between the previous and the current object.
     """
 
-    pydantic_object: Optional[Type[TBaseModel]] = None  # type: ignore
-    """The Pydantic object to use for validation. 
+    pydantic_object: Optional[Type] = None  # type: ignore
+    """The Pydantic object to use for validation.
     If None, no validation is performed."""
 
     def _diff(self, prev: Optional[Any], next: Any) -> Any:

--- a/redbox-core/tests/test_ingest.py
+++ b/redbox-core/tests/test_ingest.py
@@ -11,16 +11,12 @@ from langchain_core.embeddings.fake import FakeEmbeddings
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_elasticsearch import ElasticsearchStore
 
-
-from redbox.models.chain import GeneratedMetadata
 from redbox.chains.ingest import document_loader, ingest_from_loader
 from redbox.loader import ingester
-from redbox.loader.loaders import (
-    MetadataLoader,
-    UnstructuredChunkLoader,
-)
-from redbox.models.file import ChunkResolution
 from redbox.loader.ingester import ingest_file
+from redbox.loader.loaders import MetadataLoader, UnstructuredChunkLoader
+from redbox.models.chain import GeneratedMetadata
+from redbox.models.file import ChunkResolution
 from redbox.models.settings import Settings
 from redbox.retriever.queries import build_query_filter
 
@@ -107,7 +103,7 @@ def test_extract_metadata_extra_key(
 
     requests_mock.post(
         f"http://{env.unstructured_host}:8000/general/v0/general",
-        json=[{"text": "hello", "metadata": {}}],
+        json=[{"text": "hello", "metadata": {"filename": "something"}}],
     )
 
     """


### PR DESCRIPTION
## Context

`TBaseModel` variable was referenced in the parser but was not declared hence exception in metadata extraction. However, this variable is not needed in the parser so removing it.

## Changes proposed in this pull request

- Remove unused variable
- fix metadata extraction tests

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
