### PR TITLE
Feature: user clicks skill retrieve agent names

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -130,7 +130,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         user_message_text: str = data.get("message", "")
         selected_file_uuids: Sequence[UUID] = [UUID(u) for u in data.get("selectedFiles", [])]
         activities: Sequence[str] = data.get("activities", [])
-        selected_skill_name: str | None = data.get("selectedSkill")
+        selected_skill_id: str | None = data.get("selectedSkill")
         user: User = self.scope.get("user")
 
         user_ai_settings = await AISettingsModel.objects.aget(label=user.ai_settings_id if user else "Claude 3.7")
@@ -159,14 +159,14 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
         skill_obj = None
         selected_agent_names = []
-        if selected_skill_name:
+        if selected_skill_id:
             try:
-                skill_obj = await sync_to_async(Skill.objects.get)(name=selected_skill_name)
+                skill_obj = await sync_to_async(Skill.objects.get)(id=selected_skill_id)
                 selected_agent_names = await sync_to_async(
                     lambda: list(AgentSkill.objects.filter(skill=skill_obj).values_list("agent__name", flat=True))
                 )()
             except Skill.DoesNotExist:
-                logger.warning("Selected skill '%s' not found", selected_skill_name)
+                logger.warning("Selected skill '%s' not found", selected_skill_id)
 
         user_chat_message = await self.save_user_message(
             session, user_message_text, selected_files=selected_files, activities=activities, skill=skill_obj


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
When a user click a skill on the front end, we want to retrieve a set of agent names and set it in worker_agents in AISetting which we use when we run the app.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
When a user selects a skill (from the front end), the consumers.py can now:
- Get skill details from database
- Pull relevant agent from querying agent skill table to get a list of agent names tied to the particular skill
- Feed to LLM by updating worker_agents so it only runs agents for the specific chat query
- Saves skill link so user's message gets tagged with the skill for tracking on AISettings


## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
