### PR TITLE
feat: redirect logged in users to chat page

### DIFF
--- a/django_app/redbox_app/redbox_core/views/misc_views.py
+++ b/django_app/redbox_app/redbox_core/views/misc_views.py
@@ -20,7 +20,7 @@ def homepage_view(request):
             template_name="homepage.html",
             context={"request": request, "allow_sign_ups": settings.ALLOW_SIGN_UPS},
         )
-    
+
     return redirect("chats")
 
 

--- a/django_app/redbox_app/redbox_core/views/misc_views.py
+++ b/django_app/redbox_app/redbox_core/views/misc_views.py
@@ -14,14 +14,14 @@ logger = logging.getLogger(__name__)
 
 @require_http_methods(["GET"])
 def homepage_view(request):
-    if not request.user.is_authenticated and settings.LOGIN_METHOD == "sso":
-        return redirect("authbroker_client:login")
-    else:
+    if not request.user.is_authenticated:
         return render(
             request,
             template_name="homepage.html",
             context={"request": request, "allow_sign_ups": settings.ALLOW_SIGN_UPS},
         )
+    
+    return redirect("chats")
 
 
 @require_http_methods(["GET"])

--- a/django_app/tests/views/test_misc_views.py
+++ b/django_app/tests/views/test_misc_views.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def test_declaration_view_get(peter_rabbit: User, client: Client):
     client.force_login(peter_rabbit)
     response = client.get("/")
-    assert HTTPStatus(response.status_code).is_success
+    assert HTTPStatus(response.status_code).is_redirection
     assert response.headers["Cache-control"] == "no-store"
     assert "Report-To" not in response.headers
 
@@ -29,7 +29,7 @@ def test_declaration_view_get_with_sentry_security_header_endpoint(
     settings.SENTRY_REPORT_TO_ENDPOINT = URL("http://example.com")
     client.force_login(peter_rabbit)
     response = client.get("/")
-    assert HTTPStatus(response.status_code).is_success
+    assert HTTPStatus(response.status_code).is_redirection
     assert json.loads(response.headers["Report-To"]) == {
         "group": "csp-endpoint",
         "max_age": 10886400,


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
As a user
When I first log into Redbox
Then I want to see the main home page
So that I can be introduced to the service

As a user
From my second log in forward
When I log into Redbox
Then I should be redirected to the ‘Chats’ page
So that I can started using the service straight away

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Not logged in users will see homepage, logged in users will go to chat page.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
https://uktrade.atlassian.net/jira/software/projects/REDBOX/boards/558?assignee=5e66610684dcfc0cf39102d4&selectedIssue=REDBOX-760