### PR TITLE
Switching link to refer to citations page

### DIFF
--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -46,7 +46,7 @@
       {% for display, href, cit_id, text_in_answer, citation_name in message.unique_citation_uris() %}
         {% if display not in seen_docs %}
         <li class="govuk-!-margin-bottom-0">
-          <a class="iai-chat-bubbles__sources-link govuk-link" id="footnote-{{ message.id }}-{{ loop.index }}" href="{{ href }}" target="_blank">{{ display }}</a>
+          <a class="iai-chat-bubbles__sources-link govuk-link" id="footnote-{{ message.id }}-{{ loop.index }}" href="/citations/{{message.id}}">{{ display }}</a>
         </li>
         {% set _ = seen_docs.append(display) %}
         {% endif %}


### PR DESCRIPTION
## Context

We want source files to link to the response info page and not to directly download the file

## What

Switching the href attribute to refer to the response info page.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Confirm that for previous and new chats, when a citations link is provided, it goes to the response info page
After clicking the link, the behaviour should be below
**Before**
![image](https://github.com/user-attachments/assets/ca099647-5091-4929-9e21-b3c6a13ab820)

**After**
![image](https://github.com/user-attachments/assets/b4925855-97d0-4caf-a7bc-2f4761588658)

