### PR TITLE
fix: implement exponential backoff for 504 nodes

### DIFF
--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -2,14 +2,10 @@ import json
 import logging
 import re
 import textwrap
-import time
-from random import uniform
 from collections.abc import Callable
 from functools import reduce
 from typing import Any, Iterable
 from uuid import uuid4
-
-from botocore.exceptions import EventStreamError
 
 from langchain.schema import StrOutputParser
 from langchain_core.callbacks.manager import dispatch_custom_event
@@ -92,8 +88,6 @@ def build_merge_pattern(
     If tools are supplied, can also set state["tool_calls"].
     """
     tokeniser = get_tokeniser()
-    MAX_RETRIES = 5
-    BACKOFF_FACTOR = 1.5
 
     @RunnableLambda
     def _merge(state: RedboxState) -> dict[str, Any]:
@@ -112,22 +106,9 @@ def build_merge_pattern(
             ),
         )
 
-        retries = 0
-        while retries < MAX_RETRIES:
-            try:
-                merge_response = build_llm_chain(
-                    prompt_set=prompt_set, llm=llm, final_response_chain=final_response_chain
-                ).invoke(merge_state)
-
-                # if reaches a successful citation, exit the loop
-                break
-
-            except EventStreamError as e:
-                retries += 1
-                if retries >= MAX_RETRIES:
-                    raise e
-                wait_time = BACKOFF_FACTOR**retries + uniform(0, 1)
-                time.sleep(wait_time)
+        merge_response = build_llm_chain(
+            prompt_set=prompt_set, llm=llm, final_response_chain=final_response_chain
+        ).invoke(merge_state)
 
         merged_document.page_content = merge_response["messages"][-1].content
         request_metadata = merge_response["metadata"]

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -67,6 +67,7 @@ def get_self_route_graph(retriever: VectorStoreRetriever, prompt_set: PromptSet,
             ),
             final_response_chain=False,
         ),
+        retry=RetryPolicy(max_attempts=3),
     )
     builder.add_node(
         "p_set_route_name_from_answer",
@@ -141,6 +142,7 @@ def get_search_graph(
     builder.add_node(
         "p_stuff_docs",
         build_stuff_pattern(prompt_set=prompt_set, final_response_chain=final_response),
+        retry=RetryPolicy(max_attempts=3),
     )
 
     # Edges
@@ -173,6 +175,7 @@ def get_agentic_search_graph(tools: List[StructuredTool], debug: bool = False) -
             format_instructions=format_instructions,
             final_response_chain=False,  # Output parser handles streaming
         ),
+        retry=RetryPolicy(max_attempts=3),
     )
     builder.add_node(
         "p_retrieval_tools",
@@ -181,6 +184,7 @@ def get_agentic_search_graph(tools: List[StructuredTool], debug: bool = False) -
     builder.add_node(
         "p_give_up_agent",
         build_stuff_pattern(prompt_set=PromptSet.GiveUpAgentic, final_response_chain=True),
+        retry=RetryPolicy(max_attempts=3),
     )
     builder.add_node("p_report_sources", report_sources_process)
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
To avoid a variety of constant timeouts we get flagged in Sentry that users must be experiencing, implement the rest of exponential backoff concept with consistent approach for the nodes.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Adding langgraph's RetryPolicy and removing standardised Python approach to ensure we have matching applications of exponential backoff throughout.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Have I missed anything? More or less verbose retry policy?

## Relevant links
https://github.com/uktrade/redbox/pull/80/files

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
