### PR TITLE
Fixing issue in pre-build script

### DIFF
--- a/.copilot/phases/pre_build.sh
+++ b/.copilot/phases/pre_build.sh
@@ -7,4 +7,4 @@ cp -r "redbox-core" "django_app"
 cp "Procfile" "django_app/Procfile"
 
 cd django_app
-sed -i 's|../redbox-core|redbox-core' pyproject.toml
+sed -i 's|../redbox-core|redbox-core|' pyproject.toml


### PR DESCRIPTION
## Context

Bugfix including trailing "|" in pre-build script.
