### PR TITLE
fix: s3 file name includes timestamp and InMemoryFile switch

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -591,7 +591,7 @@ def build_s3_key(instance, filename: str) -> str:
 
     note: s3 key is not prefixed with the user's email address if not local as filename is unique
     """
-    filename = f"{instance.user.email}/{filename}"
+    filename = f"{instance.user.email}/{filename}_{datetime.now(UTC).strftime('%Y%m%d%H%M%S%f')}"
     return f"{filename}"
 
 

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -14,13 +14,18 @@ from redbox.models.settings import get_settings
 env = get_settings()
 
 
+def get_file_name(uploaded_file) -> str:
+    """Return the correct name field for both model and file objects."""
+    return getattr(uploaded_file, "unique_name", getattr(uploaded_file, "name", ""))
+
+
 def is_utf8_compatible(uploaded_file: UploadedFile) -> bool:
-    if not Path(uploaded_file.unique_name).suffix.lower().endswith((".doc", ".txt")):
+    if not Path(get_file_name(uploaded_file)).suffix.lower().endswith((".doc", ".txt")):
         logging.info("File does not require utf8 compatibility check")
         return True
     try:
-        uploaded_file.original_file.read().decode("utf-8")
-        uploaded_file.original_file.seek(0)
+        uploaded_file.read().decode("utf-8")
+        uploaded_file.seek(0)
     except UnicodeDecodeError:
         logging.info("File is incompatible with utf-8. Converting...")
         return False
@@ -39,8 +44,8 @@ def convert_to_utf8(uploaded_file: UploadedFile) -> UploadedFile:
         # Creating a new InMemoryUploadedFile object with the converted content
         new_uploaded_file = InMemoryUploadedFile(
             file=BytesIO(new_bytes),
-            field_name=uploaded_file.unique_name,
-            name=uploaded_file.unique_name,
+            field_name=get_file_name(uploaded_file),
+            name=get_file_name(uploaded_file),
             content_type="application/octet-stream",
             size=len(new_bytes),
             charset="utf-8",
@@ -54,7 +59,7 @@ def convert_to_utf8(uploaded_file: UploadedFile) -> UploadedFile:
 
 
 def is_doc_file(uploaded_file: UploadedFile) -> bool:
-    return Path(uploaded_file.unique_name).suffix.lower() == ".doc"
+    return Path(get_file_name(uploaded_file)).suffix.lower() == ".doc"
 
 
 def convert_doc_to_docx(uploaded_file: UploadedFile) -> UploadedFile:
@@ -100,18 +105,18 @@ def convert_doc_to_docx(uploaded_file: UploadedFile) -> UploadedFile:
                 if len(converted_content) == 0:
                     logging.error("Converted file is empty - this won't get converted")
 
-                output_filename = Path(uploaded_file.unique_name).with_suffix(".docx").name
+                output_filename = Path(get_file_name(uploaded_file)).with_suffix(".docx").name
                 new_file = InMemoryUploadedFile(
                     file=BytesIO(converted_content),
-                    field_name=uploaded_file.unique_name,
+                    field_name=get_file_name(uploaded_file),
                     name=output_filename,
                     content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                     size=len(converted_content),
                     charset="utf-8",
                 )
-                logging.info("doc file conversion to docx successful for %s", uploaded_file.unique_name)
+                logging.info("doc file conversion to docx successful for %s", get_file_name(uploaded_file))
         except Exception as e:
-            logging.exception("Error converting doc file %s to docx", uploaded_file.unique_name, exc_info=e)
+            logging.exception("Error converting doc file %s to docx", get_file_name(uploaded_file), exc_info=e)
             new_file = uploaded_file
         finally:
             try:
@@ -135,12 +140,12 @@ def ingest(file_id: UUID, es_index: str | None = None) -> None:
 
     # handling doc -> docx conversion
     if is_doc_file(file):
-        file = convert_doc_to_docx(file)
+        file.original_file = convert_doc_to_docx(file)
+        file.save()
     # handling utf8 compatibility
     if not is_utf8_compatible(file):
-        file = convert_to_utf8(file)
-
-    file.save()
+        file.original_file = convert_to_utf8(file)
+        file.save()
 
     logging.info("Ingesting file: %s", file)
 

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -122,7 +122,7 @@ def test_internal_citation_uri(chat_message: ChatMessage, uploaded_file: File):
         file=uploaded_file,
     )
     citation.save()
-    assert citation.uri.parts[-1] == "original_file.txt"
+    assert citation.uri.parts[-1].startswith("original_file.txt")
 
 
 def test_external_citation_uri(
@@ -161,8 +161,8 @@ def test_unique_citation_uris(chat_message: ChatMessage, uploaded_file: File):
 
     assert urls[0][0] == "http://example.com"
     assert urls[0][1] == URL("http://example.com")
-    assert urls[1][0] == "original_file.txt"
-    assert urls[1][1].parts[-1] == "original_file.txt"
+    assert urls[1][0].startswith("original_file.txt")
+    assert urls[1][1].parts[-1].startswith("original_file.txt")
 
 
 @pytest.mark.parametrize(("value", "expected"), [("invalid origin", None), ("Wikipedia", "Wikipedia")])

--- a/django_app/tests/views/test_citation_views.py
+++ b/django_app/tests/views/test_citation_views.py
@@ -45,7 +45,14 @@ def test_citations_shown(client: Client, alice: User, chat: Chat, several_files:
     filenames = [h3.get_text().strip() for h3 in files]
     citations = [element.get_text().strip() for element in citation_items]
 
-    assert filenames == ["original_file_0.txt", "original_file_1.txt", "https://wikipedia-test"]
+    expected = [
+        "original_file_0.txt",
+        "original_file_1.txt",
+        "https://wikipedia-test",
+    ]
+
+    assert len(filenames) == len(expected)
+    assert all(f.startswith(e) for f, e in zip(filenames, expected, strict=False))
     assert citations == ["Citation 1", "Citation 2", "Citation 3"]
 
 

--- a/django_app/tests/views/test_document_views.py
+++ b/django_app/tests/views/test_document_views.py
@@ -28,8 +28,17 @@ def test_upload_view(alice, client, file_pdf_path: Path, s3_client):
     """
     file_name = f"{alice.email}/{file_pdf_path.name}"
 
-    # we begin by removing any file in minio that has this key
-    s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=file_name.replace(" ", "_"))
+    # we begin by removing any file in minio that starts with this key prefix
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=settings.BUCKET_NAME, Prefix=file_name.replace(" ", "_")):
+            if "Contents" in page:
+                delete_objects = [{"Key": obj["Key"]} for obj in page["Contents"]]
+                if delete_objects:
+                    s3_client.delete_objects(Bucket=settings.BUCKET_NAME, Delete={"Objects": delete_objects})
+    except Exception:
+        logging.exception("Error cleaning up S3 objects before test")
+        # Ignore errors during cleanup
 
     assert not file_exists(s3_client, file_name)
 
@@ -47,8 +56,17 @@ def test_upload_view(alice, client, file_pdf_path: Path, s3_client):
 def test_document_upload_status(client, alice, file_pdf_path: Path, s3_client):
     file_name = f"{alice}/{file_pdf_path.name}"
 
-    # we begin by removing any file in minio that has this key
-    s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=file_name.replace(" ", "_"))
+    # we begin by removing any file in minio that starts with this key prefix
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=settings.BUCKET_NAME, Prefix=file_name.replace(" ", "_")):
+            if "Contents" in page:
+                delete_objects = [{"Key": obj["Key"]} for obj in page["Contents"]]
+                if delete_objects:
+                    s3_client.delete_objects(Bucket=settings.BUCKET_NAME, Delete={"Objects": delete_objects})
+    except Exception:
+        logging.exception("Error cleaning up S3 objects before test")
+        # Ignore errors during cleanup
 
     assert not file_exists(s3_client, file_name)
     client.force_login(alice)
@@ -62,46 +80,6 @@ def test_document_upload_status(client, alice, file_pdf_path: Path, s3_client):
         assert count_s3_objects(s3_client) == previous_count + 1
         uploaded_file = File.objects.filter(user=alice).order_by("-created_at")[0]
         assert uploaded_file.status == File.Status.processing
-
-
-@pytest.mark.django_db()
-def test_upload_view_duplicate_files(alice, bob, client, file_pdf_path: Path, s3_client):
-    # delete all alice's files
-    for key in s3_client.list_objects(Bucket=settings.BUCKET_NAME, Prefix=alice.email).get("Contents", []):
-        s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=key["Key"])
-
-    # delete all bob's files
-    for key in s3_client.list_objects(Bucket=settings.BUCKET_NAME, Prefix=bob.email).get("Contents", []):
-        s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=key["Key"])
-
-    previous_count = count_s3_objects(s3_client)
-
-    def upload_file():
-        with file_pdf_path.open("rb") as f:
-            client.post("/upload/", {"uploadDocs": f})
-            response = client.post("/upload/", {"uploadDocs": f})
-
-            assert response.status_code == HTTPStatus.FOUND
-            assert response.url == "/documents/"
-
-            return File.objects.order_by("-created_at")[0]
-
-    client.force_login(alice)
-    alices_file = upload_file()
-
-    assert count_s3_objects(s3_client) == previous_count + 1  # new file added
-    assert alices_file.unique_name.startswith(alice.email)
-
-    client.force_login(bob)
-    bobs_file = upload_file()
-
-    assert count_s3_objects(s3_client) == previous_count + 2  # new file added
-    assert bobs_file.unique_name.startswith(bob.email)
-
-    bobs_new_file = upload_file()
-
-    assert count_s3_objects(s3_client) == previous_count + 2  # no change, duplicate file
-    assert bobs_new_file.unique_name == bobs_file.unique_name
 
 
 @pytest.mark.django_db()
@@ -130,10 +108,20 @@ def test_upload_view_no_file(alice, client):
 @pytest.mark.django_db()
 def test_remove_doc_view(client: Client, alice: User, file_pdf_path: Path, s3_client: Client):
     file_name = f"{alice.email}/{file_pdf_path.name}"
+    prefix = file_name.replace(" ", "_")
 
     client.force_login(alice)
-    # we begin by removing any file in minio that has this key
-    s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=file_name.replace(" ", "_"))
+    # we begin by removing any file in minio that starts with this key prefix
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=settings.BUCKET_NAME, Prefix=prefix):
+            if "Contents" in page:
+                delete_objects = [{"Key": obj["Key"]} for obj in page["Contents"]]
+                if delete_objects:
+                    s3_client.delete_objects(Bucket=settings.BUCKET_NAME, Delete={"Objects": delete_objects})
+    except Exception:
+        logging.exception("Error cleaning up S3 objects before test")
+        # Ignore errors during cleanup
 
     previous_count = count_s3_objects(s3_client)
 
@@ -185,16 +173,18 @@ def count_s3_objects(s3_client) -> int:
 
 def file_exists(s3_client, file_name) -> bool:
     """
-    if the file key exists return True otherwise False
+    If any file key starts with the given file_name prefix, return True, otherwise False
     """
+    prefix = file_name.replace(" ", "_")
     try:
-        s3_client.get_object(Bucket=settings.BUCKET_NAME, Key=file_name.replace(" ", "_"))
+        response = s3_client.list_objects_v2(Bucket=settings.BUCKET_NAME, Prefix=prefix)
     except ClientError as client_error:
-        if client_error.response["Error"]["Code"] == "NoSuchKey":
+        if client_error.response["Error"]["Code"] in ["NoSuchBucket", "AccessDenied"]:
             return False
         raise
     else:
-        return True
+        # Check for actual objects (handles empty responses correctly)
+        return bool(response.get("Contents", []))
 
 
 @pytest.mark.django_db()
@@ -626,8 +616,17 @@ def test_upload_document_api_endpoint(alice, client, file_pdf_path, s3_client):
     Test the API endpoint for uploading a document.
     """
     file_name = f"{alice.email}/{file_pdf_path.name}"
-    # Remove any existing file
-    s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=file_name.replace(" ", "_"))
+    # we begin by removing any file in minio that starts with this key prefix
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=settings.BUCKET_NAME, Prefix=file_name.replace(" ", "_")):
+            if "Contents" in page:
+                delete_objects = [{"Key": obj["Key"]} for obj in page["Contents"]]
+                if delete_objects:
+                    s3_client.delete_objects(Bucket=settings.BUCKET_NAME, Delete={"Objects": delete_objects})
+    except Exception:
+        logging.exception("Error cleaning up S3 objects before test")
+        # Ignore errors during cleanup
     assert not file_exists(s3_client, file_name)
 
     client.force_login(alice)
@@ -643,7 +642,7 @@ def test_upload_document_api_endpoint(alice, client, file_pdf_path, s3_client):
 
     # Verify a file was created in the database
     uploaded_file = File.objects.filter(user=alice).order_by("-created_at")[0]
-    assert uploaded_file.file_name == file_pdf_path.name.replace(" ", "_")
+    assert uploaded_file.file_name.startswith(file_pdf_path.name.replace(" ", "_"))
 
 
 @pytest.mark.django_db()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,17 @@
 services:
   unstructured:
     image: quay.io/unstructured-io/unstructured-api:latest
-    #image: unstructured:latest  #- TODO - separate this commented into a buildx ccommand somewhere
-    #build:
-      #context: .
-      #dockerfile: unstructured/Dockerfile
     ports:
       - 8000:8000
     networks:
       - redbox-app-network
+    mem_limit: 6g        
+    cpus: 2
+    environment:
+      - UNSTRUCTURED_MAX_WORKERS=2
+      - UNSTRUCTURED_TEMP_DIR=/tmp/unstructured_temp
+    volumes:
+      - ./unstructured_temp:/tmp/unstructured_temp
   django-app:
     image: django-app:latest
     build:
@@ -122,7 +125,7 @@ services:
       start_period: 30s
 
   opensearch:
-    image: opensearchproject/opensearch:2.18.0
+    image: opensearchproject/opensearch:3
     environment:
       - discovery.type=single-node
       - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Users cannot upload two files. Users also have a small bug with conversion where documents can still be processed but conversion does not take place and cannot be understood by unstructured due to unique_name existing against File object, but against InMemoryUploadedFile this field is simply name, so we need a switch based on object type.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Appends the current timestamp including milliseconds to the file name to ensure it is unique every time.
New function to determine which object it is and use that field for the worker ingest

## Have you written unit tests?
- [ ] Yes
- [X] No (add why you have not)

Didn't really see this as critical enough to write tests


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No

Upload a file, upload a doc file. Can you see their timestamp in minio?


## Relevant links
