### PR TITLE
Feature/fixing citation error

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -147,7 +147,7 @@ export class ChatMessage extends HTMLElement {
     function reloadAtCurrentPosition() {
       sessionStorage.setItem('scrollPosition', window.scrollY.toString());
       location.reload();
-    }    
+    }
     window.addEventListener("scroll", (evt) => {
       if (this.programmaticScroll) {
         this.programmaticScroll = false;
@@ -270,7 +270,7 @@ export class ChatMessage extends HTMLElement {
           actionsContainer.appendChild(copyText)
 
       }
-        this.#addFootnotes(this.streamedContent, response.data.message_id);
+        // this.#addFootnotes(this.streamedContent, response.data.message_id);
         const chatResponseEndEvent = new CustomEvent("chat-response-end", {
           detail: {
             title: response.data.title,

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -36,7 +36,7 @@ def replace_ref(message_text: str, ref_name: str, message_id: str, cit_id: str, 
 
 def remove_dangling_citation(message_text: str) -> str:
     pattern = r"[\[\(\{<]ref_\d+[\]\)\}>]"
-    return re.sub(pattern, "", message_text)
+    return re.sub(pattern, "", message_text, flagx=re.IGNORECASE)
 
 
 class ChatsView(View):

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -35,8 +35,8 @@ def replace_ref(message_text: str, ref_name: str, message_id: str, cit_id: str, 
 
 
 def remove_dangling_citation(message_text: str) -> str:
-    pattern = r"[\[\(\{<]ref_\d+[\]\)\}>]"
-    return re.sub(pattern, "", message_text, flagx=re.IGNORECASE)
+    pattern = r"[\[\(\{<]ref_\d+[\]\)\}>]|ref_\d+"
+    return re.sub(pattern, "", message_text, flags=re.IGNORECASE)
 
 
 class ChatsView(View):

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -13,11 +13,12 @@ CHAT_SYSTEM_PROMPT = "You are tasked with providing information objectively and 
 
 CHAT_WITH_DOCS_SYSTEM_PROMPT = "You are tasked with providing information objectively and responding helpfully to users using context from their provided documents"
 
-CITATION_PROMPT = """Use citations to back up your answer when available. Return response in the following format: {format_instructions}.
+CITATION_PROMPT = """Use citations to back up your answer when available. Return your response in the following format: {format_instructions}.
 Example response:
-- If citations are available: {{"answer": your_answer, "citations": [list_of_citations]}}.
+If citations are available: {{"answer": "your complete answer here including any 'ref_N' citation markers inline as required in plain text", "citations": [list_of_citations]}}.
 - Each citation must be shown in the answer using a unique identifier in the format "ref_N" where N is an incrementing number starting from 1.
-- If no citations are available or needed, return an empty array for citations like this: {{"answer": your_answer, "citations": []}}.
+
+If no citations are available or needed, return an empty array for citations like this: {{"answer": "your complete answer here with no citation markers", "citations": []}}.
 Do not provide citation from your own knowledge.
 Assistant:<haiku>"""
 


### PR DESCRIPTION
## Context

On a few occasions, the number of citations included in the text response does not match the number of sources displayed. 

## What has changed?
This PR looks to do the following:
- Strengthen the citation prompt to reduce the frequency of its occurrence.
- Make the citation name replacement method case insensitive to better handle cases with hallucinated citations
- Remove the front end citation process as a tidy up and to improve the speed of the response.
<!-- What is this PR doing? What is being accomplished by this change in the code? -->

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No
Please test extensively. Confirm that the number of citations match the number of sources displayed. Also confirm that there are no dangling citation references in the displayed response.

## Relevant links
