### PR TITLE
fix: redundant iteration

### DIFF
--- a/django_app/redbox_app/redbox_core/views/api_views.py
+++ b/django_app/redbox_app/redbox_core/views/api_views.py
@@ -53,18 +53,14 @@ def aws_credentials_api(request):
         client = boto3.client("sts")
         role_arn = settings.AWS_TRANSCRIBE_ROLE_ARN
 
-        # Creating new credentials unfortunately sometimes fails
-        max_attempts = 3
-        for i in range(3):
-            try:
-                credentials = client.assume_role(
-                    RoleArn=role_arn,
-                    RoleSessionName="redbox_" + str(uuid.uuid4()),
-                    DurationSeconds=60 * 15,  # 15 minutes
-                )["Credentials"]
-            except Exception:
-                if i == max_attempts - 1:
-                    raise
+        try:
+            credentials = client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName="redbox_" + str(uuid.uuid4()),
+                DurationSeconds=60 * 15,
+            )["Credentials"]
+        except Exception as e:
+            logger.exception("Failed to assume role:", exc_info=e)
 
         return JsonResponse(
             {


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
We have an iteration for attempting to connect to creds, this doesnt need to be there anymore - custom terraform mitigates this issue and it doesnt apply to redbox

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Removes legacy attempt to connect to transcribe service. We are covered for this.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
