### PR TITLE
feat: auto approve and merge dependabot PRs

### DIFF
--- a/.github/dependabot_merge.yml
+++ b/.github/dependabot_merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'uktrade/redbox'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Dependabot alerts and the relevant PR should be auto approved and merged so it doesnt block PII pre commit hooks and/or expose our repo to vulnerabilities long term

## What is this code aiming to achieve?

<!-- What is being accomplished by this change in the code? -->
Creates a workflow to approve and merge dependabot PRs to dev, where we can carry out the relevant regression tests before creating a release.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
