### PR TITLE
fix: uploaded file should point to name not field_name

### DIFF
--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -223,7 +223,7 @@ class UploadView(View):
                     output_filename = Path(uploaded_file.name).with_suffix(".docx").name
                     new_file = InMemoryUploadedFile(
                         file=BytesIO(converted_content),
-                        field_name=uploaded_file.field_name,
+                        field_name=uploaded_file.name,
                         name=output_filename,
                         content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                         size=len(converted_content),


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
S3File does not have a field_name, it has a name.

## What is this code aiming to achieve?
Stop errors on doc/docx uploads
<!-- What is being accomplished by this change in the code? -->

