### PR TITLE
chg: update CSP to work with GTM

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -201,19 +201,27 @@ CSP_SCRIPT_SRC = (
     "https://tagmanager.google.com/",
     "https://www.googletagmanager.com/",
     "ajax.googleapis.com/",
-    "sha256-T/1K73p+yppfXXw/AfMZXDh5VRDNaoEh3enEGFmZp8M="
+    "sha256-T/1K73p+yppfXXw/AfMZXDh5VRDNaoEh3enEGFmZp8M=",
 )
 CSP_OBJECT_SRC = ("'none'",)
 CSP_TRUSTED_TYPES = ("dompurify", "default", "goog#html")
 CSP_REPORT_TO = "csp-endpoint"
-CSP_FONT_SRC = (
-    "'self'",
-    "s3.amazonaws.com",
-)
+CSP_FONT_SRC = ("'self'", "s3.amazonaws.com", "https://fonts.gstatic.com", "data:")
 CSP_INCLUDE_NONCE_IN = ("script-src",)
 CSP_STYLE_SRC = (
     "'self'",
+    "https://googletagmanager.com",
     "https://tagmanager.google.com/",
+    "https://fonts.googleapis.com",
+)
+
+CSP_IMG_SRC = (
+    "'self'",
+    "https://googletagmanager.com",
+    "https://ssl.gstatic.com",
+    "https://www.gstatic.com",
+    "https://*.google-analytics.com",
+    "https://*.googletagmanager.com",
 )
 CSP_FRAME_ANCESTORS = ("'none'",)
 


### PR DESCRIPTION
Following conversation with Vishal he spotted that we are getting some additional errors causing GTM to not work correctly

So following that and looking at this https://developers.google.com/tag-platform/security/guides/csp I've added in all the suggested urls etc, (think the general approach will need a review) also added the stuff for GTM preview, should allow easier debugging etc 