### PR TITLE
Chore: Fix spacing gap at top of left panel

### DIFF
--- a/django_app/frontend/src/redbox_design_system/rbds/iai-overrides.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/iai-overrides.scss
@@ -119,3 +119,7 @@ main,
 body {
   min-height: 0 !important;
 }
+
+.govuk-main-wrapper {
+  padding: 0;
+}


### PR DESCRIPTION
## Context

This PR is to fix the spacing gap at the top of the page caused by unnecessary padding at the top of the main div.

## What

Remove padding from `.govuk-main-wrapper`

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

- Ensure spacing is gone from the top of the sidepanel/main div

Before:
<img width="1446" height="935" alt="image" src="https://github.com/user-attachments/assets/f9a9b9c4-ac3a-46c1-b3d9-5baf9d748e06" />

After:
<img width="1360" height="934" alt="image" src="https://github.com/user-attachments/assets/0a7d12fd-d751-4731-9fff-36c4afe0cfef" />

## Relevant links
[REDBOX-976](https://uktrade.atlassian.net/browse/REDBOX-976)

[REDBOX-976]: https://uktrade.atlassian.net/browse/REDBOX-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ