### PR TITLE
feat: Added feature flag for teams functionality

### DIFF
--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -10,6 +10,9 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.timezone import template_localtime
 from markdown_it import MarkdownIt
+from waffle import flag_is_active
+
+from redbox_app.redbox_core import flags
 
 # `js-default` setting required to sanitize inputs
 # https://markdown-it-py.readthedocs.io/en/latest/security.html
@@ -109,6 +112,8 @@ def environment(**options):
             "google_analytics_link": settings.GOOGLE_ANALYTICS_LINK,
             "google_analytics_iframe_src": settings.GOOGLE_ANALYTICS_IFRAME_SRC,
             "get_messages": messages.get_messages,
+            "flag_is_active": flag_is_active,
+            "flags": flags,
         }
     )
     return env

--- a/django_app/redbox_app/redbox_core/flags.py
+++ b/django_app/redbox_app/redbox_core/flags.py
@@ -1,0 +1,1 @@
+ENABLE_TEAMS = "enable_teams"

--- a/django_app/redbox_app/templates/settings/settings.html
+++ b/django_app/redbox_app/templates/settings/settings.html
@@ -7,18 +7,33 @@
 
     <ul class="govuk-tabs__list">
       {% for tab in tabs %}
+        {% if tab.id == "manage-teams" %}
+          {% if flag_is_active(request, flags.ENABLE_TEAMS) %}
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="#{{ tab.id }}">{{ tab.title }}</a>
+            </li>
+          {% endif %}
+        {% else %}
         <li class="govuk-tabs__list-item">
-          <a class="govuk-tabs__tab" href="#{{ tab.id }}">{{ tab.title }}</a>
-        </li>
+            <a class="govuk-tabs__tab" href="#{{ tab.id }}">{{ tab.title }}</a>
+          </li>
+        {% endif %}
       {% endfor %}
     </ul>
 
     {% for tab in tabs %}
-      <div class="govuk-tabs__panel {% if not loop.first %}govuk-tabs__panel--hidden{% endif %}" id="{{ tab.id }}">
-        {% include tab.template %}
-      </div>
+      {% if tab.id == "manage-teams" %}
+        {% if flag_is_active(request, flags.ENABLE_TEAMS) %}
+          <div class="govuk-tabs__panel {% if not loop.first %}govuk-tabs__panel--hidden{% endif %}" id="{{ tab.id }}">
+            {% include tab.template %}
+          </div>
+        {% endif %}
+      {% else %}
+        <div class="govuk-tabs__panel {% if not loop.first %}govuk-tabs__panel--hidden{% endif %}" id="{{ tab.id }}">
+          {% include tab.template %}
+        </div>
+      {% endif %}
     {% endfor %}
-
   </div>
 </div>
 {% endblock %}

--- a/django_app/redbox_app/templates/sitemap.html
+++ b/django_app/redbox_app/templates/sitemap.html
@@ -14,7 +14,7 @@
                 <li><a class="govuk-link" href="{{ url('accessibility-statement') }}">Accessibility</a></li>
                 <li><a class="govuk-link" href="{{ url('homepage') }}">Home page</a></li>
                 {% if request.user.is_authenticated %}
-                    <li><a class="govuk-link" href="{{ url('settings') }}">Settings</a></li>
+                    <li><a class="govuk-link" href="{{ url('settings') }}">Profile</a></li>
                 {% endif %}
                 <li><a class="govuk-link" href="{{ url('privacy-notice') }}">Privacy</a></li>
                 {% if not request.user.is_authenticated %}

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -40,30 +40,32 @@
             <input class="govuk-file-upload {% if errors.upload_doc %} govuk-file-upload--error{% endif %}" multiple id="upload-docs" name="uploadDocs" type="file" aria-describedby="upload-docs-notification upload-docs-filetypes {% if errors.upload_doc %} file-upload-docs-error{% endif %}">
           </div>
         </div>
-        <!-- Manage access to team or personal -->
-        <div class="govuk-form-group" id="visibility-group">
-          <label class="govuk-label" for="visibility">
-            Visibility
-          </label>
-          <div class="govuk-radios" data-module="govuk-radios">
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="visibility-individual" name="visibility" type="radio" value="INDIVIDUAL" checked>
-              <label class="govuk-label govuk-radios__label" for="visibility-individual">Individual</label>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="visibility-team" name="visibility" type="radio" value="TEAM">
-              <label class="govuk-label govuk-radios__label" for="visibility-team">Share with team</label>
+        {% if flag_is_active(request, flags.ENABLE_TEAMS) %}
+          <!-- Manage access to team or personal -->
+          <div class="govuk-form-group" id="visibility-group">
+            <label class="govuk-label" for="visibility">
+              Visibility
+            </label>
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="visibility-individual" name="visibility" type="radio" value="INDIVIDUAL" checked>
+                <label class="govuk-label govuk-radios__label" for="visibility-individual">Individual</label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="visibility-team" name="visibility" type="radio" value="TEAM">
+                <label class="govuk-label govuk-radios__label" for="visibility-team">Share with team</label>
+              </div>
             </div>
           </div>
-        </div>
 
-        <!-- Team -->
-        <div class="govuk-form-group govuk-!-display-none" id="team-group">
-          {% call(team) adaptive_select(user_teams, "team", id="team", label="Share with team (optional)") %}
-            <option value="{{ team.team.id }}">{{ team.team.team_name }}</option>
-          {% endcall %}
-          {% include "document-help-text.html" %}
-        </div>
+          <!-- Team -->
+          <div class="govuk-form-group govuk-!-display-none" id="team-group">
+            {% call(team) adaptive_select(user_teams, "team", id="team", label="Share with team (optional)") %}
+              <option value="{{ team.team.id }}">{{ team.team.team_name }}</option>
+            {% endcall %}
+            {% include "document-help-text.html" %}
+          </div>
+        {% endif %}
 
         <upload-button>
           {{ govukButton(text="Upload", prevent_double_click=True, classes="govuk-!-display-inline-block") }}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR adds a feature flag for the teams work and creates a  `flags.py` file to better track feature flags used across the system.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Feature flagged team documents/document-upload and management functionality
- Added dedicated `flags.py` file to store list of flags
- Added relevant flag methods to `jinja2.py` globals to remove unnecessary context variables

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

config change/feature-flag: will be removed eventually

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Create and set the `enable_teams` flag to true/false in the admin panel and ensure the functionality is/isn't accessible.

## Relevant links
[REDBOX-1116](https://uktrade.atlassian.net/browse/REDBOX-1116)


[REDBOX-1116]: https://uktrade.atlassian.net/browse/REDBOX-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ