### PR TITLE
add role to prompt template

### DIFF
--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -77,8 +77,8 @@ def build_chat_prompt_from_messages_runnable(
                 [("system", system_prompt_message)]
                 + [(msg["role"], msg["text"]) for msg in truncated_history]
                 + [MessagesPlaceholder("messages")]
-                + [task_question_prompt]
-                + ([format_prompt] if len(format_instructions) > 0 else [])
+                + [("human", task_question_prompt)]
+                + ([("human", format_prompt)] if len(format_instructions) > 0 else [])
             ),
             partial_variables={"format_instructions": format_instructions},
         ).invoke(prompt_template_context)


### PR DESCRIPTION
## Context

There should be a role for each message in chat prompt template.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
