### PR TITLE
add default page number

### DIFF
--- a/redbox-core/redbox/loader/loaders.py
+++ b/redbox-core/redbox/loader/loaders.py
@@ -153,7 +153,9 @@ class UnstructuredChunkLoader:
                 metadata=UploadedFileMetadata(
                     index=i,
                     uri=file_name,
-                    page_number=raw_chunk["metadata"].get("page_number"),
+                    page_number=[1]
+                    if not raw_chunk["metadata"].get("page_number")
+                    else raw_chunk["metadata"].get("page_number"),
                     created_datetime=datetime.now(UTC),
                     token_count=tokeniser(raw_chunk["text"]),
                     chunk_resolution=self.chunk_resolution,


### PR DESCRIPTION
## Context

To prevent passing page_number = None to LLM, we specify the default value for page number.

## What

Use a default page number value if unstructured unable to find it.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
