### PR TITLE
fix: sentry error for ai_settings_id and for S3file

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -92,7 +92,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         activities: Sequence[str] = data.get("activities", [])
         user: User = self.scope.get("user")
 
-        user_ai_settings = await AISettingsModel.objects.aget(label=user.ai_settings_id)
+        user_ai_settings = await AISettingsModel.objects.aget(label=user.ai_settings_id if user else "default")
 
         chat_backend = await ChatLLMBackend.objects.aget(id=data.get("llm", user_ai_settings.chat_backend_id))
         temperature = data.get("temperature", user_ai_settings.temperature)

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -159,7 +159,7 @@ class UploadView(View):
             # Creating a new InMemoryUploadedFile object with the converted content
             new_uploaded_file = InMemoryUploadedFile(
                 file=BytesIO(new_bytes),
-                field_name=uploaded_file.field_name,
+                field_name=uploaded_file.name,
                 name=uploaded_file.name,
                 content_type="application/octet-stream",
                 size=len(new_bytes),


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We are getting a variety of sentry errors in relation to different parts of the ode

## Why have you proposed this change?

<!-- If there are UI changes, please include Before and After screenshots. -->
Fixing errors specifically in regards to ai_settings_id not existing for an LLM invoke and file_name is the incorrect field name, it should be name

## What is this code aiming to achieve?

<!-- What is being accomplished by this change in the code? -->
To get rid of some of the errors we get in the sentry 

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
