### PR TITLE
chore: Added AWS_PROFILE env to local env file

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,3 +2,4 @@ COLLECTION_ENDPOINT="http://admin:Opensearch2024^@localhost:9200" # pragma: allo
 MINIO_HOST = localhost
 POSTGRES_HOST = localhost
 UNSTRUCTURED_HOST = localhost
+AWS_PROFILE = redbox


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Jupyter notebooks are falling back to the `default` aws profile.
Since our platform helper changes, redbox profiles should be called `redbox`, not `default`. 
This causes "credentials not found" errors when trying to run certain notebooks. 
This change manually sets the AWS_PROFILE to `redbox` in the local env file (for now).

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Added `AWS_PROFILE = redbox` to the `.env.local.example` file for local development

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Purely config

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No


## Relevant links
