### PR TITLE
make nodes to wait before combine evaluator question

### DIFF
--- a/redbox/redbox/graph/root.py
+++ b/redbox/redbox/graph/root.py
@@ -734,10 +734,11 @@ def build_new_route_graph(
         },
     )
     builder.add_conditional_edges("sending_task", sending_task_to_agent)
-    builder.add_edge("Internal_Retrieval_Agent", "combine_question_evaluator")
-    builder.add_edge("External_Retrieval_Agent", "combine_question_evaluator")
-    builder.add_edge("Web_Search_Agent", "combine_question_evaluator")
     builder.add_edge("Legislation_Search_Agent", "combine_question_evaluator")
+    builder.add_edge(
+        ["Internal_Retrieval_Agent", "External_Retrieval_Agent", "Web_Search_Agent", "Legislation_Search_Agent"],
+        "combine_question_evaluator",
+    )
     builder.add_edge("combine_question_evaluator", "Evaluator_Agent")
     builder.add_edge("Evaluator_Agent", "report_citations")
     builder.add_edge("report_citations", END)


### PR DESCRIPTION
## Context

Worker agents go to evaluator without waiting for other worker agents to complete their tasks, causing interrupted streaming and evaluator running more than once.

## What

- update the edge so that all worker nodes are completed before going to the evaluator

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)
use the same multi_agent tests

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No

- Test that all use cases run as expected (all route, with and without documents)
- Check that streaming response is expected (no repetition, or interruption mid stream)

## Relevant links
