### PR TITLE
bugfix: Persistent side panel

### DIFF
--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -1,6 +1,6 @@
-main:has(.iai-chat-input),
+main,
 body {
-  min-height: 0;
+  min-height: 0 !important;
 }
 .rb-chat-history__title {
   position: relative;

--- a/django_app/frontend/src/chat-styles.scss
+++ b/django_app/frontend/src/chat-styles.scss
@@ -1,8 +1,7 @@
 main:has(.iai-chat-input),
-body:has(.iai-environment-warning) main:has(.iai-chat-input) {
+body {
   min-height: 0;
 }
-
 .rb-chat-history__title {
   position: relative;
   color: white;
@@ -831,7 +830,6 @@ margin-bottom: 16px;
   top: 111px;
   bottom: 0;
   z-index: 100;
-  height: 100vh;
 }
 
 .side-panel-scrollable {

--- a/django_app/frontend/src/js/web-components/chats/chat-history.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-history.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { addShowMore } from "../show-more.js";
+import { addShowMore } from '../show-more';
 
 class ChatHistory extends HTMLElement {
   chatLimit = 5;
@@ -16,7 +16,6 @@ class ChatHistory extends HTMLElement {
     addShowMore({
       container: this.querySelector(".recent-chats"),
       itemSelector: 'li',
-      itemDisplay: 'block',
       visibleCount: 5,
     })
   }

--- a/django_app/frontend/src/js/web-components/chats/document-selector.js
+++ b/django_app/frontend/src/js/web-components/chats/document-selector.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { addShowMore } from "../show-more.js";
+import { addShowMore } from '../show-more';
 
 class DocumentSelector extends HTMLElement {
   visibleDocumentLimit = 5;
@@ -11,7 +11,6 @@ class DocumentSelector extends HTMLElement {
     addShowMore({
       container: this.querySelector(".your-documents"),
       itemSelector: '.govuk-checkboxes__item',
-      itemDisplay: 'flex',
       visibleCount: 5,
     })
 

--- a/django_app/frontend/src/js/web-components/show-more.js
+++ b/django_app/frontend/src/js/web-components/show-more.js
@@ -1,16 +1,22 @@
 export function addShowMore({
     container,
     itemSelector,
-    itemDisplay = "block",
     visibleCount = 5,
     buttonText = "Show more...",
 }) {
     const items = container.querySelectorAll(itemSelector);
     if (items.length < visibleCount) return;
 
-    // Hide additional items
+    // Store display setting
+    const displayValue = items[0].style.display;
+    let displayValues = [];
+
     items.forEach((item, index) => {
-        item.style.display = index < visibleCount ? itemDisplay : "none";
+        // Preserve display value
+        displayValues[index] = item.style.display;
+
+        // Hide additional items
+        if (index >= visibleCount) item.style.display = "none";
       });
 
     // Create show more button
@@ -23,7 +29,7 @@ export function addShowMore({
 
     // Show all items and remove the button when clicked
     showMoreLink.addEventListener("click", () => {
-        items.forEach((item) => {item.style.display = itemDisplay});
+        items.forEach((item, index) => {item.style.display = displayValues[index]});
         showMoreLink.remove();
     });
 

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -173,7 +173,6 @@ upload-button {
 .govuk-footer__copyright-logo {
   display: inline-block;
   min-width: 125px;
-  padding-top: 112px;
   background-image: url(/static/govuk-frontend/assets/images/govuk-crest.png);
   background-repeat: no-repeat;
   background-position: 50% 0;

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: "govuk-assets/";
 
-@import "../node_modules/govuk-frontend/dist/govuk/all";
+@import "../node_modules/govuk-frontend/dist/govuk/index";
 
 body {
   background-color: white;


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
- Fixed side panel scrolling overflow
- Fixed footer logo height/padding
- Fixed <main> div min-height by overriding I.AI design system styling to prevent excessive space on page
- Enhanced show-more component logic to save/restore previous element display value
- Updated depreciated import statement for govuk-frontend
- 

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Note: If using a separate development Macbook/laptop - within the same network - set ADDITIONAL_HOSTS in your .env to the ip address of your DBT device for testing. The server can be accessed from your DBT laptop with <DEV_LAPTOP_IP>:8080

- Check that the scroll bar does not flow into the footer on DBT laptop. 
- The footer logo should also have a reduced padding between it and the copyright link

## Relevant links
