### PR TITLE
fix: prevent nonetype url error

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -808,7 +808,9 @@ class Citation(UUIDPrimaryKeyBase, TimeStampedModel):
     @property
     def uri(self) -> URL:
         """returns the url of either the external citation or the user-uploaded document"""
-        return URL(self.url or self.file.url)
+        if self.file or self.url:
+            return URL(self.url or self.file.url)
+        return None
 
 
 class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
We are getting an error when users access a chat in which the document has been deleted previously, there is no longer an associated url

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
First check the file still exists, then create the URL

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [X] No

## Relevant links
https://sentry.ci.uktrade.digital/organizations/dit/issues/160898/?project=272&referrer=slack