### PR TITLE
fix: prevent files not requiring utf8 check from conversion

### DIFF
--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -132,6 +132,10 @@ class UploadView(View):
 
     @staticmethod
     def is_utf8_compatible(uploaded_file: UploadedFile) -> bool:
+        if not Path(uploaded_file.name).suffix.lower().endswith((".doc", ".docx", ".txt")):
+            logger.info("File does not require utf8 compatibility check")
+            return True
+
         try:
             uploaded_file.open()
             uploaded_file.read().decode("utf-8")


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Some errors on deployment to prod that isn't reflected in dev - probably because utf-8 conversion is running against all docs instead of particular file types.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Ensure it doesn't run against primarily PDFs but also other files. This can be changed in future dependent on user errors raised on sentry.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
You ok with the approach?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
