### PR TITLE
fix: prevent redundant file upload to main s3 bucket

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -81,7 +81,7 @@ INSTALLED_APPS = [
 if USE_CLAM_AV:
     FILE_UPLOAD_HANDLERS = (
         "django_chunk_upload_handlers.clam_av.ClamAVFileUploadHandler",
-        "django_chunk_upload_handlers.s3.S3FileUploadHandler",
+        "redbox_app.storage.CustomS3FileUploadHandler",
     )
 
 if LOGIN_METHOD == "sso":

--- a/django_app/redbox_app/storage.py
+++ b/django_app/redbox_app/storage.py
@@ -1,0 +1,77 @@
+from django_chunk_upload_handlers.s3 import S3FileUploadHandler
+import logging
+from django.core.files.uploadedfile import UploadedFile
+import boto3
+import logging
+import uuid
+import os
+from django.core.files.base import ContentFile
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+class CustomS3FileUploadHandler(S3FileUploadHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.s3_client = boto3.client("s3")
+        self.bucket = settings.BUCKET_NAME
+        self.temp_key = None
+        self.original_file_name = None
+
+    def new_file(self, field_name, file_name, content_type, content_length, charset=None, content_type_extra=None):
+        self.original_file_name = f"{self.request.user.email}/{file_name}"
+        self.temp_key = f"tmp/chunk_upload_{uuid.uuid4()}"
+        logger.info("Starting upload for file: %s, temp_key: %s", self.original_file_name, self.temp_key)
+        return super().new_file(field_name, file_name, content_type, content_length, charset, content_type_extra)
+
+    def get_s3_key(self, upload_id, chunk_number):
+        logger.info("Getting S3 key for file: %s", self.original_file_name)
+        return self.original_file_name
+
+    def receive_data_chunk(self, raw_data, start):
+        logger.info("Uploading chunk to temporary key: %s", self.temp_key)
+        
+        temp_file_path = f"/tmp/chunk_{uuid.uuid4()}"
+        with open(temp_file_path, "wb") as f:
+            f.write(raw_data)
+        
+        self.s3_client.upload_file(
+            temp_file_path,
+            self.bucket,
+            self.temp_key,
+            ExtraArgs={"ContentType": self.content_type},
+        )
+        os.remove(temp_file_path)
+        
+        return raw_data
+
+    def file_complete(self, file_size):
+        logger.info("File upload complete, size: %s, saving to: %s", file_size, self.original_file_name)
+        
+        logger.info("Copying from %s to %s", self.temp_key, self.original_file_name)
+        self.s3_client.copy_object(
+            Bucket=self.bucket,
+            CopySource=f"{self.bucket}/{self.temp_key}",
+            Key=self.original_file_name,
+            ContentType=self.content_type,
+        )
+        
+        logger.info("Deleting temporary file: %s", self.temp_key)
+        self.s3_client.delete_object(Bucket=self.bucket, Key=self.temp_key)
+        
+        s3_response = self.s3_client.get_object(Bucket=self.bucket, Key=self.original_file_name)
+        file_content = s3_response["Body"].read()
+        
+        uploaded_file = UploadedFile(
+            file=ContentFile(file_content, name=self.original_file_name),
+            name=self.original_file_name,
+            content_type=self.content_type,
+            size=file_size,
+        )
+        
+        return uploaded_file
+
+    def upload_complete(self):
+        logger.info("Upload completed for file: %s", self.original_file_name)
+        return super().upload_complete()
+    


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
At the moment our S3Uploader is sending chunks to the main bucket and not deleting them, instead of just to the user's folder

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
This extends the parent S3FileUploadHandler and creates a custom one, which ensures the document is only uploaded once, to the user's folder.

## Are there any specific instructions on how to test this change?

Not locally as S3 is not used but I have tested this in UAT and dev with many documents and it successfully reduces upload time.

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
