### PR TITLE
Fix: unstructured file conversion bug

### DIFF
--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -97,7 +97,7 @@ class UploadView(View):
     def build_response(request: HttpRequest, errors: Sequence[str] | None = None) -> HttpResponse:
         return render(
             request,
-            template_name="upload.html",
+        template_name="upload.html",
             context={
                 "request": request,
                 "errors": {"upload_doc": errors or []},

--- a/django_app/redbox_app/redbox_core/views/misc_views.py
+++ b/django_app/redbox_app/redbox_core/views/misc_views.py
@@ -1,5 +1,4 @@
 import logging
-import waffle
 from http import HTTPStatus
 
 from django.conf import settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 services:
   unstructured:
-    image: quay.io/unstructured-io/unstructured-api:latest
-    #image: unstructured:latest  #- TODO - separate this commented into a buildx ccommand somewhere
-    #build:
-      #context: .
-      #dockerfile: unstructured/Dockerfile
+    image: unstructured:latest
+    build:
+      context: .
+      dockerfile: ./unstructured/Dockerfile
     ports:
       - 8000:8000
     networks:

--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -46,11 +46,16 @@ class MetadataLoader:
         """
         Chunking data using local unstructured
         """
+        import os
+        os.environ["TMPDIR"] = "/tmp"
+        import tempfile
+        logger.info(tempfile.gettempdir())
         file_bytes = self._get_file_bytes(s3_client=self.s3_client, file_name=self.file_name)
+        print("Files in tmp:", os.listdir("/tmp"))
         if ENVIRONMENT.is_local:
             url = f"http://{self.env.unstructured_host}:8000/general/v0/general"
         else:
-            url = f"http://{self.env.unstructured_host}:80/general/v0/general"
+            url = f"http://{self.env.unstructured_host}:8080/general/v0/general"
         files = {
             "files": (self.file_name, file_bytes),
         }

--- a/unstructured/Dockerfile
+++ b/unstructured/Dockerfile
@@ -1,27 +1,7 @@
-FROM python:3.9-slim
+# Use the existing image as the base image
+FROM quay.io/unstructured-io/unstructured-api:latest
 
-# Set working directory
-WORKDIR /app
-
-# Install dependencies for LibreOffice and required packages
-RUN apt-get update && apt-get install -y \
-    libreoffice libreoffice-common libreoffice-writer \
-    openjdk-17-jdk-headless \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Set JAVA_HOME environment variable
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-ENV PATH=$JAVA_HOME/bin:$PATH
-
-# Copy application files
-COPY . .
-
-# Install Python dependencies
-RUN pip install unstructured[local-inference] uvicorn
-
-# Expose port
+# Expose port 8080
 EXPOSE 8080
 
-# Run application
 CMD ["uvicorn", "app:main", "--host", "0.0.0.0", "--port", "8080"]

--- a/unstructured/Dockerfile
+++ b/unstructured/Dockerfile
@@ -3,12 +3,21 @@ FROM python:3.9-slim
 # Set working directory
 WORKDIR /app
 
-# Install LibreOffice to handle doc to docx conversion etc.
-RUN apt-get update && apt-get install -y libreoffice && rm -rf /var/lib/apt/lists/*
+# Install dependencies for LibreOffice and required packages
+RUN apt-get update && apt-get install -y \
+    libreoffice libreoffice-common libreoffice-writer \
+    openjdk-17-jdk-headless \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
+# Set JAVA_HOME environment variable
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV PATH=$JAVA_HOME/bin:$PATH
+
+# Copy application files
 COPY . .
 
-# Install unstructured via pip and uvicorn
+# Install Python dependencies
 RUN pip install unstructured[local-inference] uvicorn
 
 # Expose port

--- a/unstructured/Dockerfile
+++ b/unstructured/Dockerfile
@@ -1,7 +1,18 @@
-# Use the existing image as the base image
-FROM quay.io/unstructured-io/unstructured-api:latest
+FROM python:3.9-slim
 
-# Expose port 8080
+# Set working directory
+WORKDIR /app
+
+# Install LibreOffice to handle doc to docx conversion etc.
+RUN apt-get update && apt-get install -y libreoffice && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+# Install unstructured via pip and uvicorn
+RUN pip install unstructured[local-inference] uvicorn
+
+# Expose port
 EXPOSE 8080
 
+# Run application
 CMD ["uvicorn", "app:main", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Unstructured cant handle libreoffice files. We would like our services to be versatile so changing the dockerfile for unstructured.

## Changes proposed in this pull request
Switching to using pip instead of pulling unstructured docker image and installing libreoffice to handle doc -> docx conversion so can be processed by unstructured properly

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
