### PR TITLE
feat: remove refs from citation text

### DIFF
--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 import humanize
 import jinja2
@@ -9,6 +8,7 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.timezone import template_localtime
 from markdown_it import MarkdownIt
+
 from redbox_app.redbox_core.views.chat_views import remove_dangling_citation
 
 # `js-default` setting required to sanitize inputs
@@ -66,6 +66,7 @@ def to_user_timezone(value):
     # Replace 'Europe/London' with the actual timezone string for the user
     user_tz = pytz.timezone("Europe/London")
     return value.astimezone(user_tz).strftime("%H:%M %d/%m/%Y")
+
 
 def environment(**options):
     extra_options = {}

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -9,6 +9,7 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.timezone import template_localtime
 from markdown_it import MarkdownIt
+from redbox_app.redbox_core.views.chat_views import remove_dangling_citation
 
 # `js-default` setting required to sanitize inputs
 # https://markdown-it-py.readthedocs.io/en/latest/security.html
@@ -66,11 +67,6 @@ def to_user_timezone(value):
     user_tz = pytz.timezone("Europe/London")
     return value.astimezone(user_tz).strftime("%H:%M %d/%m/%Y")
 
-
-def remove_refs(text):
-    return re.sub(r"\bref_\d+\b", "", text).strip()
-
-
 def environment(**options):
     extra_options = {}
 
@@ -86,7 +82,7 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanise_expiry": humanise_expiry,
-            "remove_refs": remove_refs,
+            "remove_refs": remove_dangling_citation,
             "template_localtime": template_localtime,
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,
@@ -98,7 +94,7 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanise_expiry": humanise_expiry,
-            "remove_refs": remove_refs,
+            "remove_refs": remove_dangling_citation,
             "template_localtime": template_localtime,
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -3,6 +3,7 @@ import datetime
 import humanize
 import jinja2
 import pytz
+import re
 from django.conf import settings
 from django.templatetags.static import static
 from django.urls import reverse
@@ -65,6 +66,9 @@ def to_user_timezone(value):
     user_tz = pytz.timezone("Europe/London")
     return value.astimezone(user_tz).strftime("%H:%M %d/%m/%Y")
 
+def remove_refs(text):
+    return re.sub(r'\bref_\d+\b', '', text).strip()
+
 
 def environment(**options):
     extra_options = {}
@@ -81,6 +85,7 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanise_expiry": humanise_expiry,
+            "remove_refs": remove_refs,
             "template_localtime": template_localtime,
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,
@@ -92,6 +97,7 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanise_expiry": humanise_expiry,
+            "remove_refs": remove_refs,
             "template_localtime": template_localtime,
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 import humanize
 import jinja2
@@ -8,8 +9,6 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.timezone import template_localtime
 from markdown_it import MarkdownIt
-
-from redbox_app.redbox_core.views.chat_views import remove_dangling_citation
 
 # `js-default` setting required to sanitize inputs
 # https://markdown-it-py.readthedocs.io/en/latest/security.html
@@ -68,6 +67,11 @@ def to_user_timezone(value):
     return value.astimezone(user_tz).strftime("%H:%M %d/%m/%Y")
 
 
+def remove_refs(text):
+    pattern = r"(\[\s*ref_\d+\s*\]|\bref_\d+\b)\s*-?"
+    return re.sub(pattern, "", text).strip()
+
+
 def environment(**options):
     extra_options = {}
 
@@ -83,7 +87,7 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanise_expiry": humanise_expiry,
-            "remove_refs": remove_dangling_citation,
+            "remove_refs": remove_refs,
             "template_localtime": template_localtime,
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,
@@ -95,7 +99,7 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanise_expiry": humanise_expiry,
-            "remove_refs": remove_dangling_citation,
+            "remove_refs": remove_refs,
             "template_localtime": template_localtime,
             "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT.value,

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -1,9 +1,9 @@
 import datetime
+import re
 
 import humanize
 import jinja2
 import pytz
-import re
 from django.conf import settings
 from django.templatetags.static import static
 from django.urls import reverse
@@ -66,8 +66,9 @@ def to_user_timezone(value):
     user_tz = pytz.timezone("Europe/London")
     return value.astimezone(user_tz).strftime("%H:%M %d/%m/%Y")
 
+
 def remove_refs(text):
-    return re.sub(r'\bref_\d+\b', '', text).strip()
+    return re.sub(r"\bref_\d+\b", "", text).strip()
 
 
 def environment(**options):

--- a/django_app/redbox_app/templates/citation_fragment.html
+++ b/django_app/redbox_app/templates/citation_fragment.html
@@ -6,7 +6,7 @@
       <div class="govuk-!-padding-left-1 govuk-!-padding-right-1">
         <h2 class="govuk-heading-m">Response</h2>
         <div class="iai-chat-bubble">
-          <markdown-converter class="chat-message__text">{{ message.text }}</markdown-converter>
+          <markdown-converter class="chat-message__text">{{ message.text|remove_refs }}</markdown-converter>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Redbox now directly writes the citation id directly into the text response. This means that when responses are copied, the text will include ref_1, ref_2

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Uses a filter to scrub the text of ref_x references

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
