### PR TITLE
disabled legislation route making a plan for user feedback

### DIFF
--- a/redbox-core/redbox/graph/root.py
+++ b/redbox-core/redbox/graph/root.py
@@ -747,7 +747,9 @@ def build_legislation_graph(
     all_chunks_retriever: VectorStoreRetriever, multi_agent_tools: dict, debug: bool = False
 ) -> CompiledGraph:
     agents_max_tokens = AISettings().agents_max_tokens
-    allow_plan_feedback = get_settings().allow_plan_feedback
+    # Disabled as plan and user feedback is answered via newroute and those tools
+    # instead of legislation route and its specific set of tools
+    allow_legislation_plan_feedback = False
 
     builder = StateGraph(RedboxState)
     builder.add_node(
@@ -760,7 +762,7 @@ def build_legislation_graph(
     builder.add_node(
         "planner",
         my_planner(
-            allow_plan_feedback=allow_plan_feedback,
+            allow_plan_feedback=allow_legislation_plan_feedback,
             node_after_streamed="stream_plan",
             node_afer_replan="sending_task",
         ),


### PR DESCRIPTION
## Context

depending on user query, legislation route will present a plan to the user for user feedback, given feedback the rest of the answer will be generated via newroute (i.e. using tools available in that route such as gov.uk and wikipedia) instead of the Kagi web search to legislation.gov.uk that was intended

## What

disable allow user feedback in legislation route

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

Build locally, try the following prompt "@legislation I think it was in 2018, the attorney general released a human rights guidance order in norther ireland, can you find that? @legislation what was that commencement number 1 order for the terrorism act? Was it 2006? 2005? What did it say? @legislation I think there was a council regulation between 2000 and 2005 around anti-dumping duty imposed on steel roles  or cables from russia? Can you find that for me please and let me know what it says"

check that plan is not created and citations are valid urls to legislation.gov.uk only, can take several attempts to prompt as this behaviour is not always replicable

## Relevant links
