### PR TITLE
fix: text_in_answer already exists and prevents further migrations

### DIFF
--- a/django_app/redbox_app/redbox_core/migrations/0076_citation_text_in_answer.py
+++ b/django_app/redbox_app/redbox_core/migrations/0076_citation_text_in_answer.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.AlterField(
             model_name="citation",
             name="text_in_answer",
             field=models.TextField(


### PR DESCRIPTION
## Context
** This PR does cause test-django to fail but this change will be rolled back after it has been applied to dev. **

Prod says
![image](https://github.com/user-attachments/assets/7de2f18f-7315-44d9-b7ec-34b4534e55f1)

Dev says
![image](https://github.com/user-attachments/assets/6d9d8768-0bf4-4464-9104-ce8f24e377ac)

So we need to apply to dev but not to prod in order to allow any future migrations to apply. Essentially "tricking" dev.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Switch 76 to alter not add

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
