### PR TITLE
Adding unique criteria so that source is displayed just once

### DIFF
--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -42,14 +42,10 @@
   <h3 class="iai-chat-bubble__sources-heading govuk-heading-s govuk-!-margin-bottom-1">Sources</h3>
   <div class="iai-display-flex-from-desktop">
     <ol class="rb-footnote-list govuk-!-margin-bottom-0">
-      {% set seen_docs = [] %}
       {% for display, href, cit_id, text_in_answer, citation_name in message.unique_citation_uris() %}
-        {% if display not in seen_docs %}
         <li class="govuk-!-margin-bottom-0">
           <a class="iai-chat-bubbles__sources-link govuk-link" id="footnote-{{ message.id }}-{{ loop.index }}" href="{{ href }}" target="_blank">{{ display }}</a>
         </li>
-        {% set _ = seen_docs.append(display) %}
-        {% endif %}
       {% endfor %}
     </ol>
   </div>

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -42,18 +42,23 @@
   <h3 class="iai-chat-bubble__sources-heading govuk-heading-s govuk-!-margin-bottom-1">Sources</h3>
   <div class="iai-display-flex-from-desktop">
     <ol class="rb-footnote-list govuk-!-margin-bottom-0">
+      {% set seen_docs = [] %}
       {% for display, href, cit_id, text_in_answer, citation_name in message.unique_citation_uris() %}
+        {% if display not in seen_docs %}
         <li class="govuk-!-margin-bottom-0">
           <a class="iai-chat-bubbles__sources-link govuk-link" id="footnote-{{ message.id }}-{{ loop.index }}" href="{{ href }}" target="_blank">{{ display }}</a>
         </li>
+        {% set _ = seen_docs.append(display) %}
+        {% endif %}
       {% endfor %}
     </ol>
   </div>
   <br />
   {% endif %}
 </div>
-
+{% set seen_files = [] %}
 {% for file in message.selected_files.all() %}
+  {% if file not in seen_files %}
   <p class="govuk-body govuk-!-text-align-right govuk-!-font-size-16">
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <g clip-path="url(#clip0_771_609)">
@@ -70,6 +75,8 @@
       </defs>
       </svg>
     {{ file }}</p>
+    {% set _ = seen_files.append(file) %}
+    {% endif %}
 {% endfor %}
 
 {% if message.route %}


### PR DESCRIPTION
## Context
We want sources to appear only once in the sources section of a chat. 

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
We are adding a check that returns the name in the html if it hasn't already been displayed.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Confirm that new and previous chats that returned citations with one or more files included only list each file once with citation links being unaffected.

#### Expected Behaviour
**Before**
![image](https://github.com/user-attachments/assets/d4595e77-ce32-4cb3-8558-f6198d43dabf)
**After**
![image](https://github.com/user-attachments/assets/b5412ae0-f59c-42a9-85b8-8c31d546c538)


