### PR TITLE
Update citation id sorting process

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -1,11 +1,11 @@
 import logging
 import os
+import re
 import textwrap
 import uuid
 from collections.abc import Collection, Sequence
 from datetime import UTC, date, datetime, timedelta
 from typing import override
-import re
 
 import jwt
 from django.conf import settings


### PR DESCRIPTION
## Context

The citation sorting process has a known limitation when it comes to sorting 10+ citations. Since citation_names are stored as string in the format `ref_N` where N is an incrementing number from 1, the sorting would sort a `ref_10` ahead of a `ref_2` or `ref_3`. 
## What

This PR updates to sorting key to use the numbers exclusively. In the event that there are no numbers or the citation_name is None, it reverts to the original default sorting method.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No
Testing is difficult as it's very unlikely to get 10+ citations to a response.
- Confirm that citation sorting for responses with <10 citations remains unaffected
- If you have a sample response with 10+ citations, confirm that the citation ordering is correct.
