### PR TITLE
Add citation to search

### DIFF
--- a/redbox-core/redbox/api/format.py
+++ b/redbox-core/redbox/api/format.py
@@ -10,6 +10,7 @@ def format_documents(documents: list[Document]) -> str:
             f"<Document>\n"
             f"\t<SourceType>{d.metadata.get("creator_type", "Unknown")}</SourceType>\n"
             f"\t<Source>{d.metadata.get("uri", "")}</Source>\n"
+            f"\t<page_number>{d.metadata.get("page_number", "")}</page_number>\n"
             "\t<Content>\n"
             f"{d.page_content}\n"
             "\t</Content>\n"

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -8,14 +8,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.runnables import (
-    Runnable,
-    RunnableBranch,
-    RunnableGenerator,
-    RunnableLambda,
-    RunnablePassthrough,
-    chain,
-)
+from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough, chain
 
 from redbox.api.format import format_documents
 from redbox.chains.activity import log_activity

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -156,7 +156,6 @@ def build_self_route_output_parser(
     """
 
     def _self_route_output_parser(chunks: Iterable[AIMessageChunk]) -> Iterable[str]:
-        nonlocal parser
         current_content = ""
         token_count = 0
         for chunk in chunks:

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -12,12 +12,12 @@ from langchain_core.runnables import Runnable, RunnableGenerator, RunnableLambda
 
 from redbox.api.format import format_documents
 from redbox.chains.activity import log_activity
-from redbox.chains.components import get_chat_llm, get_tokeniser, get_basic_metadata_retriever
+from redbox.chains.components import get_basic_metadata_retriever, get_chat_llm, get_tokeniser
 from redbox.models.chain import ChainChatMessage, PromptSet, RedboxState, get_prompts
 from redbox.models.errors import QuestionLengthError
 from redbox.models.graph import RedboxEventType
-from redbox.transform import bedrock_tokeniser, flatten_document_state, get_all_metadata
 from redbox.models.settings import get_settings
+from redbox.transform import bedrock_tokeniser, flatten_document_state, get_all_metadata
 
 log = logging.getLogger()
 re_string_pattern = re.compile(r"(\S+)")
@@ -166,9 +166,6 @@ def build_self_route_output_parser(
                 return
             elif token_count > max_tokens_to_check:
                 break
-            # if final_response_chain:
-            #     # dispatch_custom_event(RedboxEventType.response_tokens, current_content)
-            #     yield current_content
         for chunk in chunks:
             if final_response_chain:
                 dispatch_custom_event(RedboxEventType.response_tokens, chunk.content)

--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -166,9 +166,9 @@ def build_self_route_output_parser(
                 return
             elif token_count > max_tokens_to_check:
                 break
-        if final_response_chain:
-            dispatch_custom_event(RedboxEventType.response_tokens, current_content)
-        yield current_content
+            # if final_response_chain:
+            #     # dispatch_custom_event(RedboxEventType.response_tokens, current_content)
+            #     yield current_content
         for chunk in chunks:
             if final_response_chain:
                 dispatch_custom_event(RedboxEventType.response_tokens, chunk.content)

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -201,10 +201,11 @@ def get_search_graph(
         "check_if_RAG_can_answer",
         build_stuff_pattern(
             prompt_set=PromptSet.SelfRoute,
+            format_instructions=format_instructions,
             output_parser=build_self_route_output_parser(
                 match_condition=rag_cannot_answer,
                 max_tokens_to_check=4,
-                final_response_chain=True,
+                parser=citations_output_parser,
             ),
             final_response_chain=False,
         ),
@@ -247,7 +248,7 @@ def get_search_graph(
     builder.add_conditional_edges(
         "RAG_cannot_answer",
         lambda s: rag_cannot_answer(s.last_message),
-        {True: "clear_documents", False: "set_route_to_search"},
+        {True: "clear_documents", False: "report_citations"},
     )
     builder.add_edge("clear_documents", "set_route_to_summarise")
     builder.add_edge("set_route_to_summarise", END)

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -2,8 +2,7 @@ from datetime import UTC, datetime
 from enum import Enum, StrEnum
 from functools import reduce
 from types import UnionType
-from typing import (Annotated, List, Literal, NotRequired, Required, TypedDict,
-                    get_args, get_origin)
+from typing import Annotated, List, Literal, NotRequired, Required, TypedDict, get_args, get_origin
 from uuid import UUID, uuid4
 
 import environ

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -2,7 +2,8 @@ from datetime import UTC, datetime
 from enum import Enum, StrEnum
 from functools import reduce
 from types import UnionType
-from typing import Annotated, List, Literal, NotRequired, Required, TypedDict, get_args, get_origin
+from typing import (Annotated, List, Literal, NotRequired, Required, TypedDict,
+                    get_args, get_origin)
 from uuid import UUID, uuid4
 
 import environ
@@ -97,7 +98,7 @@ class AISettings(BaseModel):
 class Source(BaseModel):
     source: str = Field(description="URL or reference to the source", default="")
     source_type: str = Field(description="creator_type of tool", default="Unknown")
-    document_name: str = Field(description="Full title from document", default="")
+    document_name: str = Field(description="Full title from document", default="Unknown")
     highlighted_text_in_source: str = Field(
         description="Direct quote from the provided document (20+ words)", default=""
     )

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -1,8 +1,9 @@
 from datetime import UTC, datetime
-from enum import StrEnum
+from enum import Enum, StrEnum
 from functools import reduce
 from types import UnionType
-from typing import Annotated, Literal, NotRequired, Required, TypedDict, get_args, get_origin, List
+from typing import (Annotated, List, Literal, NotRequired, Required, TypedDict,
+                    get_args, get_origin)
 from uuid import UUID, uuid4
 
 import environ
@@ -16,7 +17,6 @@ from pydantic import BaseModel, Field
 from redbox.models import prompts
 from redbox.models.chat import ToolEnum
 from redbox.models.settings import ChatLLMBackend
-from enum import Enum
 
 load_dotenv()
 env = environ.Env()
@@ -94,12 +94,11 @@ class AISettings(BaseModel):
     # agents reporting to planner agent
     agents: list = ["Document_Agent", "External_Data_Agent"]
 
-
 class Source(BaseModel):
     source: str = Field(description="URL or reference to the source", default="")
     source_type: str = Field(description="creator_type of tool", default="Unknown")
-    document_name: str = ""
-    highlighted_text_in_source: str = ""
+    document_name: str = Field(description="Full title from document", default="")
+    highlighted_text_in_source: str = Field(description="Direct quote from the provided document (20+ words)", default="")
     page_numbers: list[int] = Field(description="Page Number in document the highlighted text is on", default=[1])
 
 
@@ -112,7 +111,7 @@ class Citation(BaseModel):
 
 
 class StructuredResponseWithCitations(BaseModel):
-    answer: str = Field(description="Markdown structured answer to the query", default="")
+    answer: str = Field(description="Markdown structured answer to the question", default="")
     citations: list[Citation] = Field(default_factory=list)
 
 

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -2,8 +2,7 @@ from datetime import UTC, datetime
 from enum import Enum, StrEnum
 from functools import reduce
 from types import UnionType
-from typing import (Annotated, List, Literal, NotRequired, Required, TypedDict,
-                    get_args, get_origin)
+from typing import Annotated, List, Literal, NotRequired, Required, TypedDict, get_args, get_origin
 from uuid import UUID, uuid4
 
 import environ
@@ -94,11 +93,14 @@ class AISettings(BaseModel):
     # agents reporting to planner agent
     agents: list = ["Document_Agent", "External_Data_Agent"]
 
+
 class Source(BaseModel):
     source: str = Field(description="URL or reference to the source", default="")
     source_type: str = Field(description="creator_type of tool", default="Unknown")
     document_name: str = Field(description="Full title from document", default="")
-    highlighted_text_in_source: str = Field(description="Direct quote from the provided document (20+ words)", default="")
+    highlighted_text_in_source: str = Field(
+        description="Direct quote from the provided document (20+ words)", default=""
+    )
     page_numbers: list[int] = Field(description="Page Number in document the highlighted text is on", default=[1])
 
 

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -23,43 +23,21 @@ CHAT_WITH_DOCS_REDUCE_SYSTEM_PROMPT = (
     "4) Maintain the original context and meaning.\n"
 )
 
-RETRIEVAL_SYSTEM_PROMPT = (
-    """
-   Answer my question using only the documents I provide. Include proper citations for each factual claim using the following format:
+RETRIEVAL_SYSTEM_PROMPT = """
+   Answer my question using only the documents I provide. Include proper citations for each factual claim.
+   Return ONLY the JSON structure
    {format_instructions}
+   with no introduction, explanation, or additional text:
+
    Requirements:
 
-   Only cite information from the documents I provide in <Documents>{formatted_documents}</Documents>
-   Each citation must match exact text in your answer
-   Include substantial quotes from the documents (20+ words minimum)
-   Specify page numbers when available
-   Do not reference external sources beyond what I provide
+   - Only cite information from the documents I provide in <Documents>{formatted_documents}</Documents>
+   - Each citation must match exact text in your answer
+   - Include substantial quotes from the documents (20+ words minimum)
+   - Specify page numbers when available
+   - Do not reference external sources beyond what I provide
 
-   <User question>{question}</User question>
    """
-)
-
-# AGENTIC_RETRIEVAL_SYSTEM_PROMPT = (
-#     "You are an advanced problem-solving assistant. Your primary goal is to carefully "
-#     "analyse and work through complex questions or problems. You will receive a collection "
-#     "of documents (all at once, without any information about their order or iteration) and "
-#     "a list of tool calls that have already been made (also without order or iteration "
-#     "information). Based on this data, you are expected to think critically about how to "
-#     "proceed.\n"
-#     "\n"
-#     "Objective:\n"
-#     "1. Examine the available documents and tool calls:\n"
-#     "- Evaluate whether the current information is sufficient to answer the question.\n"
-#     "- Consider the success or failure of previous tool calls based on the data they returned.\n"
-#     "- Hypothesise whether new tool calls might bring more valuable information.\n"
-#     "\n"
-#     "2. Decide whether you can answer this question:\n"
-#     "- If additional tool calls are likely to yield useful information, make those calls.\n"
-#     "- If the available documents are sufficient to proceed, provide an answer\n"
-#     "Your role is to think deeply before taking any action. Carefully weigh whether new "
-#     "information is necessary or helpful. Only take action (call tools or providing and answer) after "
-#     "thorough evaluation of the current documents and tool calls."
-# )
 
 NEW_ROUTE_RETRIEVAL_SYSTEM_PROMPT = """Expert Answer Evaluation Protocol:
 
@@ -257,7 +235,7 @@ CHAT_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
 CHAT_WITH_DOCS_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {formatted_documents} \n\n Answer: "
 
-RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+RETRIEVAL_QUESTION_PROMPT = "<User question>{question}</User question>"
 
 AGENTIC_RETRIEVAL_QUESTION_PROMPT = "{question}"
 

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -31,11 +31,11 @@ RETRIEVAL_SYSTEM_PROMPT = """
 
    Requirements:
 
-   - Only cite information from the documents I provide in <Documents>{formatted_documents}</Documents>
+   - Only cite information from the documents I provide in <My_Documents>{formatted_documents}</My_Documents>
    - Each citation must match exact text in your answer
    - Include substantial quotes from the documents (20+ words minimum)
    - Specify page numbers when available
-   - Do not reference external sources beyond what I provide
+   - Do not reference external sources beyond what I provide in <My_Documents>
 
    """
 
@@ -145,21 +145,28 @@ AGENTIC_GIVE_UP_SYSTEM_PROMPT = (
 )
 
 SELF_ROUTE_SYSTEM_PROMPT = """
-   Answer my question using only the documents I provide. Include proper citations for each factual claim.
-   Return ONLY the JSON structure
-   {format_instructions}
-   with no introduction, explanation, or additional text:
+   Evaluate if you can answer my question using only the documents I provide in <My_Documents>{formatted_documents}</My_Documents>.
 
-   Requirements:
+   Choosing one option below:
 
-   - Only cite information from the documents I provide in <Documents>{formatted_documents}</Documents>
-   - Each citation must match exact text in your answer
-   - Include substantial quotes from the documents (20+ words minimum)
-   - Specify page numbers when available
-   - Do not reference external sources beyond what I provide
+   1. You are not able to answer, return the word "unanswerable". No explanation.
+
+   OR
+
+   2. You are able to answer. Include proper citations for each factual claim. Return ONLY the JSON structure:
+   {format_instructions}. DO NOT start by saying: 'Here is the JSON response', just return JSON.
+
+      Requirements:
+
+      - Only cite information from the documents I provide in <My_Documents>
+      - Each citation must match exact text in your answer
+      - Include substantial quotes from the documents (20+ words minimum)
+      - Specify page numbers when available
+      - Do not reference external sources beyond what I provide in <My_Documents>
 
    Remember: Only use information from documents. If the information isn't there, only return the word: "unanswerable".
    """
+
 # SELF_ROUTE_SYSTEM_PROMPT = """Answer the user's question using only information from documents. Do not use your own knowledge or information from any other source. Analyse document carefully to find relevant information.
 
 

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -36,6 +36,7 @@ RETRIEVAL_SYSTEM_PROMPT = """
    - Include substantial quotes from the documents (20+ words minimum)
    - Specify page numbers when available
    - Do not reference external sources beyond what I provide in <My_Documents>
+   - Use UK English spelling in response
 
    """
 

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -144,28 +144,44 @@ AGENTIC_GIVE_UP_SYSTEM_PROMPT = (
     "guiding the user in providing the information needed for a complete solution."
 )
 
-SELF_ROUTE_SYSTEM_PROMPT = """Answer the user's question using only information from documents. Do not use your own knowledge or information from any other source. Analyse document carefully to find relevant information.
+SELF_ROUTE_SYSTEM_PROMPT = """
+   Answer my question using only the documents I provide. Include proper citations for each factual claim.
+   Return ONLY the JSON structure
+   {format_instructions}
+   with no introduction, explanation, or additional text:
+
+   Requirements:
+
+   - Only cite information from the documents I provide in <Documents>{formatted_documents}</Documents>
+   - Each citation must match exact text in your answer
+   - Include substantial quotes from the documents (20+ words minimum)
+   - Specify page numbers when available
+   - Do not reference external sources beyond what I provide
+
+   Remember: Only use information from documents. If the information isn't there, only return the word: "unanswerable".
+   """
+# SELF_ROUTE_SYSTEM_PROMPT = """Answer the user's question using only information from documents. Do not use your own knowledge or information from any other source. Analyse document carefully to find relevant information.
 
 
-If document contains information that answers the question:
-- Provide a direct, concise answer based solely on that information
-- Reference specific parts of document when appropriate
-- Be clear about what the document states vs. what might be inferred
+# If document contains information that answers the question:
+# - Provide a direct, concise answer based solely on that information
+# - Reference specific parts of document when appropriate
+# - Be clear about what the document states vs. what might be inferred
 
-If document does not contain information that addresses the question:
-- Respond with "unanswerable"
-- Do not attempt to guess or provide partial answers based on your own knowledge
-- Do not apologize or explain why you can't answer
+# If document does not contain information that addresses the question:
+# - Respond with "unanswerable"
+# - Do not attempt to guess or provide partial answers based on your own knowledge
+# - Do not apologize or explain why you can't answer
 
-Important: Your response must either:
-1. Contain ONLY information from documents
-OR
-2. Be EXACTLY and ONLY the word "unanswerable"
+# Important: Your response must either:
+# 1. Contain ONLY information from documents
+# OR
+# 2. Be EXACTLY and ONLY the word "unanswerable"
 
-There should never be any additional text, explanations, or your own knowledge in the response.
+# There should never be any additional text, explanations, or your own knowledge in the response.
 
-Remember: Only use information from documents. If the information isn't there, simply respond with "unanswerable".
-"""
+# Remember: Only use information from documents. If the information isn't there, only return the word: "unanswerable".
+# """
 
 
 CHAT_MAP_SYSTEM_PROMPT = (

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -24,11 +24,19 @@ CHAT_WITH_DOCS_REDUCE_SYSTEM_PROMPT = (
 )
 
 RETRIEVAL_SYSTEM_PROMPT = (
-    "Your task is to answer user queries with reliable sources.\n"
-    "**You must provide the citations where you use the information to answer.**\n"
-    "Use UK English spelling in response.\n"
-    "Use the document `creator_type` as `source_type` if available.\n"
-    "\n"
+    """
+   Answer my question using only the documents I provide. Include proper citations for each factual claim using the following format:
+   {format_instructions}
+   Requirements:
+
+   Only cite information from the documents I provide in <Documents>{formatted_documents}</Documents>
+   Each citation must match exact text in your answer
+   Include substantial quotes from the documents (20+ words minimum)
+   Specify page numbers when available
+   Do not reference external sources beyond what I provide
+
+   <User question>{question}</User question>
+   """
 )
 
 # AGENTIC_RETRIEVAL_SYSTEM_PROMPT = (

--- a/redbox-core/tests/graph/test_app.py
+++ b/redbox-core/tests/graph/test_app.py
@@ -36,8 +36,12 @@ from redbox.transform import structure_documents_by_group_and_indices
 
 LANGGRAPH_DEBUG = True
 
-SELF_ROUTE_TO_SEARCH = ["Condense self route question", "Testing Response - Search"]
+
 SELF_ROUTE_TO_CHAT = ["Condense self route question", "unanswerable"]
+OUTPUT_WITH_CITATIONS = AIMessage(
+    content=StructuredResponseWithCitations(answer="AI is a lie", citations=[]).model_dump_json()
+)
+SELF_ROUTE_TO_SEARCH = ["Condense self route question", OUTPUT_WITH_CITATIONS]
 
 
 def assert_number_of_events(num_of_events: int):
@@ -119,6 +123,7 @@ TEST_CASES = [
                     tokens_in_all_docs=1_000,
                     llm_responses=SELF_ROUTE_TO_SEARCH,
                     expected_route=ChatRoute.search,
+                    expected_text="AI is a lie",
                     # expected_activity_events=assert_number_of_events(3),
                 ),
             ],
@@ -139,6 +144,7 @@ TEST_CASES = [
                     tokens_in_all_docs=40_000,
                     llm_responses=SELF_ROUTE_TO_SEARCH,
                     expected_route=ChatRoute.search,
+                    expected_text="AI is a lie",
                 ),
             ],
             test_id="Chat with multiple docs - self route ON",
@@ -215,6 +221,7 @@ TEST_CASES = [
                     chunk_resolution=ChunkResolution.normal,
                     llm_responses=SELF_ROUTE_TO_SEARCH,  # + ["Condense Question", "Testing Response 1"],
                     expected_route=ChatRoute.search,
+                    expected_text="AI is a lie",
                     # expected_activity_events=assert_number_of_events(2),
                 ),
             ],
@@ -252,14 +259,16 @@ TEST_CASES = [
                 RedboxTestData(
                     number_of_docs=1,
                     tokens_in_all_docs=10000,
-                    llm_responses=["Condense response", "The cake is a lie"],
+                    llm_responses=["Condense response", OUTPUT_WITH_CITATIONS],
                     expected_route=ChatRoute.search,
+                    expected_text="AI is a lie",
                 ),
                 RedboxTestData(
                     number_of_docs=5,
                     tokens_in_all_docs=10000,
-                    llm_responses=["Condense response", "The cake is a lie"],
+                    llm_responses=["Condense response", OUTPUT_WITH_CITATIONS],
                     expected_route=ChatRoute.search,
+                    expected_text="AI is a lie",
                 ),
             ],
             test_id="Search keyword - self route ON",
@@ -276,9 +285,10 @@ TEST_CASES = [
                 RedboxTestData(
                     number_of_docs=1,
                     tokens_in_all_docs=10000,
-                    llm_responses=["Condense response", "The cake is a lie"],
+                    llm_responses=["Condense response", OUTPUT_WITH_CITATIONS],
                     expected_route=ChatRoute.search,
-                    s3_keys=["s3_key"],
+                    expected_text="AI is a lie",
+                    s3_keys=[],
                 ),
             ],
             test_id="Search, nothing selected",


### PR DESCRIPTION
## Context

Inline citations help user understand where from the source the LLM derives answer from, and also create trusts.

## What is this code aiming to achieve?

Show inline citations when using self_route and @search.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ x] No

Test in docker to see the response return with citations.
## Relevant links
