### PR TITLE
feat: redirect user trying to delete failed document upload

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -596,7 +596,9 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     def unique_name(self) -> str:
         """primary key for accessing file in s3"""
         if self.status in File.INACTIVE_STATUSES:
-            logger.exception("User tried to delete %s with status %s, it has already been deleted", self.pk, self.status)
+            logger.exception(
+                "User tried to delete %s with status %s, it has already been deleted", self.pk, self.status
+            )
             raise InactiveFileError(self)
         return self.original_file.name
 

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -596,7 +596,7 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     def unique_name(self) -> str:
         """primary key for accessing file in s3"""
         if self.status in File.INACTIVE_STATUSES:
-            logger.exception("Attempt to access s3-key for inactive file %s with status %s", self.pk, self.status)
+            logger.exception("User tried to delete %s with status %s, it has already been deleted", self.pk, self.status)
             raise InactiveFileError(self)
         return self.original_file.name
 

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -153,17 +153,17 @@ def remove_doc_view(request, doc_id: uuid):
     if request.method == "POST":
         try:
             file.delete_from_elastic()
+            file.delete_from_s3()
+            file.status = File.Status.deleted
+            file.save()
+            logger.info("Removing document: %s", request.POST["doc_id"])
         except Exception as e:
             logger.exception("Error deleting file object %s.", file, exc_info=e)
             errors.append("There was an error deleting this file")
             file.status = File.Status.errored
             file.save()
-        else:
-            logger.info("Removing document: %s", request.POST["doc_id"])
-            file.delete_from_s3()
-            file.status = File.Status.deleted
-            file.save()
-            return redirect("documents")
+
+        return redirect("documents")
 
     return render(
         request,


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Currently, documents which have errored cannot be deleted. Or at least, they are "technically" deleted but because they are already removed from opensearch users are seeing a random error, when they are automatically deleted.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Just redirect the user so they don't see a random false flag regarding inactive file uploads. Its not important to them as if a doc fails to upload, it will automatically delete.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links
https://uktrade.atlassian.net/jira/software/projects/REDBOX/boards/558?selectedIssue=REDBOX-500

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
