### PR TITLE
fix: prevent outline on message send

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -500,6 +500,12 @@ chat-message {
   padding: 0.5rem 1rem;
 }
 
+.govuk-inset-text:focus,
+.govuk-inset-text:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 /* New Chat Options */
 .chat-options {
   scroll-margin-bottom: 16rem;


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
When a user presses send, there is an outline around the box. We dont want this outline

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
CSS to get rid of the outline when a user sends a message without touching any JS which would impact the streaming functionality

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Can you see the outline after you recompile the CSS and send a message?

## Relevant links
https://uktrade.atlassian.net/jira/software/projects/REDBOX/boards/558?selectedIssue=REDBOX-856