### PR TITLE
improve planner prompt

### DIFF
--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -261,8 +261,8 @@ Operational Framework
 - Determine if the request requires multi-agent coordination or can be handled directly
 
 2. Planning Phase
-
-- Define the necessary sub-tasks required to achieve the goal
+- Read carefully the responsibility of each agent.
+- Based on the agents responsibility, define the necessary sub-tasks required to achieve the goal. Each sub-task should be aligned with the agent responsibility.
 - Identify dependencies between sub-tasks
 - Select the most appropriate agent for each sub-task from the available agent pool
 - Create a structured execution plan with clear success criteria for each step
@@ -272,16 +272,16 @@ When a user query involves finding information within known documents, ALWAYS ro
 2. The query requires synthesis of information not contained in available documents
 3. The query specifically requests external information sources
 
-If a user asks to summarise a document, ALWAYS call Summarisation_Agent.
+If a user asks to summarise a document, ALWAYS call Summarisation_Agent and do not call other agents.
 
 
-## Available Agents
+## Available agents and their responsibilities
 
 When creating your execution plan, you have access to the following specialised agents:
 
-1. **Document_Agent**: Retrieves information from user's uploaded documents.
-2. **External_Data_Agent**: Retrieves information from external data sources including Wikipedia, Gov.UK, and legislation.gov.uk.
-3. **Summarisation_Agent**: Summarises entire user's uploaded documents. It does not summarise outputs from other agents.
+1. **Document_Agent**: solely responsible for retrieving information from user's uploaded documents.
+2. **External_Data_Agent**: solely responsible for retrieving information outside of user's uploaded documents, specifically from external data sources including Wikipedia, Gov.UK, and legislation.gov.uk.
+3. **Summarisation_Agent**: solely responsible for summarising entire user's uploaded documents. It does not summarise outputs from other agents.
 
 ## Output Format
 


### PR DESCRIPTION
- when user ask for summarisation, sometimes the planner ask document agent to summarise, in addition asking summarisation agent to generate another summary. This leads to duplicate summaries.
Changes in prompt aim to prevent this issue
How to test:
- run docker compose
- from UI, select a document and test summarisation via newroute: for example @newroute summarise this document
<img width="896" alt="Screenshot 2025-05-06 at 13 57 35" src="https://github.com/user-attachments/assets/0c37560a-738a-4efb-9d6e-32818086dbcc" />
