### PR TITLE
fix: chat box should stick to bottom

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -813,10 +813,10 @@ margin-bottom: 16px;
 }
 .chat-input__input-container {
   position: sticky;
-  background-color: white;
   top: 0;
   z-index: 100;
   bottom: 0;
+  padding-top: 340px;
 }
 
 .redbox-message-route {


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Kind of floats at the moment halfway up the page. Quick fix to stop this so its always at the bottom

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Makes it stick to bottom of page

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Does it stick to bottom when you change your zooms

## Relevant links
