### PR TITLE
Adding to the FAQs

### DIFF
--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -88,7 +88,7 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-2">
                 <p class="govuk-body">
-                    Generative AI is a fairly new kind of algorithmic machine learning based on 'neural architecture'  This architecture allows
+                    Generative AI is a fairly new kind of algorithmic machine learning based on 'neural architecture'. This architecture allows
                     machine learning models (called large language models in this case) to be trained on large amounts of information, and then
                     be able to converse with a user by 'generating' answers to questions or assisting with text-based processing tasks.
                 </p>
@@ -106,7 +106,7 @@
             <div class="govuk-accordion__section-content" id="faq-content-3">
                 <p class="govuk-body">
                     Not at all, the interface for Redbox comprises a document upload feature and a chat feature.  No technical skills are required,
-                    but an understanding of what large language models are and what they can do makes an enormous different to users when interacting
+                    but an understanding of what large language models are and what they can do makes an enormous difference to users when interacting
                     with them.  The principal skill to use Redbox well comes down to a skill called 'prompt engineering', which is just natural language
                     you type in and get the tool to respond.  There are some great Gov.uk short courses on generative AI you may consider taking:
                     <a href="https://cddo.blog.gov.uk/2024/01/19/artificial-intelligence-introducing-our-series-of-online-courses-on-generative-ai/" class="govuk-link">See the courses here</a>.
@@ -261,9 +261,26 @@
                 </p>
             </div>
         </div>
+      
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-10">
+                       Can I search online resources?
+                    </span>
+                </h2>
+            </div>
+        <div class="govuk-accordion__section-content" id="faq-content-9">
+                <p class="govuk-body">
+                   Yes, right now Redbox is connected to Wikipedia and Gov.uk for looking up current information. To search these sources just type @gadget at the start of your prompt and Redbox 
+                   will determine which source to search. For example, a prompt such as : @gadget find the most recent trade agreement between the UK and Italy, means Redbox will use gov.uk as
+                  the prompt is to do with UK government content.
+                </p>
+             </div>
+        </div>
 
-    </div>
+     <div>
 
-</div>
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Why have you proposed this change?

To give users a better understanding of the capabilities of Redbox by showing that it can search online resources as well.

<!-- If there are UI changes, please include Before and After screenshots. -->

## What is this code aiming to achieve?

Adding a new section about the agentic route for users to see in the homepage under the FAQs.

<!-- What is being accomplished by this change in the code? -->

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
