### PR TITLE
add check if summarise keyword was used node

### DIFF
--- a/redbox-core/redbox/graph/edges.py
+++ b/redbox-core/redbox/graph/edges.py
@@ -110,3 +110,11 @@ def build_strings_end_text_conditional(*strings: str) -> Runnable:
         return "DEFAULT"
 
     return _strings_end_text_conditional
+
+
+def is_using_search_keyword(state: RedboxState) -> bool:
+    found = re.findall(r"^@" + ChatRoute.search + "\s", state.request.question)
+    if found:
+        return True
+    else:
+        return False

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -246,6 +246,7 @@ TEST_CASES = [
                 user_uuid=uuid4(),
                 chat_history=[],
                 permitted_s3_keys=["s3_key"],
+                ai_settings=AISettings(self_route_enabled=True),
             ),
             test_data=[
                 RedboxTestData(
@@ -261,7 +262,7 @@ TEST_CASES = [
                     expected_route=ChatRoute.search,
                 ),
             ],
-            test_id="Search",
+            test_id="Search keyword - self route ON",
         ),
         generate_test_cases(
             query=RedboxQuery(


### PR DESCRIPTION
## Context

In the current Redbox search graph logic, if self_route is enabled and @search is used, it still possible to go to summarise if RAG cannot answer question. This is not followed the expected behaviour.

We need to add a node in search graph to check if keyword was used so that it forces to only use RAG even if RAG cannot find answer.

![image](https://github.com/user-attachments/assets/9b44e3e7-a43b-4c8c-86d9-5c8d95d17de8)

## Changes proposed in this pull request

- add a new node to check if @search keyword was used.

## Guidance to review

- check that when @search is used, only search route was used to produce final result

- example question: what are accelerometers in power chapter.

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
