### PR TITLE
Feature/citation links

### DIFF
--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -150,3 +150,9 @@ upload-button {
 .iai-chat-bubbles__sources-link:visited {
   color: var(--iai-product-colour, var(--iai-colour-brand));
 }
+.iai-chat-bubbles__sources-link:target {
+  outline: 3px solid rgba(0, 0, 0, 0);
+  background-color: #fd0;
+  box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+  text-decoration: none
+}

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -853,8 +853,8 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             body=elastic_log_msg,
         )
 
-    def unique_citation_uris(self) -> list[tuple[str, str]]:
-        """a unique set of names and hrefs for all citations"""
+    def unique_citation_uris(self) -> list[tuple[str, str, str, str]]:
+        """a unique set of names, hrefs, ids and relevant texts for all citations"""
 
         def get_display(citation):
             if not citation.file:
@@ -862,7 +862,7 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             return citation.file.file_name
 
         return sorted(
-            {(get_display(citation), citation.uri, citation.text_in_answer) for citation in self.citation_set.all()}
+            {(get_display(citation), citation.uri, citation.id, citation.text_in_answer) for citation in self.citation_set.all()}
         )
 
 

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -546,6 +546,9 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     def __str__(self) -> str:  # pragma: no cover
         return self.file_name
 
+    def __lt__(self, other):
+        return self.id < other.id
+
     def save(self, *args, **kwargs):
         if not self.last_referenced:
             if self.created_at:
@@ -627,9 +630,6 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     @property
     def expires(self) -> timedelta:
         return self.expires_at - datetime.now(tz=UTC)
-
-    def __lt__(self, other):
-        return self.id < other.id
 
     @classmethod
     def get_completed_and_processing_files(cls, user: User) -> tuple[Sequence["File"], Sequence["File"]]:
@@ -862,7 +862,10 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             return citation.file.file_name
 
         return sorted(
-            {(get_display(citation), citation.uri, citation.id, citation.text_in_answer) for citation in self.citation_set.all()}
+            {(get_display(citation),
+              citation.uri,
+              citation.id,
+              citation.text_in_answer) for citation in self.citation_set.all()}
         )
 
 

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -546,9 +546,6 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     def __str__(self) -> str:  # pragma: no cover
         return self.file_name
 
-    def __lt__(self, other):
-        return self.id < other.id
-
     def save(self, *args, **kwargs):
         if not self.last_referenced:
             if self.created_at:
@@ -630,6 +627,9 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
     @property
     def expires(self) -> timedelta:
         return self.expires_at - datetime.now(tz=UTC)
+
+    def __lt__(self, other):
+        return self.id < other.id
 
     @classmethod
     def get_completed_and_processing_files(cls, user: User) -> tuple[Sequence["File"], Sequence["File"]]:
@@ -862,10 +862,10 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             return citation.file.file_name
 
         return sorted(
-            {(get_display(citation),
-              citation.uri,
-              citation.id,
-              citation.text_in_answer) for citation in self.citation_set.all()}
+            {
+                (get_display(citation), citation.uri, citation.id, citation.text_in_answer)
+                for citation in self.citation_set.all()
+            }
         )
 
 

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -51,12 +51,12 @@ class ChatsView(View):
         # Add footnotes to messages
         for message in messages:
             footnote_counter = 1
-            for display, href, text_in_answer in message.unique_citation_uris():  # noqa: B007
+            for display, href,cit_id, text_in_answer in message.unique_citation_uris():  # noqa: B007
                 if text_in_answer:
                     message.text = message.text.replace(
                         text_in_answer,
-                        f'{text_in_answer}<a class="rb-footnote-link" href="#footnote-{message.id}-{footnote_counter}">{footnote_counter}</a>',  # noqa: E501
-                    )
+                        f'{text_in_answer}<a class="rb-footnote-link" href="/citations/{message.id}/#{cit_id}">{footnote_counter}</a>', # noqa: E501
+                        )
                     footnote_counter = footnote_counter + 1
 
         context = {

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -51,12 +51,12 @@ class ChatsView(View):
         # Add footnotes to messages
         for message in messages:
             footnote_counter = 1
-            for display, href,cit_id, text_in_answer in message.unique_citation_uris():  # noqa: B007
+            for display, href, cit_id, text_in_answer in message.unique_citation_uris():  # noqa: B007
                 if text_in_answer:
                     message.text = message.text.replace(
                         text_in_answer,
-                        f'{text_in_answer}<a class="rb-footnote-link" href="/citations/{message.id}/#{cit_id}">{footnote_counter}</a>', # noqa: E501
-                        )
+                        f'{text_in_answer}<a class="rb-footnote-link" href="/citations/{message.id}/#{cit_id}">{footnote_counter}</a>',  # noqa: E501
+                    )
                     footnote_counter = footnote_counter + 1
 
         context = {

--- a/django_app/redbox_app/templates/citation_fragment.html
+++ b/django_app/redbox_app/templates/citation_fragment.html
@@ -31,7 +31,7 @@
                 {% if citation.page_numbers %}
                   <div class="govuk-body-s govuk-!-margin-top-3"><strong>Page number(s):</strong> {{ citation.page_numbers | join(", ") }}</div>
                 {% endif %}
-                <markdown-converter class="iai-chat-bubble__text">{{ citation.text }}</markdown-converter>
+                <markdown-converter id="{{ citation.id }}" class="iai-chat-bubble__text">{{ citation.text }}</markdown-converter>
               </li>
             {% endfor %}
           </ul>

--- a/django_app/redbox_app/templates/citation_fragment.html
+++ b/django_app/redbox_app/templates/citation_fragment.html
@@ -31,7 +31,7 @@
                 {% if citation.page_numbers %}
                   <div class="govuk-body-s govuk-!-margin-top-3"><strong>Page number(s):</strong> {{ citation.page_numbers | join(", ") }}</div>
                 {% endif %}
-                <markdown-converter id="{{ citation.id }}" class="iai-chat-bubble__text">{{ citation.text }}</markdown-converter>
+                <markdown-converter id="{{ citation.id }}" class="iai-chat-bubbles__sources-link">{{ citation.text }}</markdown-converter>
               </li>
             {% endfor %}
           </ul>

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -56,7 +56,7 @@
   <h3 class="iai-chat-bubble__sources-heading govuk-heading-s govuk-!-margin-bottom-1">Sources</h3>
   <div class="iai-display-flex-from-desktop">
     <ol class="rb-footnote-list govuk-!-margin-bottom-0">
-      {% for display, href, text_in_answer in message.unique_citation_uris() %}
+      {% for display, href, cit_id, text_in_answer in message.unique_citation_uris() %}
         <li class="govuk-!-margin-bottom-0">
           <a class="iai-chat-bubbles__sources-link govuk-link" id="footnote-{{ message.id }}-{{ loop.index }}" href="{{ href }}" target="_blank">{{ display }}</a>
         </li>


### PR DESCRIPTION
## Context
When a question is asked via the @search route (directly or through self-direct) with at least one document selected. The response includes a footnotes section with citations.

**Current Behaviour** : When clicked, the citations link to the footnote section on the same page.

**Proposed Change**: Instead, this would like to the sources page with emphasis on the text from the link that has been selected.

## What changed
-  Updated the `unique_citation_uris` method in `django_app/redbox_app/redbox_core/models.py:856` to return the `citation.id` which is necessary for emphasis on the summary screen
- Updated `django_app/redbox_app/redbox_core/views/chat_views.py:58` to return a link to the sources summary (instead of the footnotes section using the now provided `citation.id`
-  Added `citation.id` as an identifier in `django_app/redbox_app/templates/citation_fragment.html` to allow for selecting the relevant section of the sources page.
- Updated `django_app/redbox_app/templates/macros/chat-macros.html:59` to avoid an error due to the update to the `unique_citation_uris` method.

## Are there any specific instructions on how to test this change?
- [X] Yes (if so provide more detail)
- [ ] No
Run locally and confirm that this does in fact link to the correct section.

## Relevant links
[JIRA Ticket - Changing the structure of citations](https://uktrade.atlassian.net/jira/software/projects/REDBOX/boards/558?assignee=712020%3Ac1df826f-3b55-414a-9586-d302d6fb4f88&selectedIssue=REDBOX-725)