### PR TITLE
Make Citation Ordering Match Sources Ordering

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -871,7 +871,7 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
             {
                 (get_display(citation), citation.uri, citation.id, citation.text_in_answer, citation.citation_name)
                 for citation in self.citation_set.all()
-            }
+            }, key= lambda x:x[-1]
         )
 
 

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -110,7 +110,7 @@ class Source(BaseModel):
     )
     page_numbers: list[int] = Field(description="Page Number in document the highlighted text is on", default=[1])
     ref_id: str = Field(
-        description="The Reference ID in the format 'ref_1', 'ref_2', etc.",
+        description="The Reference ID in the format 'ref_N' where N is a strictly incrementing number starting from 1",
         default="",
     )
 


### PR DESCRIPTION
## Context

We want citation ordering to match the sources ordering reference ordering to match
## What has changed

Sources section is now ordered by `citation_name` which should then match order in which sources are displayed

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

View previous chats (post creation of `citation_name`) and new chats. Confirm when viewed that citation ordering matches
