### PR TITLE
prompt not to use backticks

### DIFF
--- a/redbox-core/redbox/chains/runnables.py
+++ b/redbox-core/redbox/chains/runnables.py
@@ -48,6 +48,7 @@ def build_chat_prompt_from_messages_runnable(
             {task_system_prompt}
             {ai_settings.persona_info_prompt}
             {ai_settings.caller_info_prompt}
+            {ai_settings.answer_instruction_prompt}
             """
         prompts_budget = bedrock_tokeniser(task_system_prompt) + bedrock_tokeniser(task_question_prompt)
         chat_history_budget = ai_settings.context_window_size - ai_settings.llm_max_tokens - prompts_budget

--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -72,6 +72,7 @@ class AISettings(BaseModel):
     planner_system_prompt: str = prompts.PLANNER_PROMPT
     planner_question_prompt: str = prompts.PLANNER_QUESTION_PROMPT
     planner_format_prompt: str = prompts.PLANNER_FORMAT_PROMPT
+    answer_instruction_prompt: str = prompts.ANSWER_INSTRUCTION_SYSTEM_PROMPT
 
     # Elasticsearch RAG and boost values
     rag_k: int = 30

--- a/redbox-core/redbox/models/prompts.py
+++ b/redbox-core/redbox/models/prompts.py
@@ -11,6 +11,7 @@ While you strive to provide accurate and insightful information by fully utilisi
 # Used in all prompts for information about the caller and any query context. This is a placeholder for now.
 CALLER_INFO = ""
 
+ANSWER_INSTRUCTION_SYSTEM_PROMPT = """\nDo not use backticks (```) in the response.\n\n"""
 
 CHAT_SYSTEM_PROMPT = "You are tasked with providing information objectively and responding helpfully to users"
 


### PR DESCRIPTION
## Context

Backticks should only be used for inline coding, variable names, technical syntax, but not English text

https://uktrade.atlassian.net/browse/REDBOX-931?atlOrigin=eyJpIjoiOWM1ZTI3Njk3YmUyNDU1MThhMmQxYmQ2MWQ2OGRjZTMiLCJwIjoiaiJ9

## What

- added answer system prompt 

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
