### PR TITLE
modify search prompt to always use doc info

### DIFF
--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -17,7 +17,7 @@ CITATION_PROMPT = """Use citations to back up your answer when available. Return
 Example response:
 - If citations are available: {{"answer": your_answer, "citations": [list_of_citations]}}.
 - If no citations are available or needed, return an empty array for citations like this: {{"answer": your_answer, "citations": []}}.
-
+Do not provide citation from your own knowledge.
 Assistant:<sonnet>"""
 
 CHAT_WITH_DOCS_REDUCE_SYSTEM_PROMPT = (
@@ -31,7 +31,12 @@ CHAT_WITH_DOCS_REDUCE_SYSTEM_PROMPT = (
 )
 
 RETRIEVAL_SYSTEM_PROMPT = """
-   Answer my question using only the documents I provide. <My_Documents>{formatted_documents}</My_Documents>
+   Answer the following question based ONLY on the information contained in the provided documents.
+   <Provided_Documents>{formatted_documents}</Provided_Documents>.
+
+   If the information needed to answer the question is not present in the sources, state "The provided sources do not contain sufficient information to answer this question.
+
+   Do not use any prior knowledge or information not contained in the sources.
    """
 
 
@@ -276,7 +281,7 @@ When creating your execution plan, you have access to the following specialised 
 2. **External_Retrieval_Agent**: solely responsible for retrieving information outside of user's uploaded documents, specifically from external data sources:
       - Wikipedia
       - gov.uk
-      - legislation.gov.uk 
+      - legislation.gov.uk
 3. **Summarisation_Agent**: solely responsible for summarising entire user's uploaded documents. It does not summarise outputs from other agents.
 
 ## helpful instructions for calling agent


### PR DESCRIPTION
## Context

@search citations comes from its own knowledge.

## What

- update prompt to ensure citations are from provided documents only.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

Testing @search to check that answers are correct and citations are from documents. 
## Relevant links
