### PR TITLE
Bugfix/cant access users

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -41,7 +41,8 @@ class UserAdmin(ImportExportMixin, admin.ModelAdmin):
     export_as_json.short_description = "Export Selected"
     actions = ["export_as_json"]
 
-    search_fields = ["email"]
+    search_fields = ["email", "created_at", "name", "profession", "grade"]
+    readonly_fields = ["last_login", "created_at", "ai_experience"]
 
     fieldsets = [
         (
@@ -60,7 +61,6 @@ class UserAdmin(ImportExportMixin, admin.ModelAdmin):
                     "last_login",
                     "ai_settings",
                     "is_developer",
-                    "created_at",
                 ]
             },
         ),
@@ -222,7 +222,7 @@ class ChatMessageAdmin(ExportMixin, admin.ModelAdmin):
     date_hierarchy = "created_at"
     inlines = [CitationInline, ChatMessageTokenUseInline, ChatMessageActivityEventInline]
     readonly_fields = ["selected_files", "source_files"]
-    search_fields = ["chat__user__email"]
+    search_fields = ["chat__user__email", "text", "created_at", "route", "role"]
     ordering = ["-created_at"]
 
     @admin.display(ordering="chat__user", description="User")


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
At the moment we are unable to access the individual user's admin page, this is because created_at was specified as a fieldset originally but its readonly now so we need to exclude it.

Also its really hard to search through the messages at the moment and the users, as we don't have any fields really added to the search filter.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Adjusts some of the admin pages to specify a range of fields that admins can search through the console in order to see things.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Can you search for everything you expect to search for?

## Relevant links
