### PR TITLE
Uncommenting reload at current position line.

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -278,8 +278,8 @@ export class ChatMessage extends HTMLElement {
           },
         });
         document.dispatchEvent(chatResponseEndEvent);
-        // Testing no page-reload on response end
-        // reloadAtCurrentPosition();
+        // Reload page on response end to properly display message(s)
+        reloadAtCurrentPosition();
       } else if (response.type === "error") {
         this.querySelector(".govuk-error-summary")?.removeAttribute(
           "hidden"


### PR DESCRIPTION
## Context


## What has changed
Uncommenting the `reloadAtCurrentPostion()` line in `chat-message.js`. 

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Confirm that citations load as normal when a question is asked without requiring a manual reload.
## Relevant links
