### PR TITLE
chore: Fixed styling for underline, hover and edit chat button.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,3 +285,12 @@ django-runserver: # Run the web app locally (not in docker)
 .PHONY: dev
 dev: # Start the app locally in development mode with hot-reloading enabled
 	./dev.sh
+
+.PHONY: local-setup
+local-setup: # Run the local setup commands
+	@cp .env.local.example .env.local
+	@cp .envrc.example .envrc
+
+.PHONY: aws-login
+aws-login: # Login to AWS
+	./aws-login.sh

--- a/aws-login.sh
+++ b/aws-login.sh
@@ -13,9 +13,10 @@ if [ -f "$PROJECT_ROOT/.envrc" ]; then
     source "$PROJECT_ROOT/.envrc"
   else
     echo "direnv is not installed – skipping 'direnv allow'"
+    source "$PROJECT_ROOT/.envrc"
   fi
 else
-  echo ":information_source:  No .envrc found – using default AWS profile fallback"
+  echo ":information_source:  No .envrc found – using [default] AWS profile fallback"
 fi
 
 # Use AWS_PROFILE from env, or fallback to 'default'
@@ -27,7 +28,6 @@ DJANGO_APP_AWS_DIR="$DJANGO_APP_DIR/.aws"
 
 NOTEBOOKS_DIR="$PROJECT_ROOT/notebooks"
 NOTEBOOKS_AWS_DIR="$NOTEBOOKS_DIR/.aws"
-
 
 echo "Using AWS profile: $AWS_PROFILE"
 

--- a/dev.sh
+++ b/dev.sh
@@ -10,7 +10,7 @@ echo "Applying migrations..."
 make migrate
 
 echo "Starting Docker containers..."
-docker compose up -d --wait db opensearch minio
+docker compose up -d --wait db opensearch minio worker
 
 echo "Building static files..."
 make build-django-static

--- a/django_app/frontend/src/js/web-components/chats/canned-prompts.js
+++ b/django_app/frontend/src/js/web-components/chats/canned-prompts.js
@@ -21,7 +21,7 @@ class CannedPrompts extends HTMLElement {
    */
   #prepopulateMessageBox = (prompt) => {
     /** @type HTMLInputElement | null */
-    let chatInput = document.querySelector(".iai-chat-input__input");
+    let chatInput = document.querySelector(".message-input");
     if (chatInput) {
       chatInput.innerHTML = prompt;
       chatInput.focus();

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -278,7 +278,8 @@ export class ChatMessage extends HTMLElement {
           },
         });
         document.dispatchEvent(chatResponseEndEvent);
-        reloadAtCurrentPosition();
+        // Testing no page-reload on response end
+        // reloadAtCurrentPosition();
       } else if (response.type === "error") {
         this.querySelector(".govuk-error-summary")?.removeAttribute(
           "hidden"

--- a/django_app/frontend/src/js/web-components/chats/message-input.js
+++ b/django_app/frontend/src/js/web-components/chats/message-input.js
@@ -14,6 +14,7 @@ export class MessageInput extends HTMLElement {
     // Submit form on enter-key press (providing shift isn't being pressed)
     this.textarea.addEventListener("keypress", (evt) => {
       if (evt.key === "Enter" && !evt.shiftKey && this.textarea) {
+        this.#hideWarnings();
         evt.preventDefault();
         if (this.textarea?.textContent?.trim()) {
           this.closest("form")?.requestSubmit();
@@ -52,6 +53,15 @@ export class MessageInput extends HTMLElement {
     }
     this.textarea.textContent = "";
     this.#adjustHeight();
+  };
+  /**
+   * Hides the warning messages displayed under the textarea
+   */
+  #hideWarnings = () => {
+    const chatWarnings = /** @type {HTMLDivElement} */ (
+      document.querySelector(".chat-warnings")
+    );
+    chatWarnings.style.display = "none";
   };
 }
 customElements.define("message-input", MessageInput);

--- a/django_app/frontend/src/js/web-components/chats/message-input.js
+++ b/django_app/frontend/src/js/web-components/chats/message-input.js
@@ -3,7 +3,7 @@
 export class MessageInput extends HTMLElement {
   constructor() {
     super();
-    this.textarea = this.querySelector(".iai-chat-input__input");
+    this.textarea = this.querySelector(".message-input");
   }
 
   connectedCallback() {

--- a/django_app/frontend/src/stylesheets/chat-styles.scss
+++ b/django_app/frontend/src/stylesheets/chat-styles.scss
@@ -128,60 +128,6 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   }
 }
 
-.chat-title {
-  margin-top: 1rem;
-  display: block;
-  margin-bottom: 2rem;
-}
-.chat-title__heading.govuk-visually-hidden + .chat-title__edit-btn {
-  display: none;
-}
-.chat-title__heading-container-inner {
-  align-items: center;
-  display: flex;
-  gap: 0.75rem;
-}
-.chat-title__heading {
-  line-height: 1.3;
-  margin-bottom: 0;
-}
-
-.chat-title__input {
-  border: 1px solid #60697b;
-  border-radius: 0.25rem;
-  font-weight: 700;
-  max-width: 18rem;
-  padding: 0.375rem;
-  width: 100%;
-}
-
-.chat-message__text {
-  word-break: break-word;
-  padding-top: .5rem;
-  font-size: 16px;
-  line-height: 1.5rem;
-}
-
-.chat-message__text code {
-  display: block;
-  overflow-x: auto;
-}
-
-.chat-message__text li {
-  padding: 0;
-}
-
-.chat-message__text table {
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.chat-message__text th, .chat-message__text td {
-  text-align: left;
-  border: 1px solid var(--color-border-dark);
-  padding: .25rem;
-}
-
 .rb-activity {
   border-left: 1px solid var(--color-border-dark);
   display: flex;
@@ -211,10 +157,6 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
 .rb-activity--ai::before {
   background-color: var(--color-background);
   content: url("/static/icons/activity-redbox.svg")
-}
-
-chat-message {
-  scroll-margin-bottom: 10rem;
 }
 
 .rb-loading-ellipsis {
@@ -269,10 +211,6 @@ chat-message {
   }
 }
 
-.rb-chat-message__container {
-  margin-top: -1rem;
-  padding-bottom: 32px;
-}
 .govuk-main-wrapper:has(.iai-chat-input__input) {
   padding: 0;
 }

--- a/django_app/frontend/src/stylesheets/chat-styles.scss
+++ b/django_app/frontend/src/stylesheets/chat-styles.scss
@@ -211,10 +211,6 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   }
 }
 
-.govuk-main-wrapper:has(.iai-chat-input__input) {
-  padding: 0;
-}
-
 .rb-streaming-response-loading {
   align-items: center;
   display: flex;
@@ -383,14 +379,6 @@ main:has(.govuk-inset-text) .chat-options {
   .iai-chat-input {
     max-width: 100%;
   }
-}
-
-.iai-chat-input__input {
-  background-color: var(--color-background-white);
-  border: #767676 1px solid;
-  min-height: 1.5em;
-  max-height: 200px;
-  overflow-y: auto;
 }
 
 .exit-feedback {

--- a/django_app/frontend/src/stylesheets/components/_index.scss
+++ b/django_app/frontend/src/stylesheets/components/_index.scss
@@ -1,4 +1,6 @@
 // Components
+@forward './chat-message.scss';
+@forward './chat-title.scss';
 @forward './divider.scss';
 @forward './redbox-banner.scss';
 @forward './show-more.scss';

--- a/django_app/frontend/src/stylesheets/components/chat-message.scss
+++ b/django_app/frontend/src/stylesheets/components/chat-message.scss
@@ -1,0 +1,35 @@
+chat-message {
+  scroll-margin-bottom: 10rem;
+}
+
+.chat-message__text {
+  word-break: break-word;
+  padding-top: .5rem;
+  font-size: 16px;
+  line-height: 1.5rem;
+}
+
+.chat-message__text code {
+  display: block;
+  overflow-x: auto;
+}
+
+.chat-message__text li {
+  padding: 0;
+}
+
+.chat-message__text table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.chat-message__text th, .chat-message__text td {
+  text-align: left;
+  border: 1px solid var(--color-border-dark);
+  padding: .25rem;
+}
+
+.rb-chat-message__container {
+  margin-top: -1rem;
+  padding-bottom: 32px;
+}

--- a/django_app/frontend/src/stylesheets/components/chat-title.scss
+++ b/django_app/frontend/src/stylesheets/components/chat-title.scss
@@ -1,0 +1,29 @@
+.chat-title {
+  margin-top: 1rem;
+  display: block;
+  margin-bottom: 2rem;
+}
+
+.chat-title__heading.govuk-visually-hidden + #chat-title-edit-button {
+  display: none;
+}
+
+.chat-title__heading-container-inner {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.chat-title__heading {
+  line-height: 1.3;
+  margin-bottom: 0;
+}
+
+.chat-title__input {
+  border: 1px solid #60697b;
+  border-radius: 0.25rem;
+  font-weight: 700;
+  max-width: 18rem;
+  padding: 0.375rem;
+  width: 100%;
+}

--- a/django_app/frontend/src/stylesheets/components/show-more.js
+++ b/django_app/frontend/src/stylesheets/components/show-more.js
@@ -25,6 +25,7 @@ export function addShowMore({
     showMoreLink.textContent = buttonText;
     showMoreLink.classList.add(
         "show-more-link",
+        "govuk-link",
         "govuk-link--no-visited-state",
         "govuk-link--no-underline"
     );

--- a/django_app/frontend/src/stylesheets/components/show-more.js
+++ b/django_app/frontend/src/stylesheets/components/show-more.js
@@ -5,38 +5,37 @@ export function addShowMore({
     buttonText = "Show more...",
 }) {
     const items = container.querySelectorAll(itemSelector);
-    if (items.length < visibleCount) return;
-
-    // Store display setting
-    let displayValues = [];
+    if (items.length < visibleCount) {
+        items.forEach((item) => item.style.removeProperty('display'));
+        return;
+    }
 
     items.forEach((item, index) => {
-        // Preserve display value
-        displayValues[index] = item.style.display;
-
-        // Hide additional items
-        if (index >= visibleCount) item.style.display = "none";
-      });
-
-    // Create show more button
-    const showMoreDiv = document.createElement("div");
-    showMoreDiv.id = "show-more-div";
-    const showMoreLink = document.createElement("a");
-    showMoreLink.textContent = buttonText;
-    showMoreLink.classList.add(
-        "show-more-link",
-        "govuk-link",
-        "govuk-link--no-visited-state",
-        "govuk-link--no-underline"
-    );
-
-    // Show all items and remove the button when clicked
-    showMoreLink.addEventListener("click", () => {
-        items.forEach((item, index) => {item.style.display = displayValues[index]});
-        showMoreLink.remove();
+        item.style.display = (index >= visibleCount) ? "none" : "";
     });
 
-    // Create element
-    showMoreDiv.appendChild(showMoreLink);
-    container.appendChild(showMoreDiv);
+    // Create show more button
+    let showMoreDiv = container.querySelector("#show-more-div");
+    if (!showMoreDiv) {
+        showMoreDiv = document.createElement("div");
+        showMoreDiv.id = "show-more-div";
+        const showMoreLink = document.createElement("a");
+        showMoreLink.textContent = buttonText;
+        showMoreLink.classList.add(
+            "show-more-link",
+            "govuk-link",
+            "govuk-link--no-visited-state",
+            "govuk-link--no-underline"
+        );
+
+        // Show all items and remove the button when clicked
+        showMoreLink.addEventListener("click", () => {
+            items.forEach((item) => item.style.removeProperty('display'));
+            showMoreDiv.remove();
+        });
+
+        // Create element
+        showMoreDiv.appendChild(showMoreLink);
+        container.appendChild(showMoreDiv);
+    }
 }

--- a/django_app/frontend/src/stylesheets/components/show-more.scss
+++ b/django_app/frontend/src/stylesheets/components/show-more.scss
@@ -1,10 +1,6 @@
 .show-more-link {
     --show-more-link-color: var(--color-link-text);
-    --show-more-link-hover-color: var(--color-text);
 
     cursor: pointer;
-
-    &:hover {
-      color: var(--show-more-link-hover-color);
-    }
+    color: var(--show-more-link-color);
   }

--- a/django_app/frontend/src/stylesheets/components/side-panel.scss
+++ b/django_app/frontend/src/stylesheets/components/side-panel.scss
@@ -29,7 +29,6 @@
 
   .recent-chats {
     max-height: 316px;
-    color: var(--color-side-panel-link-text);
 
     .chat-list {
       list-style: none;
@@ -41,6 +40,8 @@
         &.selected {
           --color-side-panel-link-text: var(--color-side-panel-text);
           --color-icon-light-foreground: var(--color-side-panel-text);
+
+          color: var(--color-side-panel-text);
         }
 
         .chat-item-container {
@@ -58,13 +59,14 @@
             max-width: 100%;
             box-sizing: border-box;
             color: var(--color-side-panel-link-text);
-
-            &:hover {
-              color: var(--color-side-panel-text);
-            }
+            padding-bottom: 3px;
 
             .chat-item-link {
               color: var(--color-side-panel-link-text);
+
+              &:hover {
+                color: var(--color-link-text-hover);
+              }
             }
 
             .chat-title-text-input {

--- a/django_app/frontend/src/stylesheets/govuk-custom/_index.scss
+++ b/django_app/frontend/src/stylesheets/govuk-custom/_index.scss
@@ -2,3 +2,4 @@
 @forward './govuk-button.scss';
 @forward './govuk-footer.scss';
 @forward './govuk-header.scss';
+@forward './govuk-textarea.scss';

--- a/django_app/frontend/src/stylesheets/govuk-custom/govuk-textarea.scss
+++ b/django_app/frontend/src/stylesheets/govuk-custom/govuk-textarea.scss
@@ -1,0 +1,31 @@
+@use "../../../node_modules/govuk-frontend/dist/govuk/index" as govuk;
+
+// Currently not a potential contribution due to the number of customisations made
+// which are very specific to redbox at the moment. Typography will need some work.
+.govuk-textareax {
+  @extend .govuk-textarea;
+  font-size: 16px;
+  font-size: 1rem;
+  min-height: 6em;
+  margin-bottom: 0;
+  padding: 4px;
+  font-family: var(--font-family-primary);
+}
+@media (min-width:40.0625em) {
+  .govuk-textareax {
+    white-space: pre-wrap;
+  }
+}
+
+@media print {
+  .govuk-textareax {
+    font-size: 14pt;
+    line-height: 1.25
+  }
+}
+
+.govuk-textareax:focus {
+  outline: 4px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px
+}

--- a/django_app/frontend/src/stylesheets/iai-overrides.scss
+++ b/django_app/frontend/src/stylesheets/iai-overrides.scss
@@ -1,147 +1,105 @@
 .govuk-buttonx {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 1rem;
-    box-sizing: border-box;
-    display: inline-block;
-    position: relative;
-    width: 100%;
-    margin: 0 0 16px;
-    padding: 8px 12px 8px;
-    border: 2px solid rgba(0, 0, 0, 0);
-    border-radius: 0;
-    color: #fff;
-    background-color: #00703c;
-    box-shadow: 0 2px 0 #002d18;
-    text-align: center;
-    vertical-align: top;
-    cursor: pointer;
-    -webkit-appearance: none
-  }
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 1rem;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin: 0 0 16px;
+  padding: 8px 12px 8px;
+  border: 2px solid rgba(0, 0, 0, 0);
+  border-radius: 0;
+  color: #fff;
+  background-color: #00703c;
+  box-shadow: 0 2px 0 #002d18;
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none
+}
 
-  @media (min-width:40.0625em) {
-    .govuk-buttonx {
-      margin-bottom: 40px;
-      width: auto
-    }
+@media (min-width:40.0625em) {
+  .govuk-buttonx {
+    margin-bottom: 40px;
+    width: auto
   }
+}
 
-  .govuk-buttonx:active,
-  .govuk-buttonx:hover,
-  .govuk-buttonx:link,
-  .govuk-buttonx:visited {
-    color: #fff;
-    text-decoration: none
-  }
+.govuk-buttonx:active,
+.govuk-buttonx:hover,
+.govuk-buttonx:link,
+.govuk-buttonx:visited {
+  color: #fff;
+  text-decoration: none
+}
 
-  .govuk-buttonx::-moz-focus-inner {
-    padding: 0;
-    border: 0
-  }
+.govuk-buttonx::-moz-focus-inner {
+  padding: 0;
+  border: 0
+}
 
-  .govuk-buttonx:hover {
-    background-color: #005a30
-  }
+.govuk-buttonx:hover {
+  background-color: #005a30
+}
 
-  .govuk-buttonx:active {
-    top: 4px
-  }
+.govuk-buttonx:active {
+  top: 4px
+}
 
-  .govuk-buttonx:focus {
-    border-color: #fd0;
-    outline: 3px solid rgba(0, 0, 0, 0);
-    box-shadow: inset 0 0 0 2px #fd0
-  }
+.govuk-buttonx:focus {
+  border-color: #fd0;
+  outline: 3px solid rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 2px #fd0
+}
 
-  .govuk-buttonx:focus:not(:active):not(:hover) {
-    border-color: #fd0;
-    color: #0b0c0c;
-    background-color: #fd0;
-    box-shadow: 0 2px 0 #0b0c0c
-  }
+.govuk-buttonx:focus:not(:active):not(:hover) {
+  border-color: #fd0;
+  color: #0b0c0c;
+  background-color: #fd0;
+  box-shadow: 0 2px 0 #0b0c0c
+}
 
-  .govuk-buttonx:before {
-    content: "";
-    display: block;
-    position: absolute;
-    top: -4px;
-    right: -4px;
-    bottom: -8px;
-    left: -4px;
-    background: rgba(0, 0, 0, 0)
-  }
+.govuk-buttonx:before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -8px;
+  left: -4px;
+  background: rgba(0, 0, 0, 0)
+}
 
-  .govuk-buttonx:active:before {
-    top: -4px
-  }
+.govuk-buttonx:active:before {
+  top: -4px
+}
 
+.govuk-button--secondaryx {
+  background-color: #f3f2f1;
+  box-shadow: 0 2px 0 #929191
+}
 
+.govuk-button--secondaryx,
+.govuk-button--secondaryx:active,
+.govuk-button--secondaryx:hover,
+.govuk-button--secondaryx:link,
+.govuk-button--secondaryx:visited {
+  color: #0b0c0c
+}
 
-  .govuk-button--secondaryx {
-    background-color: #f3f2f1;
-    box-shadow: 0 2px 0 #929191
-  }
+.govuk-button--secondaryx:hover {
+  background-color: #dbdad9
+}
 
-  .govuk-button--secondaryx,
-  .govuk-button--secondaryx:active,
-  .govuk-button--secondaryx:hover,
-  .govuk-button--secondaryx:link,
-  .govuk-button--secondaryx:visited {
-    color: #0b0c0c
-  }
+.govuk-button--secondaryx:hover[disabled] {
+  background-color: #f3f2f1
+}
 
-  .govuk-button--secondaryx:hover {
-    background-color: #dbdad9
-  }
-
-  .govuk-button--secondaryx:hover[disabled] {
-    background-color: #f3f2f1
-  }
-
-  .govuk-button--secondaryx[disabled=disabled], .govuk-button--secondaryx:disabled {
-    opacity: 50%;
-  }
-
-  .govuk-textareax {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
-    box-sizing: border-box;
-    display: block;
-    width: 100%;
-    min-height: 6em;
-    margin-bottom: 0;
-    padding: 4px;
-    resize: vertical;
-    border: 2px solid #0b0c0c;
-    border-radius: 0;
-    -webkit-appearance: none;
-  }
-  @media (min-width:40.0625em) {
-    .govuk-textareax {
-      font-size: 20px;
-      font-size: 1.1875rem;
-      line-height: 1.25;
-      white-space: pre-wrap;
-    }
-  }
-
-  @media print {
-    .govuk-textareax {
-      font-size: 14pt;
-      line-height: 1.25
-    }
-  }
-
-  .govuk-textareax:focus {
-    outline: 4px solid #fd0;
-    outline-offset: 0;
-    box-shadow: inset 0 0 0 2px
-  }
+.govuk-button--secondaryx[disabled=disabled], .govuk-button--secondaryx:disabled {
+  opacity: 50%;
+}
 
 [contentEditable=true]:empty:not(:focus):before {
   content: attr(data-text)

--- a/django_app/frontend/src/stylesheets/icons/delete.scss
+++ b/django_app/frontend/src/stylesheets/icons/delete.scss
@@ -1,8 +1,10 @@
 .delete-icon {
   --delete-icon-foreground-color: var(--color-icon-light-foreground);
 
-  &:hover {
-    --delete-icon-foreground-color: var(--color-icon-light-foreground-hover);
+  &.hover {
+    &:hover {
+      --delete-icon-foreground-color: var(--color-icon-light-foreground-hover);
+    }
   }
 
   .foreground {

--- a/django_app/frontend/src/stylesheets/icons/edit.scss
+++ b/django_app/frontend/src/stylesheets/icons/edit.scss
@@ -1,8 +1,10 @@
 .edit-icon {
   --edit-icon-foreground-color: var(--color-icon-light-foreground);
 
+  &.hover {
     &:hover {
-    --edit-icon-foreground-color: var(--color-icon-light-foreground-hover);
+      --edit-icon-foreground-color: var(--color-icon-light-foreground-hover);
+    }
   }
 
   .foreground {

--- a/django_app/frontend/src/variables.scss
+++ b/django_app/frontend/src/variables.scss
@@ -63,9 +63,13 @@ $govuk-brand-colour: #1d70b8;
   --color-button-primary: var(--redbox-blue);/* old:#1759BC */
   --color-text: var(--dbt-black);
   --color-link-text: var(--redbox-blue);
+  --color-link-text-hover: var(--gds-dark-blue);
 
   // Icons
   --color-icon-light-foreground: var(--redbox-blue);
   --color-icon-light-foreground-hover: var(--dbt-black);
   --color-icon-dark-foreground: var(--redbox-white);
+
+  // Typography
+  --font-family-primary: "Noto Sans", Arial;
 }

--- a/django_app/frontend/tests-web-components/canned-prompts.spec.js
+++ b/django_app/frontend/tests-web-components/canned-prompts.spec.js
@@ -6,6 +6,6 @@ test(`Clicking canned prompts updates the text input`, async ({ page }) => {
 
   await page.goto("/chats");
 
-  const textInput = page.locator(".iai-chat-input__input");
+  const textInput = page.locator(".message-input");
   await expect(textInput).toHaveValue("");
 });

--- a/django_app/frontend/tests-web-components/copy-text.spec.js
+++ b/django_app/frontend/tests-web-components/copy-text.spec.js
@@ -11,7 +11,7 @@ test(`Content can be copied to clipboard`, async ({ page }) => {
   await page.getByText("Copy information").click();
   const response = page.locator(".chat-message__text").nth(1);
 
-  const messageInput = page.locator(".iai-chat-input__input");
+  const messageInput = page.locator(".message-input");
   await messageInput.focus();
   await page.keyboard.press("Meta+V");
   expect(await response.textContent()).toEqual(await messageInput.inputValue());

--- a/django_app/frontend/tests-web-components/message-input.spec.js
+++ b/django_app/frontend/tests-web-components/message-input.spec.js
@@ -6,10 +6,10 @@ test(`Message input functionality`, async ({ page }) => {
 
   await page.goto("/chats");
 
-  const messageInput = page.locator(".iai-chat-input__input");
+  const messageInput = page.locator(".message-input");
 
   const height1 = await page.evaluate(
-    () => document.querySelector(".iai-chat-input__input").scrollHeight
+    () => document.querySelector(".message-input").scrollHeight
   );
 
   // Pressing shift + enter doesn't send the message
@@ -19,7 +19,7 @@ test(`Message input functionality`, async ({ page }) => {
 
   // The height of the textarea increases to fit content
   const height2 = await page.evaluate(
-    () => document.querySelector(".iai-chat-input__input").scrollHeight
+    () => document.querySelector(".message-input").scrollHeight
   );
   expect(height2 > height1).toBeTruthy();
 
@@ -39,7 +39,7 @@ test(`Message input functionality`, async ({ page }) => {
 
   // And the height of the textarea returns to it's original height
   const height3 = await page.evaluate(
-    () => document.querySelector(".iai-chat-input__input").scrollHeight
+    () => document.querySelector(".message-input").scrollHeight
   );
   expect(height3).toEqual(height1);
 });

--- a/django_app/frontend/tests-web-components/utils.js
+++ b/django_app/frontend/tests-web-components/utils.js
@@ -32,7 +32,7 @@ const signIn = async (page) => {
 };
 
 const sendMessage = async (page) => {
-  await page.locator(".iai-chat-input__input").fill("Testing");
+  await page.locator(".message-input").fill("Testing");
   await page.getByRole("button", { name: "Send" }).click();
 };
 

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -183,19 +183,21 @@
       </send-message>
       {% endif %}
       {% if not messages %}
-        <div class="govuk-warning-text govuk-body govuk-!-margin-bottom-1 govuk-!-padding-bottom-0">
-          <span class="govuk-warning-text__icon small-warning" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text govuk-!-padding-left-7">
-            <span class="govuk-visually-hidden">Warning</span>
-            You can use up to, and including, official sensitive documents.
-          </strong>
-        </div>
-        <div class="govuk-warning-text govuk-body govuk-!-margin-bottom-1 govuk-!-padding-bottom-0">
-          <span class="govuk-warning-text__icon small-warning" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text govuk-!-padding-left-7">
-            <span class="govuk-visually-hidden">Warning</span>
-            Redbox can make mistakes. You must check for accuracy before using the output.
-          </strong>
+        <div class="chat-warnings">
+          <div class="govuk-warning-text govuk-body govuk-!-margin-bottom-1 govuk-!-padding-bottom-0">
+            <span class="govuk-warning-text__icon small-warning" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text govuk-!-padding-left-7">
+              <span class="govuk-visually-hidden">Warning</span>
+              You can use up to, and including, official sensitive documents.
+            </strong>
+          </div>
+          <div class="govuk-warning-text govuk-body govuk-!-margin-bottom-1 govuk-!-padding-bottom-0">
+            <span class="govuk-warning-text__icon small-warning" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text govuk-!-padding-left-7">
+              <span class="govuk-visually-hidden">Warning</span>
+              Redbox can make mistakes. You must check for accuracy before using the output.
+            </strong>
+          </div>
         </div>
       {% endif %}
 

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -139,7 +139,7 @@
         Need help? View <a href="{{ url('faq') }}" class="govuk-link" target="_blank">Advanced Prompt FAQ.</a>
       </div>
       <message-input>
-        <div class="govuk-textareax iai-chat-input__input js-user-text" id="message" name="message" contenteditable="true" role="textbox" aria-multiline="true" data-text="Type here..."></div>
+        <div class="govuk-textareax" id="message" name="message" contenteditable="true" role="textbox" aria-multiline="true" data-text="Type here..."></div>
       </message-input>
   {% if enable_dictation_flag_is_active %}
   <send-message-with-dictation data-api-key="{{ redbox_api_key }}">

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -139,7 +139,7 @@
         Need help? View <a href="{{ url('faq') }}" class="govuk-link" target="_blank">Advanced Prompt FAQ.</a>
       </div>
       <message-input>
-        <div class="govuk-textareax" id="message" name="message" contenteditable="true" role="textbox" aria-multiline="true" data-text="Type here..."></div>
+        <div class="govuk-textareax message-input" id="message" name="message" contenteditable="true" role="textbox" aria-multiline="true" data-text="Type here..."></div>
       </message-input>
   {% if enable_dictation_flag_is_active %}
   <send-message-with-dictation data-api-key="{{ redbox_api_key }}">

--- a/django_app/redbox_app/templates/macros/chat-history-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-history-macros.html
@@ -9,7 +9,10 @@
         <chat-history-item data-chatid="{{ chat.id }}" {% if chat.id == active_chat_id %}data-iscurrentchat="true"{% endif %}>
             <div class="chat-item-container">
                 <span class="chat-item-text-container">
-                    <a class="chat-item-link govuk-link--no-underline" href="{{ link }}" {% if chat.id == active_chat_id %}aria-current="page"{% endif %}>{{ chat.name }}</a>
+                    <a class="chat-item-link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                       href="{{ link }}" {% if chat.id == active_chat_id %}aria-current="page"{% endif %}>
+                        {{ chat.name }}
+                    </a>
                     <div class="chat-title-text-input">
                         <label class="govuk-visually-hidden" for="chat-title-text-input-{{ chat.id }}">Chat title</label>
                         <input type="text" id="chat-title-text-input-{{ chat.id }}"/>

--- a/docs/installation/running-django-locally.md
+++ b/docs/installation/running-django-locally.md
@@ -36,6 +36,12 @@ Install frontend dependencies if not done already `npm install`
 Run `npm run dev` to watch for changes and automatically rebuild
 
 ### Quick start
-Alternatively, run `make dev` to run migrations, copy static files and start the frontend with parcel in watch mode on [localhost:8081](http://localhost:8081/). The magic link for login should appear in the terminal: `CTRL+F` > `magic_link`. You may need to increase the terminal buffer in order to capture the magic link. [Terminal › Integrated: Scrollback](vscode://settings/terminal.integrated.scrollback).
+Alternatively, run the following to get started quickly:
 
-*Note: You will still need to setup the local environment variables as mentioned earlier.*
+`make local-setup` will setup the necessary environment variables (only needed once).
+
+`make dev` will run migrations, copy static files and start the frontend with parcel in watch mode on [localhost:8081](http://localhost:8081/).
+
+The magic link for login should appear in the terminal: `CTRL+F` > `magic_link`. You may need to increase the terminal buffer in order to capture the magic link. [Terminal › Integrated: Scrollback](vscode://settings/terminal.integrated.scrollback).
+
+To restart the app, `Ctrl+C` the active terminal and run `make dev` again.


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

This PR fixes the edit chat title button showing when no chat is selected bug and some minor style discrepancies.
I also updated the getting started guide and added a few make commands to make setting up a bit easier. 
Lastly I moved the chat-title and chat-message styles out of chat-styles.scss into their own component stylesheets.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Fixed styling for side-panel underline and hover states (underline thickness and hover color)
- Put icon hover states behind optional class
- Added make commands for setting up local environment variables
- Updated AWS login script to not be dependant on direnv, the file will now be sourced directly regardless if its installed. Also created a Makefile command
- Updated documentation to reflect changes to makefile
- Changed chat textarea to be font-size: 16px
- Moved some more styles out of chat-styles into their own stylesheets.
- Fixed document uploads not working when running the frontend locally.
- Disabled page reload on new chat initial message.
- Removed warning messages on form-submission instead of after chat-response-end event + page-reload.

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

- Confirm the underline matches the govuk-frontend styling.
- Confirm the edit chat title button no longer shows upon login and redirect to the /chats page.
- Confirm the icons in the side-panel no longer have hover states.
- Confirm the "Type here..." text in the textarea is 16px.
- Confirm document uploads work when running the frontend locally (`make dev`)
- Confirm chat and show-more still works as expected after initial chat message with no reload.
- Confirm warning messages dissapear instantly upon sending initial chat message.
- Optional: Confirm make make local-setup > aws-login, can be run without direnv installed

<img width="1331" height="915" alt="image" src="https://github.com/user-attachments/assets/121d3ff0-a5f8-4f94-94fb-60518c163760" />

## Relevant links
[Chat title edit bug](https://teams.microsoft.com/l/message/19:d7966b2e17a94ec0903840dd686fdbbd@thread.v2/1752228452116?context=%7B%22contextType%22%3A%22chat%22%7D)