### PR TITLE
change *embeding to vectore_field in openseaerch query

### DIFF
--- a/redbox-core/redbox/retriever/queries.py
+++ b/redbox-core/redbox/retriever/queries.py
@@ -69,7 +69,7 @@ def get_all(
     )
 
     return {
-        "_source": {"excludes": ["*embedding"]},
+        "_source": {"excludes": ["vector_field"]},
         "query": {"bool": {"must": {"match_all": {}}, "filter": query_filter}},
     }
 
@@ -85,7 +85,7 @@ def get_metadata(
     )
 
     return {
-        "_source": {"excludes": ["*embedding", "text"]},
+        "_source": {"excludes": ["vector_field", "text"]},
         "query": {"bool": {"must": {"match_all": {}}, "filter": query_filter}},
     }
 


### PR DESCRIPTION
## Context

We do not have 'embedding' properties in our vector store, instead we use `vector_field`

## Changes proposed in this pull request

- changing `* embedding` to `vector_field`

## Guidance to review

- check that retriever tests pass
- check the application running as usual in docker

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
