### PR TITLE
test: fix API tests

### DIFF
--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -70,10 +70,13 @@ def default_ai_settings(db):  # noqa: ARG001
 
 
 @pytest.fixture()
+def api_key():
+    return settings.REDBOX_API_KEY
+
+
+@pytest.fixture()
 def create_user():
     def _create_user(
-        email,
-        date_joined_iso,
         username,
         is_staff=False,
         grade=User.UserGrade.DIRECTOR,
@@ -81,10 +84,7 @@ def create_user():
         profession=User.Profession.IA,
         ai_experience=User.AIExperienceLevel.EXPERIENCED_NAVIGATOR,
     ):
-        date_joined = datetime.fromisoformat(date_joined_iso).astimezone(UTC)
         return User.objects.create_user(
-            email=email,
-            date_joined=date_joined,
             is_staff=is_staff,
             grade=grade,
             business_unit=business_unit,
@@ -98,9 +98,7 @@ def create_user():
 
 @pytest.fixture()
 def alice(create_user):
-    return create_user(
-        email="alice@cabinetoffice.gov.uk", date_joined_iso="2000-01-01", username="alice@cabinetoffice.gov.uk"
-    )
+    return create_user(username="alice@cabinetoffice.gov.uk")
 
 
 @pytest.fixture()
@@ -110,14 +108,12 @@ def chat_with_alice(alice):
 
 @pytest.fixture()
 def bob(create_user):
-    return create_user(email="bob@example.com", date_joined_iso="2000-01-01", username="bob@example.com")
+    return create_user(username="bob@example.com")
 
 
 @pytest.fixture()
 def peter_rabbit():
-    return User.objects.create_user(
-        email="peter.rabbit@example.com", password="P455W0rd", username="peter.rabbit@example.com"
-    )
+    return User.objects.create_user(password="P455W0rd", username="peter.rabbit@example.com")
 
 
 @pytest.fixture()
@@ -125,7 +121,6 @@ def user_with_demographic_data() -> User:
     return User.objects.create_user(
         name="Sir Gregory Pitkin",
         ai_experience=User.AIExperienceLevel.EXPERIENCED_NAVIGATOR,
-        email="mrs.tiggywinkle@example.com",
         grade="DG",
         business_unit="Prime Minister's Office",
         profession="AN",
@@ -135,16 +130,12 @@ def user_with_demographic_data() -> User:
 
 @pytest.fixture()
 def staff_user(create_user):
-    return create_user(
-        email="staff@example.com", date_joined_iso="2000-01-01", is_staff=True, username="staff@example.com"
-    )
+    return create_user(is_staff=True, username="staff@example.com")
 
 
 @pytest.fixture()
 def superuser() -> User:
-    return User.objects.create_superuser(
-        email="super@example.com", date_joined_iso="2000-01-01", username="super@example.com"
-    )
+    return User.objects.create_superuser(username="super@example.com")
 
 
 @pytest.fixture()

--- a/django_app/tests/views/test_api_views.py
+++ b/django_app/tests/views/test_api_views.py
@@ -12,22 +12,23 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.django_db()
-def test_api_view(user_with_chats_with_messages_over_time: User, client: Client):
+def test_api_view(user_with_chats_with_messages_over_time: User, client: Client, api_key: str):
     # Given
-    client.force_login(user_with_chats_with_messages_over_time)
+    headers = {"HTTP_X_API_KEY": api_key}
 
     # When
     url = reverse("user-view")
-    response = client.get(url)
+    response = client.get(url, **headers)
 
     # Then
     assert response.status_code == HTTPStatus.OK
-    assert response.json()["email"] == user_with_chats_with_messages_over_time.email
+    user_with_chats = next(user for user in response.json()["results"] if user["chats"])
+    assert user_with_chats["ai_experience"] == user_with_chats_with_messages_over_time.ai_experience
 
 
 @pytest.mark.django_db()
 def test_api_view_fail(client: Client):
-    # Given that the user is not logged in
+    # Given that the user does not pass an API key
 
     # When
     url = reverse("user-view")
@@ -35,4 +36,4 @@ def test_api_view_fail(client: Client):
 
     # Then
     assert response.status_code == HTTPStatus.FORBIDDEN
-    assert response.json() == {"detail": "Authentication credentials were not provided."}
+    assert response.json() == {"detail": "No API key provided"}


### PR DESCRIPTION
## Context

There are some broken tests from some legacy work. This fixes just some of them: the ones in test_api_views.py


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

There were 5 issues causing the tests to fail that this change fixes:

- An incorrect assumption on the form of an error message in the case of a 403
- Using a now-removed date_joined field
- Passing an email address into model creation, where is also determined the email address based on username.
- Assuming that a regular user can access the view-message endpoint, when they
      (correctly) cannot, and instead need to pass an API key
- Incorrect assumption on the structure of the response to user-view

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Looking at the code and making sure more tests don't fail should be enough.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links

N/A

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
