### PR TITLE
Chore: Updated AWS login script

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,4 +1,7 @@
+# AWS profile configuration
 export AWS_PROFILE=redbox
 export AWS_REGION=eu-west-2
 export AWS_DEFAULT_REGION=eu-west-2
+
+# Only needed for certain MAC OS.
 export DOCKER_DEFAULT_PLATFORM=linux/amd64

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,4 @@
+export AWS_PROFILE=redbox
+export AWS_REGION=eu-west-2
+export AWS_DEFAULT_REGION=eu-west-2
+export DOCKER_DEFAULT_PLATFORM=linux/amd64

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 **/*.db
 .idea/
 redbox-core/models/
+.envrc
+
 # Credentials
 .aws/
 

--- a/aws-login.sh
+++ b/aws-login.sh
@@ -34,8 +34,12 @@ echo "Using AWS profile: $AWS_PROFILE"
 # 1. Ensure main .aws directory and credentials file exist
 mkdir -p "$AWS_DIR"
 if [ ! -f "$AWS_DIR/credentials" ]; then
-  echo "Creating missing $AWS_DIR/credentials"
-  touch "$AWS_DIR/credentials"
+  echo "'credentials' file missing. Copying from example..."
+  if [ -f "$AWS_DIR/credentials.example" ]; then
+    cp "$AWS_DIR/credentials.example" "$AWS_DIR/credentials"
+  else
+    echo "'credentials.example' not found in $AWS_DIR!"
+  fi
 fi
 
 # 2. Login with AWS SSO

--- a/aws-login.sh
+++ b/aws-login.sh
@@ -21,8 +21,14 @@ fi
 # Use AWS_PROFILE from env, or fallback to 'default'
 AWS_PROFILE="${AWS_PROFILE:-default}"
 AWS_DIR="$PROJECT_ROOT/.aws"
+
+DJANGO_APP_DIR="$PROJECT_ROOT/django_app"
+DJANGO_APP_AWS_DIR="$DJANGO_APP_DIR/.aws"
+
 NOTEBOOKS_DIR="$PROJECT_ROOT/notebooks"
 NOTEBOOKS_AWS_DIR="$NOTEBOOKS_DIR/.aws"
+
+
 echo "Using AWS profile: $AWS_PROFILE"
 
 # 1. Ensure main .aws directory and credentials file exist
@@ -45,7 +51,12 @@ done
 # 4. Clean up backup
 rm -f "$AWS_DIR/credentials.bak"
 
-# 5. Ensure notebooks/.aws exists and copy over credentials
+# 5. Ensure django_app/.aws exists and copy over credentials
+mkdir -p "$DJANGO_APP_AWS_DIR"
+cp "$AWS_DIR/credentials" "$DJANGO_APP_AWS_DIR/credentials"
+echo "AWS credentials updated and copied to notebooks/.aws"
+
+# 6. Ensure notebooks/.aws exists and copy over credentials
 mkdir -p "$NOTEBOOKS_AWS_DIR"
 cp "$AWS_DIR/credentials" "$NOTEBOOKS_AWS_DIR/credentials"
 echo "AWS credentials updated and copied to notebooks/.aws"

--- a/aws-login.sh
+++ b/aws-login.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e  # Exit on errors
+
+# Absolute path to project root (directory of this script)
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$PROJECT_ROOT"
+
+# If .envrc exists, run direnv allow and source for instant access
+if [ -f "$PROJECT_ROOT/.envrc" ]; then
+  if command -v direnv >/dev/null 2>&1; then
+    echo ".envrc found – running 'direnv allow'"
+    direnv allow
+    source "$PROJECT_ROOT/.envrc"
+  else
+    echo "direnv is not installed – skipping 'direnv allow'"
+  fi
+else
+  echo ":information_source:  No .envrc found – using default AWS profile fallback"
+fi
+
+# Use AWS_PROFILE from env, or fallback to 'default'
+AWS_PROFILE="${AWS_PROFILE:-default}"
+AWS_DIR="$PROJECT_ROOT/.aws"
+NOTEBOOKS_DIR="$PROJECT_ROOT/notebooks"
+NOTEBOOKS_AWS_DIR="$NOTEBOOKS_DIR/.aws"
+echo "Using AWS profile: $AWS_PROFILE"
+
+# 1. Ensure main .aws directory and credentials file exist
+mkdir -p "$AWS_DIR"
+if [ ! -f "$AWS_DIR/credentials" ]; then
+  echo "Creating missing $AWS_DIR/credentials"
+  touch "$AWS_DIR/credentials"
+fi
+
+# 2. Login with AWS SSO
+aws sso login --profile "$AWS_PROFILE"
+
+# 3. Update credentials in main .aws/credentials
+aws configure export-credentials --profile "$AWS_PROFILE" --format env-no-export | while IFS= read -r line; do
+  key=$(echo "$line" | cut -d'=' -f1)
+  value=$(echo "$line" | cut -d'=' -f2-)
+  sed -i.bak "s|^${key}=.*|${key}=${value}|" "$AWS_DIR/credentials" || echo "${key}=${value}" >> "$AWS_DIR/credentials"
+done
+
+# 4. Clean up backup
+rm -f "$AWS_DIR/credentials.bak"
+
+# 5. Ensure notebooks/.aws exists and copy over credentials
+mkdir -p "$NOTEBOOKS_AWS_DIR"
+cp "$AWS_DIR/credentials" "$NOTEBOOKS_AWS_DIR/credentials"
+echo "AWS credentials updated and copied to notebooks/.aws"


### PR DESCRIPTION
… if available to avoid potential profile conflicts

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Currently, logging into AWS uses the "default" profile, this change allows it to pull variables from an .envrc file using direnv for cleaner service/profile naming to avoid conflicts. This will also help with future dbt-platform-helper implementations.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Updated script to pull from .envrc if it exists and run `direnv allow` to export to the current environment
- Added functionality to copy credentials to notebooks and django_app directories to avoid having to use a single venv for all apps within the project.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

run `./aws-login` from the project root and ensure the .aws directories and credentials are created within the django_app/notebooks directories (assuming the root .aws/credentials.example directory and file already exists).

## Relevant links
