### PR TITLE
Simple fix to await text_in_answer

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -526,13 +526,18 @@ class ChatConsumer(AsyncWebsocketConsumer):
                     }
 
                 await self.send_to_client("source", payload)
+
+                text_in_answer = (
+                    await convert_american_to_british_spelling(c.text_in_answer)
+                    if self.scope.get("user").uk_or_us_english
+                    else c.text_in_answer
+                )
+
                 self.citations.append(
                     (
                         file,
                         AICitation(
-                            text_in_answer=convert_american_to_british_spelling(c.text_in_answer)
-                            if self.scope.get("user").uk_or_us_english
-                            else c.text_in_answer,
+                            text_in_answer=text_in_answer,
                             sources=[s],
                         ),
                     )


### PR DESCRIPTION
## Context

Due to `convert_american_to_british_spelling` returning a coroutine, an error was thrown when producing citations due to Pydantic typing of the citation model expecting a string. 

## What

For the citation model await has been added for the American to British spelling conversion to input a string. 

## Have you written unit tests?
- [ ] Yes (add why you have not)
- [x] No


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Test that citations are correctly returned, esp. for the web search agent. 

## Relevant links
