### PR TITLE
If documents are not selected, they should not be used

### DIFF
--- a/redbox-core/redbox/retriever/queries.py
+++ b/redbox-core/redbox/retriever/queries.py
@@ -105,8 +105,8 @@ def build_document_query(
         * Text, as a keyword and similarity
     """
     # If nothing is selected, consider all permitted files selected
-    if not selected_files:
-        selected_files = permitted_files
+    # if not selected_files:
+    #     selected_files = permitted_files
 
     query_filter = build_query_filter(
         selected_files=selected_files,

--- a/redbox-core/tests/retriever/test_retriever.py
+++ b/redbox-core/tests/retriever/test_retriever.py
@@ -51,10 +51,7 @@ def test_parameterised_retriever(
     * If documents are selected and there's no permission to get them
         * The length of the result is zero
     * If documents aren't selected and there's permission to get them
-        * The length of the result is equal to the rag_k parameter
-        * The result page content is a subset of all possible correct
-        page content
-        * The result contains only file_names from permitted S3 keys
+        * The length of the result is zero
     * If documents aren't selected and there's no permission to get them
         * The length of the result is zero
 
@@ -77,6 +74,8 @@ def test_parameterised_retriever(
     permission = bool(stored_file_parameterised.query.permitted_s3_keys)
 
     if not permission:
+        assert len(result) == 0
+    elif not selected:
         assert len(result) == 0
     else:
         assert len(result) == chain_params["rag_k"]


### PR DESCRIPTION
## Context

When using `ParameterisedRetriever` in @search or in `self_route`, all permitted documents will be used even when users do not select any documents

However, we should only use documents that user selects when doing search to prevent unexpected response

## Changes proposed in this pull request

- remove the code that use all permitted files when documents are not selected
- fix retriever tests to match with new behaviour
- fix search_tool test to match with new behaviour

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
