### PR TITLE
Spike LLM to choose route

### DIFF
--- a/notebooks/LLM_choose_route.ipynb
+++ b/notebooks/LLM_choose_route.ipynb
@@ -21,6 +21,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We explore prompts that 1) uses only user'question to determine the route, and 2) uses user's question and basic documents metadata (document name, description and keywords) to determine route. The reason is that by giving information about document metadata, LLM is more equipped with information to help determining the route."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Conclusion: Based on the experiment results, we achieved 80% using the prompt with metadata. In addition, using this prompt show that LLM uses slightly shorter time to make decision. Therefore, we will be implementing a new node with LLM_decide_tool_1 going forward."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Prompts"
    ]
   },

--- a/notebooks/LLM_choose_route.ipynb
+++ b/notebooks/LLM_choose_route.ipynb
@@ -1,0 +1,388 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext dotenv\n",
+    "%dotenv /Users/saisakulchernbumroong/Documents/vsprojects/DBT_redbox/redbox/.env.test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### We are investigating whether an LLM can identify correct tool e.g. search or summarise given user's question"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prompts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LLM_decide_tool_0 = (\"\"\"Given analysis request, determine whether to use search or summarise tools.\n",
+    "\n",
+    "Context:\n",
+    "- Search tool: Used to find and analyze specific relevant sections in a document\n",
+    "- Summarise tool: Used to create an overview of the entire document's content\n",
+    "\n",
+    "Please analyze the following request:\n",
+    "{question}\n",
+    "\n",
+    "Follow these steps to determine the appropriate tool:\n",
+    "\n",
+    "1. Identify the key requirements in the request:\n",
+    "   - Is it asking for specific information or general overview?\n",
+    "   - Are there specific topics/keywords mentioned?\n",
+    "   - Is the scope focused or broad?\n",
+    "\n",
+    "2. Evaluate request characteristics:\n",
+    "   - Does it need comprehensive coverage or targeted information?\n",
+    "   - Are there specific questions to answer?\n",
+    "   - Is context from the entire document needed?\n",
+    "\n",
+    "3. Recommend either search or summarise based on:\n",
+    "   - If focused/specific information is needed → Recommend search\n",
+    "   - If general overview/main points needed → Recommend summarise\n",
+    "\n",
+    "- Recommended Tool: [Search/Summarise]\n",
+    "- Reason for the recommendation\n",
+    "Provide your recommendation in this format:\n",
+    "\\n{format_instructions}\\n\n",
+    "                   \n",
+    "Analysis request:\n",
+    "{question}\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LLM_decide_tool_1 = (\"\"\"Given analysis request and document demtadata, determine whether to use search or summarise tools.\n",
+    "\n",
+    "Context:\n",
+    "- Search tool: Used to find and analyze specific relevant sections in a document\n",
+    "- Summarise tool: Used to create an overview of the entire document's content\n",
+    "\n",
+    "Please analyze the following request:\n",
+    "{question}\n",
+    "\n",
+    "Follow these steps to determine the appropriate tool:\n",
+    "\n",
+    "1. Identify the key requirements in the request:\n",
+    "   - Is it asking for specific information or general overview?\n",
+    "   - Are there specific topics/keywords mentioned?\n",
+    "   - Is the scope focused or broad?\n",
+    "\n",
+    "2. Evaluate request characteristics:\n",
+    "   - Does it need comprehensive coverage or targeted information?\n",
+    "   - Are there specific questions to answer?\n",
+    "   - Is context from the entire document needed?\n",
+    "\n",
+    "3. Recommend either search or summarise based on:\n",
+    "   - If focused/specific information is needed → Recommend search\n",
+    "   - If general overview/main points needed → Recommend summarise\n",
+    "   - Priortise search tool if both tools can be used to produce good answer \n",
+    "\n",
+    "- Recommended Tool: [Search/Summarise]\n",
+    "\n",
+    "Provide your recommendation in this format:\n",
+    "\\n{format_instructions}\\n\n",
+    "\n",
+    "Analysis request:\n",
+    "{question}\n",
+    "                   \n",
+    "Document metadata: {metadata}\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating necceasry functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from enum import Enum\n",
+    "from redbox.chains.components import get_basic_metadata_retriever\n",
+    "import time\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from redbox.chains.parser import ClaudeParser\n",
+    "from pydantic import BaseModel\n",
+    "from redbox.chains.components import get_chat_llm\n",
+    "from redbox.models.chain import RedboxState, RedboxQuery, AISettings\n",
+    "from langchain_core.runnables import chain\n",
+    "from uuid import uuid4\n",
+    "from redbox.models.settings import ChatLLMBackend\n",
+    "from redbox.models.settings import get_settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_state(user_uuid, prompts, documents, ai_setting):\n",
+    "    q = RedboxQuery(\n",
+    "        question=f\"{prompts[-1]}\",\n",
+    "        s3_keys=documents,\n",
+    "        user_uuid=user_uuid,\n",
+    "        chat_history=prompts[:-1],\n",
+    "        ai_settings=ai_setting,\n",
+    "        permitted_s3_keys=documents,\n",
+    "    )\n",
+    "\n",
+    "    return RedboxState(\n",
+    "        request=q,\n",
+    "    )\n",
+    "\n",
+    "def basic_chat_chain(system_prompt, _additional_variables: dict = {}, parser=None):\n",
+    "    @chain\n",
+    "    def _basic_chat_chain(state: RedboxState):\n",
+    "        nonlocal parser\n",
+    "        llm = get_chat_llm(state.request.ai_settings.chat_backend)\n",
+    "        context = ({\n",
+    "                    \"question\": state.request.question,\n",
+    "                    }\n",
+    "                | _additional_variables\n",
+    "            )\n",
+    "        \n",
+    "        if parser:\n",
+    "            format_instructions = parser.get_format_instructions()\n",
+    "            prompt = ChatPromptTemplate([(system_prompt)], partial_variables={\"format_instructions\": format_instructions})\n",
+    "        else:\n",
+    "            prompt = ChatPromptTemplate([(system_prompt)])\n",
+    "            parser = ClaudeParser()\n",
+    "        chain = prompt | llm | parser\n",
+    "        return chain.invoke(context)\n",
+    "    return _basic_chat_chain\n",
+    "\n",
+    "def lm_choose_route(system_prompt: str, parser: ClaudeParser):\n",
+    "    metadata = None\n",
+    "    \n",
+    "    @chain\n",
+    "    def get_metadata(state: RedboxState):\n",
+    "        nonlocal metadata\n",
+    "        env = get_settings()\n",
+    "        retriever = get_basic_metadata_retriever(env)\n",
+    "        metadata = retriever.invoke(state)\n",
+    "        return state\n",
+    "    \n",
+    "    @chain\n",
+    "    def use_result(state: RedboxState):\n",
+    "        chain = basic_chat_chain(system_prompt=system_prompt, parser=parser, _additional_variables={'metadata': metadata})\n",
+    "        return chain.invoke(state)\n",
+    "    \n",
+    "    return get_metadata | use_result\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Defining class to capture LLM response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "members = [\"Search\", \"Summarise\"]\n",
+    "\n",
+    "#create options map for the supervisor output parser.\n",
+    "tools_options = {tool:tool for tool in members}\n",
+    "\n",
+    "#create Enum object\n",
+    "ToolEnum = Enum('ToolEnum', tools_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class AgentDecision(BaseModel):\n",
+    "    next: ToolEnum = ToolEnum.Search\n",
+    "\n",
+    "class AgentDecisionWithReason(BaseModel):\n",
+    "    next: ToolEnum = ToolEnum.Search\n",
+    "    reason: str"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing approach"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set up Redbox state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = get_state(user_uuid=uuid4(), prompts=['What did Serena Williams say about fairness in relation to her experience with postnatal complications?'], documents=['test@dbt.gov.uk/1 The power chapter.pdf'], ai_setting=AISettings(chat_backend=ChatLLMBackend(name=\"anthropic.claude-3-sonnet-20240229-v1:0\", provider=\"bedrock\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test prompt 0 without metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = LLM_decide_tool_0\n",
+    "agent_parser = ClaudeParser(pydantic_object=AgentDecisionWithReason)\n",
+    "# return results with reason\n",
+    "test_chain_reason = basic_chat_chain(system_prompt=prompt, parser=agent_parser)\n",
+    "start = time.time()\n",
+    "test_chain_reason.invoke(x)\n",
+    "print(f'time used: {time.time() - start}')\n",
+    "\n",
+    "# return results without reason\n",
+    "agent_parser = ClaudeParser(pydantic_object=AgentDecision)\n",
+    "test_chain_no_reason = basic_chat_chain(system_prompt=prompt, parser=agent_parser)\n",
+    "start = time.time()\n",
+    "test_chain_no_reason.invoke(x)\n",
+    "print(f'time used: {time.time() - start}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test prompt 1 with metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = LLM_decide_tool_1\n",
+    "agent_parser = ClaudeParser(pydantic_object=AgentDecisionWithReason)\n",
+    "# return results with reason\n",
+    "test_chain_reason = lm_choose_route(system_prompt=prompt, parser=agent_parser)\n",
+    "start = time.time()\n",
+    "test_chain_reason.invoke(x)\n",
+    "print(f'time used: {time.time() - start}')\n",
+    "\n",
+    "# return results without reason\n",
+    "agent_parser = ClaudeParser(pydantic_object=AgentDecision)\n",
+    "test_chain_no_reason = lm_choose_route(system_prompt=prompt, parser=agent_parser)\n",
+    "start = time.time()\n",
+    "test_chain_no_reason.invoke(x)\n",
+    "print(f'time used: {time.time() - start}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Experiments\n",
+    "import pandas as pd\n",
+    "df = pd.read_csv(\"/Users/saisakulchernbumroong/Documents/RB exp/intent_exp/route_results_consensus.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# making change on the chain and correct parser you want to test here\n",
+    "agent_parser = ClaudeParser(pydantic_object=AgentDecisionWithReason)\n",
+    "test_chain = lm_choose_route(system_prompt=LLM_decide_tool_1, parser=agent_parser)\n",
+    "\n",
+    "\n",
+    "next_move = []\n",
+    "move_reason = []\n",
+    "for prompt in df.Prompt:\n",
+    "    x = get_state(user_uuid=uuid4(), prompts=[prompt], documents=['test@dbt.gov.uk/1 The power chapter.pdf'], ai_setting=AISettings(chat_backend=ChatLLMBackend(name=\"anthropic.claude-3-sonnet-20240229-v1:0\", provider=\"bedrock\")))\n",
+    "    res = test_chain.invoke(x)\n",
+    "    next_move += [res.next.value]\n",
+    "    move_reason += [res.reason] # comment this line out if you are not returning reason\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save result\n",
+    "save_path = \"/Users/saisakulchernbumroong/Documents/RB exp/intent_exp/intent_prompt3_basic_metadata.csv\"\n",
+    "pd.DataFrame({'Prompt': df.Prompt, 'Consensus': df.consensus, 'LLM_tool_select': next_move, 'LLM_reason': move_reason}).to_csv(save_path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "redbox-root-In7wI2Lt-py3.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/redbox-core/redbox/chains/components.py
+++ b/redbox-core/redbox/chains/components.py
@@ -1,31 +1,29 @@
 import logging
-
 import os
 from functools import cache
 
 from dotenv import load_dotenv
+from langchain.chat_models import init_chat_model
+from langchain_community.embeddings import BedrockEmbeddings
 from langchain_core.embeddings import Embeddings, FakeEmbeddings
-from langchain_core.tools import StructuredTool
 from langchain_core.runnables import Runnable
+from langchain_core.tools import StructuredTool
 from langchain_core.utils import convert_to_secret_str
 
 # from langchain_elasticsearch import ElasticsearchRetriever
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
 
-
 from redbox.chains.parser import StreamingJsonOutputParser
+from redbox.models.chain import StructuredResponseWithCitations
 from redbox.models.settings import ChatLLMBackend, Settings
 from redbox.retriever import (
     AllElasticsearchRetriever,
-    ParameterisedElasticsearchRetriever,
+    BasicMetadataRetriever,
     MetadataRetriever,
     OpenSearchRetriever,
+    ParameterisedElasticsearchRetriever,
 )
-from langchain_community.embeddings import BedrockEmbeddings
-from langchain.chat_models import init_chat_model
-from redbox.models.chain import StructuredResponseWithCitations
 from redbox.transform import bedrock_tokeniser
-
 
 logger = logging.getLogger(__name__)
 load_dotenv()
@@ -113,6 +111,13 @@ def get_parameterised_retriever(env: Settings, embeddings: Embeddings | None = N
 
 def get_metadata_retriever(env: Settings):
     return MetadataRetriever(
+        es_client=env.elasticsearch_client(),
+        index_name=env.elastic_chunk_alias,
+    )
+
+
+def get_basic_metadata_retriever(env: Settings):
+    return BasicMetadataRetriever(
         es_client=env.elasticsearch_client(),
         index_name=env.elastic_chunk_alias,
     )

--- a/redbox-core/redbox/retriever/__init__.py
+++ b/redbox-core/redbox/retriever/__init__.py
@@ -1,8 +1,9 @@
 from .retrievers import (
     AllElasticsearchRetriever,
-    ParameterisedElasticsearchRetriever,
+    BasicMetadataRetriever,
     MetadataRetriever,
     OpenSearchRetriever,
+    ParameterisedElasticsearchRetriever,
 )
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "AllElasticsearchRetriever",
     "MetadataRetriever",
     "OpenSearchRetriever",
+    "BasicMetadataRetriever",
 ]

--- a/redbox-core/redbox/retriever/queries.py
+++ b/redbox-core/redbox/retriever/queries.py
@@ -90,6 +90,23 @@ def get_metadata(
     }
 
 
+def get_minimum_metadata(
+    chunk_resolution: ChunkResolution | None,
+    state: RedboxState,
+) -> dict[str, Any]:
+    """Retrive document metadata without page_content"""
+    query_filter = build_query_filter(
+        selected_files=state.request.s3_keys,
+        permitted_files=state.request.permitted_s3_keys,
+        chunk_resolution=chunk_resolution,
+    )
+
+    return {
+        "_source": {"includes": ["metadata.name", "metadata.description", "metadata.keywords"]},
+        "query": {"bool": {"must": {"match_all": {}}, "filter": query_filter}},
+    }
+
+
 def build_document_query(
     query: str,
     query_vector: list[float],


### PR DESCRIPTION
## Context

Can the supervisor agent correctly classify the user intent and reliably call the correct tool?

As a user I want to be able to get the response from a correct tool without having to use specific keywords.

## Changes proposed in this pull request

- spike to investigate optimal prompts that allow LLM to determine best route give user's question
- add`BasicMetadataRetriever` to retrieve basic metadata: name, keywords, description
- add `get_minimum_metadata` to query open search and return metadata
- add `get_basic_metadata_retriever` function to get `BasicMetadataRetriever`

## Guidance to review

- inspect the notebook and test if you can run it.
- suggestion on additional explanation or wording for the notebook context.

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
