### PR TITLE
Updating DB File Handling for the Tabular Agent

### DIFF
--- a/redbox-core/redbox/models/chain.py
+++ b/redbox-core/redbox/models/chain.py
@@ -323,12 +323,21 @@ class RedboxState(BaseModel):
     agent_plans: MultiAgentPlan | None = None
     tasks_evaluator: Annotated[list[AnyMessage], add_messages] = Field(default_factory=list)
     db_location: str | None = None
+    original_documents: DocumentState | None = None
 
     @property
     def last_message(self) -> AnyMessage:
         if not self.messages:
             raise ValueError("No messages in the state")
         return self.messages[-1]
+
+    def store_document_state(self):
+        self.original_documents = self.documents.model_copy(deep=True)
+
+    def documents_changed(self) -> bool:
+        if not self.original_documents:
+            return False
+        return self.original_documents != self.documents
 
 
 class PromptSet(StrEnum):


### PR DESCRIPTION
Adding an original documents attribute to the RedboxState and recreating db file only if it doesn't exist or documents change

## Context

Conservatively, the current QA process for the `tabular` agent creates and deletes a db file each time a question is asked.

## What Changed
1. Added an `original_documents` attribute to the RedboxState which is either `None` or a deep copy of the documents
2. Added a `documents_changed` method  to RedboxState. This returns `True` if the documents selected have changed and `False` otherwise
3. Removed the deletion of the db file from every QA flow.
4. Added logic to only re-create the db file if it doesn't exist or the documents selected have changed.


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No
* Check that the db file created is persisted when a question is asked using the `Tabular` agent in the same chat
* When a different chat is initiated, a different db file will be created.
## Relevant links
