### PR TITLE
Create agent to receive prompts

### DIFF
--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -19,15 +19,15 @@ from langchain_core.tools import StructuredTool
 from langchain_core.vectorstores import VectorStoreRetriever
 
 from redbox.chains.activity import log_activity
-from redbox.chains.components import get_chat_llm, get_tokeniser, get_structured_response_with_citations_parser
+from redbox.chains.components import get_chat_llm, get_structured_response_with_citations_parser, get_tokeniser
 from redbox.chains.parser import ClaudeParser
 from redbox.chains.runnables import CannedChatLLM, build_llm_chain, chain_use_metadata, create_chain_agent
-from redbox.models import ChatRoute
-from redbox.models.chain import DocumentState, PromptSet, RedboxState, RequestMetadata, MultiAgentPlan, AgentTask
-from redbox.models.graph import ROUTE_NAME_TAG, SOURCE_DOCUMENTS_TAG, RedboxActivityEvent, RedboxEventType
-from redbox.transform import combine_documents, flatten_document_state
-from redbox.models.prompts import DOCUMENT_AGENT_PROMPT, PLANNER_PROMPT
 from redbox.graph.nodes.sends import run_tools_parallel
+from redbox.models import ChatRoute
+from redbox.models.chain import AgentTask, DocumentState, MultiAgentPlan, PromptSet, RedboxState, RequestMetadata
+from redbox.models.graph import ROUTE_NAME_TAG, SOURCE_DOCUMENTS_TAG, RedboxActivityEvent, RedboxEventType
+from redbox.models.prompts import PLANNER_PROMPT
+from redbox.transform import combine_documents, flatten_document_state
 
 log = logging.getLogger(__name__)
 re_keyword_pattern = re.compile(r"@(\w+)")
@@ -368,28 +368,27 @@ def create_planner():
     return _create_planner
 
 
-def build_agent(tools):
+def build_agent(agent_name: str, system_prompt: str, tools):
     @RunnableLambda
     def _build_agent(state: RedboxState):
-        # tools = [search_documents]
         parser = ClaudeParser(pydantic_object=AgentTask)
         try:
             task = parser.parse(state.last_message.content)
         except Exception as e:
-            print(f"Cannot parse in document agent: {e}")
+            print(f"Cannot parse in {agent_name}: {e}")
         activity_node = build_activity_log_node(
-            RedboxActivityEvent(message=f"Document Agent is completing task: {task.task}")
+            RedboxActivityEvent(message=f"{agent_name} is completing task: {task.task}")
         )
         activity_node.invoke(state)
 
-        doc_agent = create_chain_agent(
-            system_prompt=DOCUMENT_AGENT_PROMPT,
+        worker_agent = create_chain_agent(
+            system_prompt=system_prompt,
             use_metadata=True,
             parser=None,
             tools=tools,
             _additional_variables={"task": task.task, "expected_output": task.expected_output},
         )
-        ai_msg = doc_agent.invoke(state)
+        ai_msg = worker_agent.invoke(state)
         result = run_tools_parallel(ai_msg, tools, state)
         return {"messages": result}
 

--- a/redbox-core/redbox/graph/nodes/processes.py
+++ b/redbox-core/redbox/graph/nodes/processes.py
@@ -368,7 +368,7 @@ def create_planner():
     return _create_planner
 
 
-def build_agent(agent_name: str, system_prompt: str, tools):
+def build_agent(agent_name: str, system_prompt: str, tools: list, use_metadata: bool = False):
     @RunnableLambda
     def _build_agent(state: RedboxState):
         parser = ClaudeParser(pydantic_object=AgentTask)
@@ -383,7 +383,7 @@ def build_agent(agent_name: str, system_prompt: str, tools):
 
         worker_agent = create_chain_agent(
             system_prompt=system_prompt,
-            use_metadata=True,
+            use_metadata=use_metadata,
             parser=None,
             tools=tools,
             _additional_variables={"task": task.task, "expected_output": task.expected_output},

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -23,6 +23,7 @@ from redbox.graph.edges import (
 from redbox.graph.nodes.processes import (
     PromptSet,
     build_activity_log_node,
+    build_agent,
     build_chat_pattern,
     build_error_pattern,
     build_merge_pattern,
@@ -33,12 +34,11 @@ from redbox.graph.nodes.processes import (
     build_set_self_route_from_llm_answer,
     build_stuff_pattern,
     clear_documents_process,
+    create_evaluator,
+    create_planner,
     empty_process,
     lm_choose_route,
     report_sources_process,
-    create_planner,
-    build_agent,
-    create_evaluator,
 )
 from redbox.graph.nodes.sends import (
     build_document_chunk_send,
@@ -50,6 +50,7 @@ from redbox.graph.nodes.tools import get_log_formatter_for_retrieval_tool
 from redbox.models.chain import AgentDecision, RedboxState
 from redbox.models.chat import ChatRoute, ErrorRoute
 from redbox.models.graph import ROUTABLE_KEYWORDS, RedboxActivityEvent
+from redbox.models.prompts import DOCUMENT_AGENT_PROMPT, EXTERNAL_DATA_AGENT
 from redbox.transform import structure_documents_by_file_name, structure_documents_by_group_and_indices
 
 
@@ -800,9 +801,21 @@ def build_new_graph(
 ) -> CompiledGraph:
     builder = StateGraph(RedboxState)
     builder.add_node("planner", create_planner())
-    builder.add_node("Document_Agent", build_agent(tools=multi_agent_tools["document_agent"]))
+    builder.add_node(
+        "Document_Agent",
+        build_agent(
+            agent_name="Document Agent", system_prompt=DOCUMENT_AGENT_PROMPT, tools=multi_agent_tools["document_agent"]
+        ),
+    )
     builder.add_node("send", empty_process)
-    builder.add_node("External_Data_Agent", build_agent(tools=multi_agent_tools["external_document_agent"]))
+    builder.add_node(
+        "External_Data_Agent",
+        build_agent(
+            agent_name="External Data Agent",
+            system_prompt=EXTERNAL_DATA_AGENT,
+            tools=multi_agent_tools["external_document_agent"],
+        ),
+    )
     builder.add_node("Evaluator_Agent", create_evaluator())
     builder.add_node(
         "report_citations",

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -804,7 +804,10 @@ def build_new_graph(
     builder.add_node(
         "Document_Agent",
         build_agent(
-            agent_name="Document Agent", system_prompt=DOCUMENT_AGENT_PROMPT, tools=multi_agent_tools["document_agent"]
+            agent_name="Document Agent",
+            system_prompt=DOCUMENT_AGENT_PROMPT,
+            tools=multi_agent_tools["document_agent"],
+            use_metadata=True,
         ),
     )
     builder.add_node("send", empty_process)
@@ -814,6 +817,7 @@ def build_new_graph(
             agent_name="External Data Agent",
             system_prompt=EXTERNAL_DATA_AGENT,
             tools=multi_agent_tools["external_document_agent"],
+            use_metadata=False,
         ),
     )
     builder.add_node("Evaluator_Agent", create_evaluator())


### PR DESCRIPTION
## Context

External Data Agent prompt were not passed when creating this agent.

## What is this code aiming to achieve?
The `create_agent` function needs to be able to receive different agent system prompts, so that this function can be reused.

<!-- What is being accomplished by this change in the code? -->

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
