### PR TITLE
correctly call legislation graph

### DIFF
--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -95,7 +95,7 @@ def new_root_graph(
     )
     builder.add_node(
         "legislation_graph",
-        build_new_graph(all_chunks_retriever, legislation_tools, debug),
+        build_legislation_graph(all_chunks_retriever, legislation_tools, debug),
     )
     builder.add_node(
         "retrieve_metadata", get_retrieve_metadata_graph(metadata_retriever=metadata_retriever, debug=debug)
@@ -743,7 +743,7 @@ def build_new_graph(
     return builder.compile(debug=debug)
 
 
-def get_legislation_graph(
+def build_legislation_graph(
     all_chunks_retriever: VectorStoreRetriever, multi_agent_tools: dict, debug: bool = False
 ) -> CompiledGraph:
     agents_max_tokens = AISettings().agents_max_tokens


### PR DESCRIPTION
## Context

Bug -> legislation route currently build newroute graph where legislation tool is not available

## What

Correctly call the legislation graph where the applicable tool is available

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No
-
Build locally, use prompts prefixed with https://github.com/legislation to check that answers relate to the question asked, and citations only point to http://legislation.gov.uk/ and are valid urls

## Relevant links
