### PR TITLE
fix: prevent 504 for user table

### DIFF
--- a/django_app/redbox_app/redbox_core/serializers.py
+++ b/django_app/redbox_app/redbox_core/serializers.py
@@ -22,6 +22,8 @@ class ChatMessageSerializer(serializers.ModelSerializer):
     selected_files = FileSerializer(many=True, read_only=True)
     source_files = FileSerializer(many=True, read_only=True)
     token_use = ChatMessageTokenUseSerializer(source="chatmessagetokenuse_set", many=True, read_only=True)
+    chat_id = serializers.PrimaryKeyRelatedField(source="chat", read_only=True)
+    user_id = serializers.PrimaryKeyRelatedField(source="chat.user", read_only=True)
 
     class Meta:
         model = ChatMessage
@@ -38,6 +40,8 @@ class ChatMessageSerializer(serializers.ModelSerializer):
             "rating_text",
             "rating_chips",
             "token_use",
+            "chat_id",
+            "user_id",
         )
 
 
@@ -45,6 +49,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (
+            "id",
             "ai_experience",
             "business_unit",
             "grade",

--- a/django_app/redbox_app/redbox_core/serializers.py
+++ b/django_app/redbox_app/redbox_core/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-from redbox_app.redbox_core.models import Chat, ChatMessage, ChatMessageTokenUse, File
+from redbox_app.redbox_core.models import ChatMessage, ChatMessageTokenUse, File
 
 User = get_user_model()
 
@@ -41,17 +41,7 @@ class ChatMessageSerializer(serializers.ModelSerializer):
         )
 
 
-class ChatSerializer(serializers.ModelSerializer):
-    messages = ChatMessageSerializer(source="chatmessage_set", many=True, read_only=True)
-
-    class Meta:
-        model = Chat
-        fields = ("id", "created_at", "modified_at", "messages")
-
-
 class UserSerializer(serializers.ModelSerializer):
-    chats = ChatSerializer(source="chat_set", many=True, read_only=True)
-
     class Meta:
         model = User
         fields = (
@@ -60,5 +50,7 @@ class UserSerializer(serializers.ModelSerializer):
             "grade",
             "profession",
             "role",
-            "chats",
+            "is_staff",
+            "is_active",
+            "is_superuser",
         )

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -79,7 +79,7 @@ other_urlpatterns = [
 
 
 api_url_patterns = [
-    path("api/v0/", views.user_view_pre_alpha, name="user-view"),
+    path("api/v0/users/", views.user_view_pre_alpha, name="user-view"),
     path("api/v0/messages/", views.message_view_pre_alpha, name="message-view"),
 ]
 

--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -83,6 +83,9 @@ def create_user():
         business_unit=User.BusinessUnit.DIGITAL_DATA_AND_TECHNOLOGY,
         profession=User.Profession.IA,
         ai_experience=User.AIExperienceLevel.EXPERIENCED_NAVIGATOR,
+        role="Trade Advisor",
+        is_active=True,
+        is_superuser=True,
     ):
         return User.objects.create_user(
             is_staff=is_staff,
@@ -91,6 +94,9 @@ def create_user():
             profession=profession,
             ai_experience=ai_experience,
             username=username,
+            role=role,
+            is_active=is_active,
+            is_superuser=is_superuser,
         )
 
     return _create_user

--- a/django_app/tests/test_admin.py
+++ b/django_app/tests/test_admin.py
@@ -9,7 +9,7 @@ from django.test import Client
 from django.urls import reverse
 
 from redbox_app.redbox_core.models import ChatMessage
-from redbox_app.redbox_core.serializers import ChatMessageSerializer, ChatSerializer, UserSerializer
+from redbox_app.redbox_core.serializers import ChatMessageSerializer, UserSerializer
 
 User = get_user_model()
 
@@ -93,39 +93,18 @@ def test_message_serializer(chat_message_with_citation_and_tokens: ChatMessage):
 
 
 @pytest.mark.django_db()
-def test_chat_serializer(chat_message_with_citation: ChatMessage):
-    actual = ChatSerializer().to_representation(chat_message_with_citation.chat)
-    assert "id" in actual
-    assert "created_at" in actual
-    assert "modified_at" in actual
-    assert "messages" in actual
-    assert isinstance(actual["messages"], list)
-    assert len(actual["messages"]) == 1
-    message = actual["messages"][0]
-    assert "id" in message
-    assert "created_at" in message
-    assert "modified_at" in message
-    assert "text" in message
-    assert message["text"] == "An answer."
-    assert "role" in message
-    assert "selected_files" in message
-    assert "source_files" in message
-    assert "rating" in message
-    assert "rating_text" in message
-    assert "rating_chips" in message
-    assert "token_use" in message
-
-
-@pytest.mark.django_db()
 def test_user_serializer(chat_message_with_citation: ChatMessage):
     expected = {
         "ai_experience": "Experienced Navigator",
         "business_unit": "Digital, Data and Technology (DDaT)",
         "grade": "D",
         "profession": "IA",
+        "role": "Trade Advisor",
+        "is_staff": False,
+        "is_active": True,
+        "is_superuser": True,
     }
     actual = UserSerializer().to_representation(chat_message_with_citation.chat.user)
+
     for k, v in expected.items():
         assert actual[k] == v, k
-
-    assert actual["chats"][0]["messages"][0]["text"] == "An answer."

--- a/django_app/tests/views/test_api_views.py
+++ b/django_app/tests/views/test_api_views.py
@@ -22,8 +22,6 @@ def test_api_view(client: Client, api_key: str):
 
     # Then
     assert response.status_code == HTTPStatus.OK
-    user_with_chats = next(user for user in response.json()["results"])
-    assert user_with_chats["role"] == "Trade Advisor"
 
 
 @pytest.mark.parametrize("path_name", ["user-view", "message-view"])

--- a/django_app/tests/views/test_api_views.py
+++ b/django_app/tests/views/test_api_views.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.django_db()
-def test_api_view(user_with_chats_with_messages_over_time: User, client: Client, api_key: str):
+def test_api_view(client: Client, api_key: str):
     # Given
     headers = {"HTTP_X_API_KEY": api_key}
 
@@ -22,8 +22,8 @@ def test_api_view(user_with_chats_with_messages_over_time: User, client: Client,
 
     # Then
     assert response.status_code == HTTPStatus.OK
-    user_with_chats = next(user for user in response.json()["results"] if user["chats"])
-    assert user_with_chats["ai_experience"] == user_with_chats_with_messages_over_time.ai_experience
+    user_with_chats = next(user for user in response.json()["results"])
+    assert user_with_chats["role"] == "Trade Advisor"
 
 
 @pytest.mark.parametrize("path_name", ["user-view", "message-view"])


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Following on from DIAPPs work ([here](https://github.com/uktrade/redbox/pull/76)) we would like to ensure the errors stop for our other two tables too. DIAPP has now covered the information we need regarding Chat/ChatMessages so I'm severing the connection between chats in the UserSerializer

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Remove ChatSerializer as its covered by ChatMessageSerializer
Add extra fields to UserSerializer
Remove chats from being called unnecessarily in the UserSerializer which is causing the 504 timeouts
Update relevant tests
