### PR TITLE
Fix summarisation and exponential backoff for summarisation

### DIFF
--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -35,7 +35,7 @@ from redbox.models.chain import RedboxState
 from redbox.models.chat import ChatRoute, ErrorRoute
 from redbox.models.graph import ROUTABLE_KEYWORDS, RedboxActivityEvent
 from redbox.transform import structure_documents_by_file_name, structure_documents_by_group_and_indices
-
+from langgraph.pregel import RetryPolicy
 
 def get_self_route_graph(retriever: VectorStoreRetriever, prompt_set: PromptSet, debug: bool = False):
     builder = StateGraph(RedboxState)
@@ -237,10 +237,12 @@ def get_chat_with_documents_graph(
     builder.add_node(
         "p_summarise_each_document",
         build_merge_pattern(prompt_set=PromptSet.ChatwithDocsMapReduce),
+        retry=RetryPolicy(max_attempts=3)
     )
     builder.add_node(
         "p_summarise_document_by_document",
         build_merge_pattern(prompt_set=PromptSet.ChatwithDocsMapReduce),
+        retry=RetryPolicy(max_attempts=3)
     )
     builder.add_node(
         "p_summarise",
@@ -248,6 +250,7 @@ def get_chat_with_documents_graph(
             prompt_set=PromptSet.ChatwithDocs,
             final_response_chain=True,
         ),
+        retry=RetryPolicy(max_attempts=3)
     )
     builder.add_node("p_clear_documents", clear_documents_process)
     builder.add_node(

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -134,6 +134,7 @@ CHAT_MAP_SYSTEM_PROMPT = (
     "2) Avoid repetition,\n"
     "3) Ensure the summary is easy to understand,\n"
     "4) Maintain the original context and meaning.\n"
+    "5) Do not start your answer by saying: here is a summary...Go straight to the point."
 )
 
 REDUCE_SYSTEM_PROMPT = (


### PR DESCRIPTION
- fixed the summarisation prompt to prevent LLM getting confused as it summarise entire document and not just the last section of the document
- fixed ThrottlingException limit issues for summarisation using exponential backoff (implemented in the 3 summarisation nodes).
