### PR TITLE
feat: implement uwotm8s 1.6 ignore feature

### DIFF
--- a/django_app/oritem8.txt
+++ b/django_app/oritem8.txt
@@ -1,0 +1,2 @@
+filters
+connection

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -16,7 +16,6 @@ from django.forms.models import model_to_dict
 from django.utils import timezone
 from langchain_core.documents import Document
 from pydantic import ValidationError
-from uwotm8 import convert_american_to_british_spelling
 from websockets import ConnectionClosedError, WebSocketClientProtocol
 
 from redbox import Redbox
@@ -47,6 +46,11 @@ from redbox_app.redbox_core.models import (
     MonitorSearchRoute,
 )
 from redbox_app.redbox_core.models import AISettings as AISettingsModel
+from redbox_app.redbox_core.services import message as message_service
+
+convert_american_to_british_spelling = sync_to_async(
+    message_service.convert_american_to_british_spelling, thread_sensitive=True
+)
 
 User = get_user_model()
 OptFileSeq = Sequence[File] | None

--- a/django_app/redbox_app/redbox_core/services/message.py
+++ b/django_app/redbox_app/redbox_core/services/message.py
@@ -1,7 +1,12 @@
+import logging
 import re
+import subprocess
+import sys
 from collections.abc import Sequence
 
 from redbox_app.redbox_core.models import ChatMessage, File
+
+logger = logging.getLogger(__name__)
 
 
 def replace_ref(
@@ -67,3 +72,19 @@ def decorate_selected_files(all_files: Sequence[File], messages: Sequence[ChatMe
     for file in all_files:
         file.selected = file in selected_files
     return all_files
+
+
+def convert_american_to_british_spelling(text):
+    try:
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "uwotm8", "--ignore", "oritem8.txt"],
+            input=text,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except Exception as e:
+        logger.exception("Failed to convert text: %s", text, exc_info=e)
+        return text
+
+    return result.stdout


### PR DESCRIPTION
## Context
Update the uwotm8 package to bring in ignore list functionality.

## What

- Updated uwotm8 from 0.1.4 to 0.1.6
- Reimplement `convert_american_to_british_spelling` to be ran as a subprocess and allow an ignore list to be added
- Created oritem8.txt to store ignored words

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

See related issue below for replication steps.

Before: 
<img width="1810" height="1008" alt="image" src="https://github.com/user-attachments/assets/0411f217-c9ae-41f5-b3bb-72e5d747a2a8" />

After:
<img width="1798" height="898" alt="image" src="https://github.com/user-attachments/assets/b43499ed-c9a6-4fd3-83f6-444445ab9cfc" />


## Relevant links
https://github.com/uktrade/redbox/issues/428