### PR TITLE
Fix @route keyword not detect

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -15,10 +15,25 @@ from django.forms.models import model_to_dict
 from django.utils import timezone
 from langchain_core.documents import Document
 from openai import RateLimitError
+from uwotm8 import convert_american_to_british_spelling
+from websockets import ConnectionClosedError, WebSocketClientProtocol
+
+from redbox import Redbox
+from redbox.models.chain import (
+    AISettings,
+    ChainChatMessage,
+    RedboxQuery,
+    RedboxState,
+    RequestMetadata,
+    Source,
+    metadata_reducer,
+)
+from redbox.models.chain import Citation as AICitation
+from redbox.models.graph import RedboxActivityEvent
+from redbox.models.settings import get_settings
 from redbox_app.redbox_core import error_messages
-from redbox_app.redbox_core.models import ActivityEvent
-from redbox_app.redbox_core.models import AISettings as AISettingsModel
 from redbox_app.redbox_core.models import (
+    ActivityEvent,
     Chat,
     ChatLLMBackend,
     ChatMessage,
@@ -27,15 +42,7 @@ from redbox_app.redbox_core.models import (
     File,
     MonitorSearchRoute,
 )
-from uwotm8 import convert_american_to_british_spelling
-from websockets import ConnectionClosedError, WebSocketClientProtocol
-
-from redbox import Redbox
-from redbox.models.chain import AISettings, ChainChatMessage
-from redbox.models.chain import Citation as AICitation
-from redbox.models.chain import RedboxQuery, RedboxState, RequestMetadata, Source, metadata_reducer
-from redbox.models.graph import RedboxActivityEvent
-from redbox.models.settings import get_settings
+from redbox_app.redbox_core.models import AISettings as AISettingsModel
 
 User = get_user_model()
 OptFileSeq = Sequence[File] | None

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -18,17 +18,22 @@ from openai import RateLimitError
 from redbox_app.redbox_core import error_messages
 from redbox_app.redbox_core.models import ActivityEvent
 from redbox_app.redbox_core.models import AISettings as AISettingsModel
-from redbox_app.redbox_core.models import (Chat, ChatLLMBackend, ChatMessage,
-                                           ChatMessageTokenUse, Citation, File,
-                                           MonitorSearchRoute)
+from redbox_app.redbox_core.models import (
+    Chat,
+    ChatLLMBackend,
+    ChatMessage,
+    ChatMessageTokenUse,
+    Citation,
+    File,
+    MonitorSearchRoute,
+)
 from uwotm8 import convert_american_to_british_spelling
 from websockets import ConnectionClosedError, WebSocketClientProtocol
 
 from redbox import Redbox
 from redbox.models.chain import AISettings, ChainChatMessage
 from redbox.models.chain import Citation as AICitation
-from redbox.models.chain import (RedboxQuery, RedboxState, RequestMetadata,
-                                 Source, metadata_reducer)
+from redbox.models.chain import RedboxQuery, RedboxState, RequestMetadata, Source, metadata_reducer
 from redbox.models.graph import RedboxActivityEvent
 from redbox.models.settings import get_settings
 
@@ -110,7 +115,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
         # save user message
         permitted_files = File.objects.filter(user=user, status=File.Status.complete)
         selected_files = permitted_files.filter(id__in=selected_file_uuids)
-        self.chat_message = await self.save_user_message(session, user_message_text, selected_files=selected_files, activities=activities)
+        self.chat_message = await self.save_user_message(
+            session, user_message_text, selected_files=selected_files, activities=activities
+        )
 
         await self.llm_conversation(selected_files, session, user, user_message_text, permitted_files)
 

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -15,34 +15,22 @@ from django.forms.models import model_to_dict
 from django.utils import timezone
 from langchain_core.documents import Document
 from openai import RateLimitError
+from redbox_app.redbox_core import error_messages
+from redbox_app.redbox_core.models import ActivityEvent
+from redbox_app.redbox_core.models import AISettings as AISettingsModel
+from redbox_app.redbox_core.models import (Chat, ChatLLMBackend, ChatMessage,
+                                           ChatMessageTokenUse, Citation, File,
+                                           MonitorSearchRoute)
 from uwotm8 import convert_american_to_british_spelling
 from websockets import ConnectionClosedError, WebSocketClientProtocol
 
 from redbox import Redbox
-from redbox.models.chain import (
-    AISettings,
-    ChainChatMessage,
-    RedboxQuery,
-    RedboxState,
-    RequestMetadata,
-    Source,
-    metadata_reducer,
-)
+from redbox.models.chain import AISettings, ChainChatMessage
 from redbox.models.chain import Citation as AICitation
+from redbox.models.chain import (RedboxQuery, RedboxState, RequestMetadata,
+                                 Source, metadata_reducer)
 from redbox.models.graph import RedboxActivityEvent
 from redbox.models.settings import get_settings
-from redbox_app.redbox_core import error_messages
-from redbox_app.redbox_core.models import (
-    ActivityEvent,
-    Chat,
-    ChatLLMBackend,
-    ChatMessage,
-    ChatMessageTokenUse,
-    Citation,
-    File,
-    MonitorSearchRoute,
-)
-from redbox_app.redbox_core.models import AISettings as AISettingsModel
 
 User = get_user_model()
 OptFileSeq = Sequence[File] | None
@@ -122,9 +110,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         # save user message
         permitted_files = File.objects.filter(user=user, status=File.Status.complete)
         selected_files = permitted_files.filter(id__in=selected_file_uuids)
-        await self.save_user_message(session, user_message_text, selected_files=selected_files, activities=activities)
-
-        self.chat_message = await self.create_ai_message(session)
+        self.chat_message = await self.save_user_message(session, user_message_text, selected_files=selected_files, activities=activities)
 
         await self.llm_conversation(selected_files, session, user, user_message_text, permitted_files)
 
@@ -142,7 +128,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
         session_messages = ChatMessage.objects.filter(chat=session).order_by("created_at")
         message_history: Sequence[Mapping[str, str]] = [message async for message in session_messages]
-
+        logger.debug("message history %s from session", message_history)
+        logger.debug("message history size: %s from session", len(message_history))
         ai_settings = await self.get_ai_settings(session)
         state = RedboxState(
             request=RedboxQuery(
@@ -221,17 +208,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
             ActivityEvent.objects.create(chat_message=chat_message, message=message)
 
         chat_message.log()
-        return chat_message
-
-    @database_sync_to_async
-    def create_ai_message(self, session: Chat) -> ChatMessage:
-        chat_message = ChatMessage(
-            chat=session,
-            text="",
-            role=ChatMessage.Role.ai,
-            route=self.route,
-        )
-        chat_message.save()
         return chat_message
 
     @database_sync_to_async

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -21,13 +21,7 @@ from redbox.models.graph import FINAL_RESPONSE_TAG, ROUTE_NAME_TAG, SOURCE_DOCUM
 from redbox.models.prompts import CHAT_MAP_QUESTION_PROMPT
 from redbox_app.redbox_core import error_messages
 from redbox_app.redbox_core.consumers import ChatConsumer
-from redbox_app.redbox_core.models import (
-    ActivityEvent,
-    Chat,
-    ChatMessage,
-    ChatMessageTokenUse,
-    File,
-)
+from redbox_app.redbox_core.models import ActivityEvent, Chat, ChatMessage, ChatMessageTokenUse, File
 
 User = get_user_model()
 
@@ -518,7 +512,7 @@ async def test_chat_consumer_redbox_state(
 
         # Then
         expected_request = RedboxQuery(
-            question="",
+            question="Third question, with selected files?",
             s3_keys=selected_file_keys,
             user_uuid=alice.id,
             chat_history=[
@@ -526,7 +520,6 @@ async def test_chat_consumer_redbox_state(
                 {"role": "ai", "text": "An answer."},
                 {"role": "user", "text": "A second question?"},
                 {"role": "ai", "text": "A second answer."},
-                {"role": "user", "text": "Third question, with selected files?"},  # Include latest user message
             ],
             ai_settings=ai_settings,
             permitted_s3_keys=permitted_file_keys,

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -51,7 +51,7 @@ from redbox.graph.nodes.tools import get_log_formatter_for_retrieval_tool
 from redbox.models.chain import AgentDecision, AISettings, PromptSet, RedboxState
 from redbox.models.chat import ChatRoute, ErrorRoute
 from redbox.models.graph import ROUTABLE_KEYWORDS, RedboxActivityEvent
-from redbox.models.prompts import INTERNAL_RETRIEVAL_AGENT_PROMPT, EXTERNAL_RETRIEVAL_AGENT_PROMPT
+from redbox.models.prompts import EXTERNAL_RETRIEVAL_AGENT_PROMPT, INTERNAL_RETRIEVAL_AGENT_PROMPT
 from redbox.transform import structure_documents_by_file_name, structure_documents_by_group_and_indices
 
 
@@ -823,6 +823,7 @@ def build_new_graph(
 ) -> CompiledGraph:
     agents_max_tokens = AISettings().agents_max_tokens
     builder = StateGraph(RedboxState)
+    builder.add_node("remove_keyword", strip_route)
     builder.add_node("planner", create_planner())
     builder.add_node(
         "Internal_Retrieval_Agent",
@@ -865,7 +866,8 @@ def build_new_graph(
         retry=RetryPolicy(max_attempts=3),
     )
 
-    builder.add_edge(START, "planner")
+    builder.add_edge(START, "remove_keyword")
+    builder.add_edge("planner", "remove_keyword")
     builder.add_conditional_edges("planner", sending_task_to_agent)
     builder.add_edge("Internal_Retrieval_Agent", "clear_tasks")
     builder.add_edge("External_Retrieval_Agent", "clear_tasks")

--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -867,7 +867,7 @@ def build_new_graph(
     )
 
     builder.add_edge(START, "remove_keyword")
-    builder.add_edge("planner", "remove_keyword")
+    builder.add_edge("remove_keyword", "planner")
     builder.add_conditional_edges("planner", sending_task_to_agent)
     builder.add_edge("Internal_Retrieval_Agent", "clear_tasks")
     builder.add_edge("External_Retrieval_Agent", "clear_tasks")


### PR DESCRIPTION
## Context

Correct graph is not invoked when using @route e.g. @search, @gadget, etc. If use @route it goes to chat if no document is selected, otherwise self-route graph is invoked.
Example: prompt: @gadget how do I renew passport?
Expected results: Response generated using @gadget route
Results: Response generated using @chat

See https://uktrade.atlassian.net/browse/REDBOX-844?atlOrigin=eyJpIjoiZjk1NTkxNjA4OTliNDNlZmIyZDg5Zjc0NzBhMWY0ZjIiLCJwIjoiaiJ9
## What

- use -2 as index.
- fix consumers.py test. 
- add a node to remove keyword in newroute

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

Tests
1. Don't select a document, use @newroute how to renew passport. Follow up question: @newroute how much is it?
2. Don't select a document, use @search how to renew passport. Check the response is from @search route



## Relevant links
