### PR TITLE
Bugfix/self route toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,3 +103,4 @@ REDBOX_API_KEY = myapi
 # AUTHBROKER_URL=https://sso.trade.gov.uk
 
 ENABLE_METADATA_EXTRACTION = True
+SELF_ROUTE_ENABLED = False

--- a/redbox-core/redbox/graph/edges.py
+++ b/redbox-core/redbox/graph/edges.py
@@ -60,12 +60,14 @@ def has_exceed_max_limit(state: RedboxState) -> Literal["max_exceeded", "pass"]:
         return "pass"
 
 
-def set_route_basedon_token_limit(prompt_set: PromptSet) -> Runnable[RedboxState, dict[str, Any]]:
-    """Uses a set of prompts to calculate the total tokens used in this request and returns a label
+def set_route_based_on_llm_answer_token_limit(prompt_set: PromptSet) -> Runnable[RedboxState, dict[str, Any]]:
+    """
+    Set route
+    Uses a set of prompts to calculate the total tokens used in this request and returns a label
     for the request handler to be used
     """
 
-    def _set_route_basedon_token_limit(
+    def _set_route_based_on_token_limit(
         state: RedboxState,
     ) -> dict[str, Any]:
         system_prompt, question_prompt = get_prompts(state, prompt_set)
@@ -78,7 +80,7 @@ def set_route_basedon_token_limit(prompt_set: PromptSet) -> Runnable[RedboxState
         else:
             return {"route_name": ChatRoute.chat_with_docs}
 
-    return RunnableLambda(_set_route_basedon_token_limit).with_config(tags=[ROUTE_NAME_TAG])
+    return RunnableLambda(_set_route_based_on_token_limit).with_config(tags=[ROUTE_NAME_TAG])
 
 
 def build_documents_bigger_than_context_conditional(prompt_set: PromptSet) -> Runnable:

--- a/redbox-core/redbox/graph/edges.py
+++ b/redbox-core/redbox/graph/edges.py
@@ -60,7 +60,7 @@ def has_exceed_max_limit(state: RedboxState) -> Literal["max_exceeded", "pass"]:
         return "pass"
 
 
-def set_route_based_on_llm_answer_token_limit(prompt_set: PromptSet) -> Runnable[RedboxState, dict[str, Any]]:
+def set_route_based_on_token_limit(prompt_set: PromptSet) -> Runnable[RedboxState, dict[str, Any]]:
     """
     Set route
     Uses a set of prompts to calculate the total tokens used in this request and returns a label

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -232,7 +232,7 @@ def get_chat_with_documents_graph(
 
     # Processes
     builder.add_node("p_pass_question_to_text", build_passthrough_pattern())
-    builder.add_node("p_set_chat_docs_route", build_set_route_pattern(route=ChatRoute.chat_with_docs))
+    # builder.add_node("p_set_chat_docs_route", build_set_route_pattern(route=ChatRoute.chat_with_docs))
     builder.add_node(
         "p_set_chat_docs_map_reduce_route",
         build_set_route_pattern(route=ChatRoute.chat_with_docs_map_reduce),
@@ -322,7 +322,7 @@ def get_chat_with_documents_graph(
             ChatRoute.chat_with_docs_map_reduce: "p_retrieve_all_chunks",
         },
     )
-    builder.add_edge("p_set_chat_docs_route", "p_retrieve_all_chunks")
+    # builder.add_edge("p_set_chat_docs_route", "p_retrieve_all_chunks")
     builder.add_edge("p_set_chat_docs_map_reduce_route", "p_retrieve_all_chunks")
     builder.add_conditional_edges(
         "p_retrieve_all_chunks",

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -281,9 +281,6 @@ def get_chat_with_documents_graph(
         build_activity_log_node(lambda state: RedboxActivityEvent(message=f"Using _{state.route_name}_")),
     )
 
-    rag_subgraph = get_search_graph(retriever=parameterised_retriever, debug=debug)
-    builder.add_node("p_search", rag_subgraph)
-
     # Decisions
     builder.add_node("d_request_handler_from_total_tokens", empty_process)
     builder.add_node("d_single_doc_summaries_bigger_than_context", empty_process)
@@ -318,7 +315,7 @@ def get_chat_with_documents_graph(
         "p_answer_or_decide_route",
         lambda state: state.route_name,
         {
-            ChatRoute.search: "p_search",
+            ChatRoute.search: END,
             ChatRoute.chat_with_docs_map_reduce: "p_retrieve_all_chunks",
         },
     )

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -5,6 +5,7 @@ from langchain_core.vectorstores import VectorStoreRetriever
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.graph import CompiledGraph
 from langgraph.prebuilt import ToolNode
+from langgraph.pregel import RetryPolicy
 
 from redbox.chains.components import get_structured_response_with_citations_parser
 from redbox.chains.runnables import build_self_route_output_parser
@@ -37,7 +38,6 @@ from redbox.models.chain import RedboxState
 from redbox.models.chat import ChatRoute, ErrorRoute
 from redbox.models.graph import ROUTABLE_KEYWORDS, RedboxActivityEvent
 from redbox.transform import structure_documents_by_file_name, structure_documents_by_group_and_indices
-from langgraph.pregel import RetryPolicy
 
 
 def get_self_route_graph(retriever: VectorStoreRetriever, prompt_set: PromptSet, debug: bool = False):
@@ -281,6 +281,9 @@ def get_chat_with_documents_graph(
         build_activity_log_node(lambda state: RedboxActivityEvent(message=f"Using _{state.route_name}_")),
     )
 
+    rag_subgraph = get_search_graph(retriever=parameterised_retriever, debug=debug)
+    builder.add_node("p_search", rag_subgraph)
+
     # Decisions
     builder.add_node("d_request_handler_from_total_tokens", empty_process)
     builder.add_node("d_single_doc_summaries_bigger_than_context", empty_process)
@@ -302,7 +305,7 @@ def get_chat_with_documents_graph(
         {
             "max_exceeded": "p_too_large_error",
             "context_exceeded": "d_self_route_is_enabled",
-            "pass": "p_set_chat_docs_route",
+            "pass": "d_self_route_is_enabled",
         },
     )
     builder.add_conditional_edges(
@@ -315,7 +318,7 @@ def get_chat_with_documents_graph(
         "p_answer_or_decide_route",
         lambda state: state.route_name,
         {
-            ChatRoute.search: END,
+            ChatRoute.search: "p_search",
             ChatRoute.chat_with_docs_map_reduce: "p_retrieve_all_chunks",
         },
     )

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -5,6 +5,8 @@ from types import UnionType
 from typing import Annotated, Literal, NotRequired, Required, TypedDict, get_args, get_origin
 from uuid import UUID, uuid4
 
+import environ
+from dotenv import load_dotenv
 from langchain_core.documents import Document
 from langchain_core.messages import AnyMessage
 from langgraph.graph.message import add_messages
@@ -13,6 +15,10 @@ from pydantic import BaseModel, Field
 
 from redbox.models import prompts
 from redbox.models.settings import ChatLLMBackend
+
+load_dotenv()
+
+env = environ.Env()
 
 
 class ChainChatMessage(TypedDict):
@@ -29,7 +35,7 @@ class AISettings(BaseModel):
 
     # Prompts and LangGraph settings
     max_document_tokens: int = 1_000_000
-    self_route_enabled: bool = False
+    self_route_enabled: bool = env.bool("SELF_ROUTE_ENABLED", default=False)
     map_max_concurrency: int = 128
     stuff_chunk_context_ratio: float = 0.75
     recursion_limit: int = 50

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -10,19 +10,29 @@ from pytest_mock import MockerFixture
 from tiktoken.core import Encoding
 
 from redbox import Redbox
-from redbox.models.chain import (AISettings, Citation, RedboxQuery,
-                                 RedboxState, RequestMetadata, Source,
-                                 StructuredResponseWithCitations,
-                                 metadata_reducer)
+from redbox.models.chain import (
+    AISettings,
+    Citation,
+    RedboxQuery,
+    RedboxState,
+    RequestMetadata,
+    Source,
+    StructuredResponseWithCitations,
+    metadata_reducer,
+)
 from redbox.models.chat import ChatRoute, ErrorRoute
 from redbox.models.file import ChunkResolution
 from redbox.models.graph import RedboxActivityEvent
 from redbox.models.settings import Settings
-from redbox.test.data import (GenericFakeChatModelWithTools,
-                              RedboxChatTestCase, RedboxTestData,
-                              generate_test_cases, mock_all_chunks_retriever,
-                              mock_metadata_retriever,
-                              mock_parameterised_retriever)
+from redbox.test.data import (
+    GenericFakeChatModelWithTools,
+    RedboxChatTestCase,
+    RedboxTestData,
+    generate_test_cases,
+    mock_all_chunks_retriever,
+    mock_metadata_retriever,
+    mock_parameterised_retriever,
+)
 from redbox.transform import structure_documents_by_group_and_indices
 
 LANGGRAPH_DEBUG = True

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -605,6 +605,6 @@ def test_get_available_keywords(tokeniser: Encoding, env: Settings):
         env=env,
         debug=LANGGRAPH_DEBUG,
     )
-    keywords = {ChatRoute.search, ChatRoute.gadget}
+    keywords = {ChatRoute.search, ChatRoute.gadget, ChatRoute.newroute}
 
     assert keywords == set(app.get_available_keywords().keys())


### PR DESCRIPTION
## Context

In Redbox graph, when a user selects a document, there are 3 possible scenarios:
exceed limit (>1M) → return document is too large
exceed context (>128K) → self_route 
pass (<=128K) go to summarise
In the current setting, self_route is off, which means summarise is always called, and search graph is never called. 
This affects Redbox performance when users ask questions on specific parts of the document.

Before:
![Screenshot 2025-02-17 at 13 00 29](https://github.com/user-attachments/assets/8d06e48a-f4e3-488a-b82e-04befa28242c)


## Changes proposed in this pull request

- create ENV var for setting self_route and change the code to get the setting from ENV
- Change the graph so that self_route is called when request token less than limit

After:
![Screenshot 2025-02-18 at 09 42 54](https://github.com/user-attachments/assets/35fa09bb-ec16-4b06-8a46-7a695b91af53)



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
