### PR TITLE
Bugfix: Fixed textbox not being editable after selecting a document

### DIFF
--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -191,6 +191,9 @@ class FileUpload extends HTMLElement {
         });
 
         document.body.addEventListener("file-uploads-processed", this.messageInput?.enableSubmit);
+        document.body.addEventListener("file-uploads-removed", () => {
+            if (!this.messageInput?.getValue()) this.messageInput.reset();
+        });
     }
 
     /**
@@ -203,9 +206,14 @@ class FileUpload extends HTMLElement {
                 document.createElement("uploaded-files")
             );
             this.textarea.prepend(uploadedFiles);
+
+            if (!this.messageInput.getValue()) {
+                this.messageInput.reset();
+                this.#moveCaretToEnd();
+            }
         }
 
-        return this.uploadedFiles?.addFile(name);
+        return this.uploadedFiles.addFile(name);
     }
 
 
@@ -216,15 +224,10 @@ class FileUpload extends HTMLElement {
     #handleFiles(files) {
         if (!files) return;
 
-        const moveCaretToEnd = (!this.textarea?.textContent?.trim());
         this.#disableSubmit();
 
         for (const file of files) {
             this.uploadFile(file);
-        }
-        if (moveCaretToEnd) {
-            this.textarea?.appendChild(document.createElement("br"));
-            this.#moveCaretToEnd();
         }
     }
 

--- a/django_app/frontend/src/redbox_design_system/rbds/components/uploaded-files.js
+++ b/django_app/frontend/src/redbox_design_system/rbds/components/uploaded-files.js
@@ -62,7 +62,10 @@ export class UploadedFiles extends HTMLElement {
         this.files.splice(index, 1); // Remove file from array
         if (uploadedFile.parentNode === this.container) this.container.removeChild(uploadedFile);
         if (this.allProcessed()) this.#emitProcessedEvent();
-        if (this.isEmpty()) this.remove();
+        if (this.isEmpty()) {
+            this.remove();
+            this.#emitRemovedEvent();
+        }
         return true;
     }
 
@@ -107,6 +110,15 @@ export class UploadedFiles extends HTMLElement {
     #emitProcessedEvent() {
         document.body.dispatchEvent(new CustomEvent("file-uploads-processed"));
     }
+
+
+    /**
+     * Emits an event to signify that the element has been removed
+     */
+    #emitRemovedEvent() {
+        document.body.dispatchEvent(new CustomEvent("file-uploads-removed"));
+    }
+
 
     /**
      * Monitors the processing status of each uploaded file


### PR DESCRIPTION
## Context
The textbox was not editable after selecting a document in the sidepanel

## What
Reset the textbox on addition/removal of the uploaded-files container if no prior content

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Select a document in the side-panel, you should still be able to enter text in the textbox.

## Relevant links
