### PR TITLE
Make footer GDS styled

### DIFF
--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -162,6 +162,27 @@ upload-button {
   text-decoration: none;
 }
 
+/* Readded logo CSS here as we store the background-image in a different location*/
+.govuk-footer__copyright-logo {
+  display: inline-block;
+  min-width: 125px;
+  padding-top: 112px;
+  background-image: url(/static/govuk-frontend/assets/images/govuk-crest.png);
+  background-repeat: no-repeat;
+  background-position: 50% 0;
+  background-size: 125px 102px;
+  text-align: center;
+  white-space: nowrap
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:2),
+only screen and (min-resolution:2dppx),
+only screen and (min-resolution:192dpi) {
+  .govuk-footer__copyright-logo {
+    background-image: url(static/govuk-frontend/assets/images/govuk-crest-2x.png)
+  }
+}
+
 /* Chats Page - to come after i.AI Design System */
 @import "./chat-styles.scss";
 

--- a/django_app/redbox_app/templates/accessibility-statement.html
+++ b/django_app/redbox_app/templates/accessibility-statement.html
@@ -5,47 +5,65 @@
 {% set departmental_owner = "Department for Business and Trade" %}
 {% set zoom_level = "300%" %}
 {% set review_date_last = "21st June 2024" %}
-{% set compliance_status = 'This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG22/" class="govuk-link">Web Content Accessibility Guidelines version 2.2</a> AA standard.' %}
+{% set compliance_status = 'This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG22/"
+  class="govuk-link">Web Content Accessibility Guidelines version 2.2</a> AA standard.' %}
 
 
 {% block content %}
 
-<div class="govuk-width-container iai-grid">
-  <div class="iai-grid__start-3-span-8">
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">Accessibility statement for Redbox</h1>
+      <h1 class="govuk-heading-l">Accessibility statement for Redbox</h1>
 
-    <p class="govuk-body">This accessibility statement applies to Redbox.</p>
-    <p class="govuk-body">This website is run by the {{ departmental_owner }}. We want as many people as possible to be able to use this website. For example, that means you should be able to:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-body">
-      <li>change colours, contrast levels and fonts</li>
-      <li>zoom in up to {{ zoom_level }} without the text spilling off the screen</li>
-      <li>navigate most of the website using a keyboard or speech recognition software</li>
-      <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
-    </ul>
-    <p class="govuk-body">We've also made the website text as simple as possible to understand.</p>
-    <p class="govuk-body"><a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a> has advice on making your device easier to use if you have a disability.</p>
+      <p class="govuk-body">This accessibility statement applies to Redbox.</p>
+      <p class="govuk-body">This website is run by the {{ departmental_owner }}. We want as many people as possible to
+        be able to use this website. For example, that means you should be able to:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-body">
+        <li>change colours, contrast levels and fonts</li>
+        <li>zoom in up to {{ zoom_level }} without the text spilling off the screen</li>
+        <li>navigate most of the website using a keyboard or speech recognition software</li>
+        <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and
+          VoiceOver)</li>
+      </ul>
+      <p class="govuk-body">We've also made the website text as simple as possible to understand.</p>
+      <p class="govuk-body"><a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a> has advice on
+        making your device easier to use if you have a disability.</p>
 
-    <h2 class="govuk-heading-m">Feedback and contact information</h2>
-    <p class="govuk-body">If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, email <a href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a></p>
-    <p class="govuk-body">We'll consider your request and get back to you in 14 days.</p>
+      <h2 class="govuk-heading-m">Feedback and contact information</h2>
+      <p class="govuk-body">If you need information on this website in a different format like accessible PDF, large
+        print, easy read, audio recording or braille, email <a href="mailto:{{contact_email}}"
+          class="govuk-link">{{contact_email}}</a></p>
+      <p class="govuk-body">We'll consider your request and get back to you in 14 days.</p>
 
-    <h2 class="govuk-heading-m">Reporting accessibility problems with this website</h2>
-    <p class="govuk-body">We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact the team at <a href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a>.</p>
+      <h2 class="govuk-heading-m">Reporting accessibility problems with this website</h2>
+      <p class="govuk-body">We're always looking to improve the accessibility of this website. If you find any problems
+        not listed on this page or think we're not meeting accessibility requirements, contact the team at <a
+          href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a>.</p>
 
-    <h2 class="govuk-heading-m">Enforcement procedure</h2>
-    <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the "accessibility regulations"). If you're not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support Service (EASS)</a>.</p>
+      <h2 class="govuk-heading-m">Enforcement procedure</h2>
+      <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public
+        Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the "accessibility
+        regulations"). If you're not happy with how we respond to your complaint, <a
+          href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support
+          Service (EASS)</a>.</p>
 
-    <h2 class="govuk-heading-m">Technical information about this website's accessibility</h2>
-    <p class="govuk-body">{{ departmental_owner }} is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+      <h2 class="govuk-heading-m">Technical information about this website's accessibility</h2>
+      <p class="govuk-body">{{ departmental_owner }} is committed to making its website accessible, in accordance with
+        the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 
-    <h2 class="govuk-heading-m">Compliance status</h2>
-    <p class="govuk-body">{{ compliance_status | safe }}</p>
+      <h2 class="govuk-heading-m">Compliance status</h2>
+      <p class="govuk-body">{{ compliance_status | safe }}</p>
 
-    <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
-    <p class="govuk-body">This statement was prepared on 27th February 2024. It was last reviewed on {{ review_date_last }}.</p>
-    <p class="govuk-body">This website was last tested on {{ review_date_last }} against the WCAG 2.2 AA standard. The test was carried out by the Incubator for Artificial Intelligence (i.AI) manually using the WCAG Evaluation Methodology tool.</p>
+      <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
+      <p class="govuk-body">This statement was prepared on 27th February 2024. It was last reviewed on {{
+        review_date_last }}.</p>
+      <p class="govuk-body">This website was last tested on {{ review_date_last }} against the WCAG 2.2 AA standard. The
+        test was carried out by the Incubator for Artificial Intelligence (i.AI) manually using the WCAG Evaluation
+        Methodology tool.</p>
 
+    </div>
   </div>
 </div>
 

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -82,7 +82,7 @@
   {% endif %}
 
 
-  <main id="main-content" role="main">
+  <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
     {% block content %}
     {% endblock %}
   </main>

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -93,39 +93,68 @@
     {'text': 'Support', 'url': url('support') },
     {'text': 'Sitemap', 'url': url('sitemap') }
   ] %}
-  <footer class="iai-footer">
-    <div class="iai-footer__container govuk-width-container">
-      <div class="iai-footer__links-container">
-        <a class="iai-footer__logo" href="https://ai.gov.uk">
-          <svg width="65" height="40" aria-label="i.AI" focusable="false" viewBox="0 0 167 105"><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><rect y="24.937px" width="22px" fill="#fff" height="80px" x="0px"></rect><rect fill="#c50878" x="144.87" width="21.82" height="104.15"></rect><circle r="11" cx="11px" fill="#fff" cy="11px"></circle><path fill="#c50878" d="M122.1,104.15,115,83.7H79.41l-6.75,20.45H48.52L87.06,0H108.6l38.15,104.15ZM97.44,27.8,85.76,63.55h23.1Z"></path><circle r="11" cx="36.700001px" fill="#fff" cy="93.682587px"></circle></g></g></svg>
-        </a>
-        <div>
-          <ul class="iai-footer__list">
-            {% for link in footer_links %}
-              <li class="iai-footer__list-item">
-                <a class="iai-footer__link iai-footer__link--large" href="{{ link.url }}">{{ link.text }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-          <div class="iai-footer__licence">
-            <svg aria-hidden="true" focusable="false" class="iai-footer__licence-logo" viewBox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-            </svg>
-            <span>
-              All content is available under the
-              <a class="iai-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
-          </div>
+
+  <footer class="govuk-footer">
+    <div class="govuk-width-container">
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          <ul class="govuk-footer__inline-list">
+
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/privacy-notice/">
+                Privacy
+              </a>
+            </li>
+
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/accessibility-statement">
+                Accessibility
+              </a>
+            </li>
+
+
+
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/support">
+                Support
+              </a>
+            </li>
+
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/sitemap">
+                Sitemap
+              </a>
+            </li>
+
+        </ul>
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41">
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+          </svg>
+          <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
         </div>
-      </div>
-      <div class="iai-footer__feedback-container">
-        <svg aria-hidden="true" focusable="false" width="37" height="37" viewBox="0 0 37 37" fill="none">
-          <path d="M36.1936 18.0968C36.1936 8.1022 28.0913 0 18.0968 0C8.1022 0 0 8.1022 0 18.0968C0 28.0913 8.1022 36.1936 18.0968 36.1936C28.0913 36.1936 36.1936 28.0913 36.1936 18.0968Z" fill="#EDEEF2"/>
-          <path d="M36.1936 18.0968C36.1936 8.1022 28.0913 0 18.0968 0C8.1022 0 0 8.1022 0 18.0968C0 28.0913 8.1022 36.1936 18.0968 36.1936C28.0913 36.1936 36.1936 28.0913 36.1936 18.0968Z" fill="#C50878"/>
-          <path d="M9 17L27 12V24L9 20V17Z" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M17.5997 22.8C17.4947 23.1808 17.3156 23.5373 17.0728 23.8489C16.83 24.1605 16.5282 24.4213 16.1847 24.6163C15.8411 24.8113 15.4625 24.9367 15.0704 24.9854C14.6784 25.0341 14.2806 25.0051 13.8997 24.9C13.5189 24.795 13.1625 24.6159 12.8508 24.3731C12.5392 24.1303 12.2784 23.8285 12.0834 23.4849C11.8884 23.1414 11.763 22.7627 11.7143 22.3707C11.6657 21.9786 11.6947 21.5808 11.7997 21.2" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        <span class="iai-footer__feedback-text">This is a new service. Your <a class="iai-footer__link" href="https://teams.microsoft.com/l/channel/19%3A9ae6b3b539724595a3139c2b16dc56ef%40thread.tacv2/Redbox%20trial%20participants%20Chat%20Channel?groupId=7a71ce78-fe77-4185-825c-ae40cb07d614&tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86">feedback</a> will help us to <span class="iai-prevent-orphans">improve it</span></span>
+        <div class="govuk-footer__meta-item">
+          <a
+            class="govuk-footer__link govuk-footer__copyright-logo"
+            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+            © Crown copyright
+          </a>
+        </div>
       </div>
     </div>
   </footer>

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -88,10 +88,10 @@
   </main>
 
   {% set footer_links = [
-    {'text': 'Privacy', 'url': url('privacy-notice') },
-    {'text': 'Accessibility', 'url': url('accessibility-statement') },
-    {'text': 'Support', 'url': url('support') },
-    {'text': 'Sitemap', 'url': url('sitemap') }
+    {'text': 'Privacy policy', 'url': 'privacy-notice' },
+    {'text': 'Accessibility statement', 'url': 'accessibility-statement' },
+    {'text': 'Support', 'url': 'support' },
+    {'text': 'Sitemap', 'url': 'sitemap' }
   ] %}
 
   <footer class="govuk-footer">
@@ -101,31 +101,13 @@
           <h2 class="govuk-visually-hidden">Support links</h2>
           <ul class="govuk-footer__inline-list">
 
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="/privacy-notice/">
-                Privacy
-              </a>
-            </li>
-
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="/accessibility-statement">
-                Accessibility
-              </a>
-            </li>
-
-
-
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="/support">
-                Support
-              </a>
-            </li>
-
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="/sitemap">
-                Sitemap
-              </a>
-            </li>
+            {% for item in footer_links %}
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/{{ item['url'] }}/">
+                  {{ item['text'] }}
+                </a>
+              </li>
+            {% endfor %}
 
         </ul>
           <svg

--- a/django_app/redbox_app/templates/privacy-notice.html
+++ b/django_app/redbox_app/templates/privacy-notice.html
@@ -3,73 +3,106 @@
 {% set pageTitle = "Privacy notice" %}
 
 {% set departmental_owner = "Department for Business and Trade" %}
-{% set department_address = "Department for Business and Trade, Old Admiralty Building, Admiralty Place, London, SW1A 2DY" %}
+{% set department_address = "Department for Business and Trade, Old Admiralty Building, Admiralty Place, London, SW1A
+2DY" %}
 {% set last_updated = "21st June 2024" %}
 
 
 {% block content %}
 
-<div class="govuk-width-container iai-grid">
-  <div class="iai-grid__start-3-span-8">
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">Privacy notice for Redbox</h1>
-    <div class="govuk-body">
-      <p class="govuk-body-l">This notice sets out how we will use your personal data, and your rights. It is made under Articles 13 and/or 14 of the UK General Data Protection Regulation (UK GDPR).</p>
+      <h1 class="govuk-heading-l">Privacy notice for Redbox</h1>
+      <div class="govuk-body">
+        <p class="govuk-body-l">This notice sets out how we will use your personal data, and your rights. It is made
+          under Articles 13 and/or 14 of the UK General Data Protection Regulation (UK GDPR).</p>
 
-      <h2 class="govuk-heading-m">Your data</h2>
-      <h3 class="govuk-heading-s">Purpose</h3>
-      <p class="govuk-body">The purposes for which we are processing your personal data are:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-body">
-        <li>enabling login to the platform</li>
-        <li>chat history and log information will be anonymised and analysis of this will be used to improve the service</li>
-      </ul>
+        <h2 class="govuk-heading-m">Your data</h2>
+        <h3 class="govuk-heading-s">Purpose</h3>
+        <p class="govuk-body">The purposes for which we are processing your personal data are:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-body">
+          <li>enabling login to the platform</li>
+          <li>chat history and log information will be anonymised and analysis of this will be used to improve the
+            service</li>
+        </ul>
 
-      <h3 class="govuk-heading-s">The data</h3>
-      <p class="govuk-body">We will process the following personal data:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-body">
-        <li>organisational email address</li>
-        <li>chat history</li>
-      </ul>
+        <h3 class="govuk-heading-s">The data</h3>
+        <p class="govuk-body">We will process the following personal data:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-body">
+          <li>organisational email address</li>
+          <li>chat history</li>
+        </ul>
 
-      <h3 class="govuk-heading-s">Legal basis of processing</h3>
-      <p class="govuk-body">The legal basis for processing your personal data is:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-body">
-        <li>data subject consents</li>
-      </ul>
+        <h3 class="govuk-heading-s">Legal basis of processing</h3>
+        <p class="govuk-body">The legal basis for processing your personal data is:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-body">
+          <li>data subject consents</li>
+        </ul>
 
-      <h3 class="govuk-heading-s">Recipients</h3>
-      <p class="govuk-body">Your personal data will be shared by us with analysts/researchers within the {{ departmental_owner }} if you have consented to be contacted further about Redbox.</p>
-      <p class="govuk-body">As your personal data will be stored on our IT infrastructure it will also be shared with our data processors who provide email and document management and storage services.</p>
+        <h3 class="govuk-heading-s">Recipients</h3>
+        <p class="govuk-body">Your personal data will be shared by us with analysts/researchers within the {{
+          departmental_owner }} if you have consented to be contacted further about Redbox.</p>
+        <p class="govuk-body">As your personal data will be stored on our IT infrastructure it will also be shared with
+          our data processors who provide email and document management and storage services.</p>
 
-      <h3 class="govuk-heading-s">Retention</h3>
-      <p class="govuk-body">Your personal data will be retained for 12 months after account inactivity. At that point we will delete your email address, depersonalising the data we hold. If you have provided us consent to contact you, we will retain your email until <DATE> and continue sharing it with evaluators so they can conduct research on the long term impact of Redbox.</p>
+        <h3 class="govuk-heading-s">Retention</h3>
+        <p class="govuk-body">Your personal data will be retained for 12 months after account inactivity. At that point
+          we will delete your email address, depersonalising the data we hold. If you have provided us consent to
+          contact you, we will retain your email until <DATE> and continue sharing it with evaluators so they can
+            conduct research on the long term impact of Redbox.</p>
 
-      <h3 class="govuk-heading-s">Your rights</h3>
-      <p class="govuk-body">You have the right to request information about how your personal data are processed, and to request a copy of that personal data.</p>
-      <p class="govuk-body">You have the right to request that any inaccuracies in your personal data are rectified without delay.</p>
-      <p class="govuk-body">You have the right to request that any incomplete personal data are completed, including by means of a supplementary statement.</p>
-      <p class="govuk-body">You have the right to request that your personal data are erased if there is no longer a justification for them to be processed.</p>
-      <p class="govuk-body">You have the right in certain circumstances (for example, where accuracy is contested) to request that the processing of your personal data is restricted.</p>
-      <p class="govuk-body">You have the right to object to the processing of your personal data where it is processed for direct marketing purposes.</p>
-      <p class="govuk-body">You have the right to withdraw consent to the processing of your personal data at any time.</p>
+        <h3 class="govuk-heading-s">Your rights</h3>
+        <p class="govuk-body">You have the right to request information about how your personal data are processed, and
+          to request a copy of that personal data.</p>
+        <p class="govuk-body">You have the right to request that any inaccuracies in your personal data are rectified
+          without delay.</p>
+        <p class="govuk-body">You have the right to request that any incomplete personal data are completed, including
+          by means of a supplementary statement.</p>
+        <p class="govuk-body">You have the right to request that your personal data are erased if there is no longer a
+          justification for them to be processed.</p>
+        <p class="govuk-body">You have the right in certain circumstances (for example, where accuracy is contested) to
+          request that the processing of your personal data is restricted.</p>
+        <p class="govuk-body">You have the right to object to the processing of your personal data where it is processed
+          for direct marketing purposes.</p>
+        <p class="govuk-body">You have the right to withdraw consent to the processing of your personal data at any
+          time.</p>
 
-      <h3 class="govuk-heading-s">International transfers</h3>
-      <p class="govuk-body">As your personal data is stored on our IT infrastructure, and shared with our data processors, it may be transferred and stored securely outside the UK. Where that is the case it will be subject to equivalent legal protection through an adequacy decision or reliance on Standard Contractual Clauses.</p>
+        <h3 class="govuk-heading-s">International transfers</h3>
+        <p class="govuk-body">As your personal data is stored on our IT infrastructure, and shared with our data
+          processors, it may be transferred and stored securely outside the UK. Where that is the case it will be
+          subject to equivalent legal protection through an adequacy decision or reliance on Standard Contractual
+          Clauses.</p>
 
-      <h3 class="govuk-heading-s">Complaints</h3>
-      <p class="govuk-body">If you consider that your personal data has been misused or mishandled, you may make a complaint to the Information Commissioner, who is an independent regulator. The Information Commissioner can be contacted at: Information Commissioner's Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF, or 0303 123 1113, or <a href="mailto:icocasework@ico.org.uk" class="govuk-link">icocasework@ico.org.uk</a>. Any complaint to the Information Commissioner is without prejudice to your right to seek redress through the courts.</p>
+        <h3 class="govuk-heading-s">Complaints</h3>
+        <p class="govuk-body">If you consider that your personal data has been misused or mishandled, you may make a
+          complaint to the Information Commissioner, who is an independent regulator. The Information Commissioner can
+          be contacted at: Information Commissioner's Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF,
+          or 0303 123 1113, or <a href="mailto:icocasework@ico.org.uk" class="govuk-link">icocasework@ico.org.uk</a>.
+          Any complaint to the Information Commissioner is without prejudice to your right to seek redress through the
+          courts.</p>
 
-      <h3 class="govuk-heading-s">Contact details</h3>
-      <p class="govuk-body">The data controller for your personal data is the {{ departmental_owner }}. The contact details for the data controller are: {{ department_address | safe }}.</p>
-      <p class="govuk-body">The contact details for the data controller's Data Protection Officer are: <a href="mailto:redbox@businessandtrade.gov.uk" class="govuk-link">redbox@businessandtrade.gov.uk</a>.</p>
-      <p class="govuk-body">The Data Protection Officer provides independent advice and monitoring of {{ departmental_owner }}'s use of personal information.</p>
+        <h3 class="govuk-heading-s">Contact details</h3>
+        <p class="govuk-body">The data controller for your personal data is the {{ departmental_owner }}. The contact
+          details for the data controller are: {{ department_address | safe }}.</p>
+        <p class="govuk-body">The contact details for the data controller's Data Protection Officer are: <a
+            href="mailto:redbox@businessandtrade.gov.uk" class="govuk-link">redbox@businessandtrade.gov.uk</a>.</p>
+        <p class="govuk-body">The Data Protection Officer provides independent advice and monitoring of {{
+          departmental_owner }}'s use of personal information.</p>
 
-      <h2 class="govuk-heading-m">Changes to this notice</h2>
-      <p class="govuk-body">We may change this privacy notice. When we make changes to this notice, the "last updated" date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and your data immediately. If these changes affect how your personal data is processed, {{ departmental_owner }} will take reasonable steps to make sure you know.</p>
-      <p class="govuk-body">Last updated: {{ last_updated }}</p>
+        <h2 class="govuk-heading-m">Changes to this notice</h2>
+        <p class="govuk-body">We may change this privacy notice. When we make changes to this notice, the "last updated"
+          date at the bottom of this page will also change. Any changes to this privacy notice will apply to you and
+          your data immediately. If these changes affect how your personal data is processed, {{ departmental_owner }}
+          will take reasonable steps to make sure you know.</p>
+        <p class="govuk-body">Last updated: {{ last_updated }}</p>
 
+      </div>
     </div>
   </div>
 </div>
 
 {% endblock %}
+
+</div>

--- a/django_app/redbox_app/templates/support.html
+++ b/django_app/redbox_app/templates/support.html
@@ -4,57 +4,59 @@
 
 {% block content %}
 
-<div class="govuk-width-container iai-grid">
-  <div class="iai-grid__start-3-span-8">
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">Support</h1>
+      <h1 class="govuk-heading-l">Support</h1>
 
-    {#
-    <h2 class="govuk-heading-m">User guide</h2>
-    <iframe src="https://player.vimeo.com/video/860937749?h=05caad19d6" class="video--iframe" frameborder="0" allowfullscreen title="<SYSTEM_NAME> support video"></iframe>
-    <p class="govuk-body">You can download the <a target="_blank" rel="noopener noreferrer" href="{{static('<USER_GUIDE_LOCATION>.pdf')}}" class="govuk-link"><SYSTEM_NAME> User Guide (PDF, 1.1MB)</a>, a step-by-step guide to signing in and using your <SYSTEM_NAME> account.</p>
+      {#
+      <h2 class="govuk-heading-m">User guide</h2>
+      <iframe src="https://player.vimeo.com/video/860937749?h=05caad19d6" class="video--iframe" frameborder="0" allowfullscreen title="<SYSTEM_NAME> support video"></iframe>
+      <p class="govuk-body">You can download the <a target="_blank" rel="noopener noreferrer" href="{{static('<USER_GUIDE_LOCATION>.pdf')}}" class="govuk-link"><SYSTEM_NAME> User Guide (PDF, 1.1MB)</a>, a step-by-step guide to signing in and using your <SYSTEM_NAME> account.</p>
 
-    <h2 class="govuk-heading-m">Accessing Redbox</h2>
-    <p class="govuk-body">You can access your Redbox account by visiting <a href="<SYSTEM_URL>" class="govuk-link"><SYSTEM_URL></a>. You'll need to type your work email address in the box provided and select the submit button.</p>
-    #}
+      <h2 class="govuk-heading-m">Accessing Redbox</h2>
+      <p class="govuk-body">You can access your Redbox account by visiting <a href="<SYSTEM_URL>" class="govuk-link"><SYSTEM_URL></a>. You'll need to type your work email address in the box provided and select the submit button.</p>
+      #}
 
-    <h2 class="govuk-heading-m">Signing in</h2>
-    <p class="govuk-body">If you're having trouble signing in to the Redbox platform, check that:</p>
+      <h2 class="govuk-heading-m">Signing in</h2>
+      <p class="govuk-body">If you're having trouble signing in to the Redbox platform, check that:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>you're using your work email address</li>
-      <li>you've typed your work email address correctly</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you're using your work email address</li>
+        <li>you've typed your work email address correctly</li>
+      </ul>
 
-    <p class="govuk-body">You should check your junk or spam folder for an email from Redbox.</p>
+      <p class="govuk-body">You should check your junk or spam folder for an email from Redbox.</p>
 
-    <p class="govuk-body">If you're still having trouble then you can contact us using the details at the bottom of this page.</p>
+      <p class="govuk-body">If you're still having trouble then you can contact us using the details at the bottom of this page.</p>
 
-    {#
-    <h2 class="govuk-heading-m">Email address not allowed</h2>
-    <p class="govuk-body">If you see the error message: "Currently you need a Civil Service email address to register", contact us using the details at the bottom of this page and include the name of your organisation.</p>
+      {#
+      <h2 class="govuk-heading-m">Email address not allowed</h2>
+      <p class="govuk-body">If you see the error message: "Currently you need a Civil Service email address to register", contact us using the details at the bottom of this page and include the name of your organisation.</p>
 
-    <h2 class="govuk-heading-m">Can’t find my government department</h2>
-    <p class="govuk-body">If you can’t find the department you belong to when you are signing in for the first time then go to the bottom of the dropdown list and if you are:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>a civil servant then choose: Other - Civil Servant</li>
-      <li>a public servant then choose: Other - Public Servant</li>
-      <li>not sure then choose: Other</li>
-    </ul>
+      <h2 class="govuk-heading-m">Can’t find my government department</h2>
+      <p class="govuk-body">If you can’t find the department you belong to when you are signing in for the first time then go to the bottom of the dropdown list and if you are:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>a civil servant then choose: Other - Civil Servant</li>
+        <li>a public servant then choose: Other - Public Servant</li>
+        <li>not sure then choose: Other</li>
+      </ul>
 
-    <h2 class="govuk-heading-m">Can’t find my grade</h2>
-    <p class="govuk-body">If the grades shown do not fit with your role then either choose the one that is equivalent to your role or select ‘Other’.</p>
-    #}
+      <h2 class="govuk-heading-m">Can’t find my grade</h2>
+      <p class="govuk-body">If the grades shown do not fit with your role then either choose the one that is equivalent to your role or select ‘Other’.</p>
+      #}
 
-    <h2 class="govuk-heading-m">Bug or site vulnerability</h2>
-    <p class="govuk-body">If you've found an issue or a vulnerability, contact us using the details at the bottom of this page including as much information as possible.</p>
+      <h2 class="govuk-heading-m">Bug or site vulnerability</h2>
+      <p class="govuk-body">If you've found an issue or a vulnerability, contact us using the details at the bottom of this page including as much information as possible.</p>
 
-    <h2 class="govuk-heading-m">Website not loading</h2>
-    <p class="govuk-body">If the website is not loading, please close the browser tab and try again later.</p>
+      <h2 class="govuk-heading-m">Website not loading</h2>
+      <p class="govuk-body">If the website is not loading, please close the browser tab and try again later.</p>
 
-    <h2 class="govuk-heading-m">Contact us</h2>
-    <p class="govuk-body">If you've read the information above but haven't been able to find a solution to your problem, please email us at <a href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a> including as much information as possible, including the current version number, which is {{ version }}.</p>
+      <h2 class="govuk-heading-m">Contact us</h2>
+      <p class="govuk-body">If you've read the information above but haven't been able to find a solution to your problem, please email us at <a href="mailto:{{contact_email}}" class="govuk-link">{{contact_email}}</a> including as much information as possible, including the current version number, which is {{ version }}.</p>
 
+    </div>
   </div>
 </div>
 

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -73,7 +73,7 @@ other_urlpatterns = [
     path("update-demographics", views.UpdateDemographicsView.as_view(), name="update-demographics"),
     path(".well-known/security.txt", views.SecurityTxtRedirectView.as_view(), name="security.txt"),
     path("security", views.SecurityTxtRedirectView.as_view(), name="security"),
-    path("sitemap", views.misc_views.sitemap_view, name="sitemap"),
+    path("sitemap/", views.misc_views.sitemap_view, name="sitemap"),
     path("faq/", views.faq_view, name="faq"),
 ]
 

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -55,7 +55,7 @@ class BasePage(ABC):
 
     def check_a11y(self, exclude: Sequence[str] | None = None):
         context = {"exclude": exclude} if exclude else None
-        expect(self.page.locator(".iai-footer__container")).to_be_visible()  # Ensure page is fully loaded
+        expect(self.page.locator(".govuk-footer")).to_be_visible()  # Ensure page is fully loaded
         results = self.axe.run(self.page, context=context, options=self.AXE_OPTIONS)
         if results.violations_count:
             error_message = f"accessibility violations from page {self}: {results.generate_report()} "


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

The footer of Redbox needs to match the new GDS styling of the app.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Replaces the I.AI footer with a GDS footer.
- Improves the formatting of the ancillary pages - wrapping them in proper `<main>` and gov-uk `<div>` tags


*The size of this PR is misleading as most 'changed' lines have just been indented a bit more

![image](https://github.com/user-attachments/assets/0abb081f-90e0-48fb-95c3-589e44aff20d)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
