### PR TITLE
Bugfix: let enter key send message

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/message-input.js
+++ b/django_app/frontend/src/js/web-components/chats/message-input.js
@@ -61,7 +61,9 @@ export class MessageInput extends HTMLElement {
     const chatWarnings = /** @type {HTMLDivElement} */ (
       document.querySelector(".chat-warnings")
     );
+    if (chatWarnings) {
     chatWarnings.style.display = "none";
+    }
   };
 }
 customElements.define("message-input", MessageInput);

--- a/django_app/redbox_app/redbox_core/middleware.py
+++ b/django_app/redbox_app/redbox_core/middleware.py
@@ -106,7 +106,6 @@ class APIKeyAuthentication(BaseAuthentication):
 @sync_and_async_middleware
 def sentry_user_middleware(get_response):
     if iscoroutinefunction(get_response):
-
         async def middleware(request: HttpRequest) -> HttpResponse:
             if hasattr(request, "user"):
                 is_authenticated = await sync_to_async(getattr)(request.user, "is_authenticated", False)
@@ -123,7 +122,6 @@ def sentry_user_middleware(get_response):
                 response = await response
             return response
     else:
-
         def middleware(request: HttpRequest) -> HttpResponse:
             if hasattr(request, "user") and request.user.is_authenticated:
                 sentry_sdk.set_user(

--- a/django_app/redbox_app/redbox_core/middleware.py
+++ b/django_app/redbox_app/redbox_core/middleware.py
@@ -106,6 +106,7 @@ class APIKeyAuthentication(BaseAuthentication):
 @sync_and_async_middleware
 def sentry_user_middleware(get_response):
     if iscoroutinefunction(get_response):
+
         async def middleware(request: HttpRequest) -> HttpResponse:
             if hasattr(request, "user"):
                 is_authenticated = await sync_to_async(getattr)(request.user, "is_authenticated", False)
@@ -122,6 +123,7 @@ def sentry_user_middleware(get_response):
                 response = await response
             return response
     else:
+
         def middleware(request: HttpRequest) -> HttpResponse:
             if hasattr(request, "user") and request.user.is_authenticated:
                 sentry_sdk.set_user(


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
let enter key send message

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Chat warnings don't exist after first message so it fails to do the enter key event because that's called after the hide warnings class


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Can you send a message after you sent a message

## Relevant links
