### PR TITLE
bug: Update url routing and fix document selection

### DIFF
--- a/django_app/frontend/src/js/services/views.js
+++ b/django_app/frontend/src/js/services/views.js
@@ -1,14 +1,17 @@
 // @ts-check
 
 import htmx from "htmx.org";
-import { getActiveChatId } from "../utils";
+import { getActiveChatId, getActiveSkillSlug } from "../utils";
 
 /**
  * Reloads chat window component
  * @param {string | null} chatId - Active chat ID
 */
-export function updateChatWindow(chatId = getActiveChatId()) {;
-    const url = chatId ? `/chats/${chatId}/chat-window/` : "/chats/chat-window/";
+export function updateChatWindow(chatId = getActiveChatId(), skill_slug = getActiveSkillSlug()) {;
+    const skill_url_fragment = skill_slug ? `/skills/${skill_slug}` : "";
+    const chat_url_fragment = chatId ? `/${chatId}` : "";
+    const url = `${skill_url_fragment}/chats${chat_url_fragment}/chat-window/`;
+
     return htmx.ajax('get', url, {
     target: '#chat-window',
     swap: 'outerHTML',
@@ -20,8 +23,11 @@ export function updateChatWindow(chatId = getActiveChatId()) {;
  * Reloads recent chats side-panel template
  * @param {string | null} chatId - Active chat ID
 */
-export function updateRecentChatHistory(chatId = getActiveChatId()) {;
-    const url = chatId ? `/chats/${chatId}/recent-chats/` : "/chats/recent-chats/";
+export function updateRecentChatHistory(chatId = getActiveChatId(), skill_slug = getActiveSkillSlug()) {;
+    const skill_url_fragment = skill_slug ? `/skills/${skill_slug}` : "";
+    const chat_url_fragment = chatId ? `/${chatId}` : "";
+    const url = `${skill_url_fragment}/chats${chat_url_fragment}/recent-chats/`;
+
     return htmx.ajax('get', url, {
       target: 'chat-history',
       swap: 'outerHTML',
@@ -33,8 +39,11 @@ export function updateRecentChatHistory(chatId = getActiveChatId()) {;
  * Reloads Your documents side-panel template
  * @param {string | null} chatId - Active chat ID
 */
-export function updateYourDocuments(chatId = getActiveChatId()) {;
-    const url = chatId ? `/documents/your-documents/${chatId}/` : "/documents/your-documents/";
+export function updateYourDocuments(chatId = getActiveChatId(), skill_slug = getActiveSkillSlug()) {;
+    const skill_url_fragment = skill_slug ? `/skills/${skill_slug}` : "";
+    const chat_url_fragment = chatId ? `/${chatId}` : "";
+    const url = `${skill_url_fragment}/documents/your-documents${chat_url_fragment}/`;
+
     return htmx.ajax('get', url, {
       target: 'document-selector',
       swap: 'outerHTML',

--- a/django_app/frontend/src/js/utils/active-skill.js
+++ b/django_app/frontend/src/js/utils/active-skill.js
@@ -8,3 +8,13 @@ export function getActiveSkillId() {
         document.querySelector('[data-skill-id]')
     )?.dataset.skillId;
 }
+
+
+/**
+ * Get active skill slug if present
+*/
+export function getActiveSkillSlug() {
+    return /** @type {HTMLElement} */ (
+        document.querySelector('[data-skill-slug]')
+    )?.dataset.skillSlug;
+}

--- a/django_app/frontend/src/redbox_design_system/rbds/styles/utils.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/styles/utils.scss
@@ -1,5 +1,5 @@
 .rbds-no-hover {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 // Can be moved to its own component if drag/drop functionality gets reused
@@ -9,7 +9,7 @@
 }
 
 .rbds-align-middle {
-    vertical-align: middle;
+  vertical-align: middle;
 }
 
 // Leave a gap for the header when navigating to page sections
@@ -21,6 +21,12 @@
   border: 1px solid var(--color-border);
 }
 
-.push-bottom {
+.rbds-push-bottom {
   margin-top: auto;
+}
+
+.rbds-text-ellipses {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -28,6 +28,7 @@ from slugify import slugify
 from yarl import URL
 
 from redbox.models.settings import get_settings
+from redbox_app.redbox_core.services import url as url_service
 from redbox_app.redbox_core.utils import get_date_group
 
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
@@ -114,10 +115,15 @@ class Skill(UUIDPrimaryKeyBase, TimeStampedModel):
         """Check to see if an info page has been created for skill"""
         return self.info_template is not None
 
-    def get_info_page_url(self):
+    @cached_property
+    def info_page_url(self):
         return reverse("skill-info", kwargs={"skill_slug": self.slug})
 
-    def get_files(self, file_type: Optional["FileSkill.FileType"] = None):
+    @cached_property
+    def chat_url(self) -> str:
+        return url_service.get_chat_url(skill_slug=self.slug)
+
+    def get_files(self, file_type: Optional["FileSkill.FileType"] = None) -> Sequence["File"]:
         file_type = file_type or FileSkill.FileType.MEMBER
         return File.objects.filter(file_skills__skill=self, file_skills__file_type=file_type)
 
@@ -937,6 +943,14 @@ class Chat(UUIDPrimaryKeyBase, TimeStampedModel, AbstractAISettings):
     @property
     def date_group(self):
         return get_date_group(self.newest_message_date)
+
+    @cached_property
+    def url(self) -> str | None:
+        """Returns the url for this chat."""
+        return url_service.get_chat_url(
+            chat_id=self.id,
+            skill_slug=self.skill.slug if self.skill else None,
+        )
 
 
 class Citation(UUIDPrimaryKeyBase, TimeStampedModel):

--- a/django_app/redbox_app/redbox_core/services/chats.py
+++ b/django_app/redbox_app/redbox_core/services/chats.py
@@ -16,6 +16,7 @@ from redbox_app.redbox_core import flags
 from redbox_app.redbox_core.models import Chat, ChatLLMBackend, ChatMessage, Skill
 from redbox_app.redbox_core.services import documents as documents_service
 from redbox_app.redbox_core.services import message as message_service
+from redbox_app.redbox_core.services import url as url_service
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,8 @@ def get_context(request: HttpRequest, chat_id: uuid.UUID | None = None, skill_sl
                     logger.info("Citation Numbering Missed")
         message.text = message_service.remove_dangling_citation(message_text=message.text)
 
+    urls = {"chat_url": url_service.get_chat_url(chat_id, skill_slug)}
+
     return {
         "skill": skill,
         "chat_id": chat_id,
@@ -117,6 +120,7 @@ def get_context(request: HttpRequest, chat_id: uuid.UUID | None = None, skill_sl
         "redbox_api_key": settings.REDBOX_API_KEY,
         "enable_dictation_flag_is_active": flag_is_active(request, flags.ENABLE_DICTATION),
         **file_context,
+        "urls": urls,
     }
 
 
@@ -128,8 +132,10 @@ def render_chats(request: HttpRequest, context: dict) -> HttpResponse:
     )
 
 
-def render_recent_chats(request: HttpRequest, active_chat_id: uuid.UUID | None = None) -> TemplateResponse:
-    context = get_context(request, active_chat_id)
+def render_recent_chats(
+    request: HttpRequest, active_chat_id: uuid.UUID | None = None, skill_slug: str | None = None
+) -> TemplateResponse:
+    context = get_context(request, active_chat_id, skill_slug)
 
     return TemplateResponse(
         request,
@@ -138,8 +144,10 @@ def render_recent_chats(request: HttpRequest, active_chat_id: uuid.UUID | None =
     )
 
 
-def render_chat_window(request: HttpRequest, active_chat_id: uuid.UUID | None = None) -> TemplateResponse:
-    context = get_context(request, active_chat_id)
+def render_chat_window(
+    request: HttpRequest, active_chat_id: uuid.UUID | None = None, skill_slug: str | None = None
+) -> TemplateResponse:
+    context = get_context(request, active_chat_id, skill_slug)
 
     return TemplateResponse(
         request,

--- a/django_app/redbox_app/redbox_core/services/documents.py
+++ b/django_app/redbox_app/redbox_core/services/documents.py
@@ -49,8 +49,8 @@ def get_file_context(request, skill: Skill | None = None):
     }
 
 
-def render_your_documents(request, active_chat_id) -> TemplateResponse:
-    context = chat_service.get_context(request, active_chat_id)
+def render_your_documents(request, active_chat_id, skill_slug: str | None = None) -> TemplateResponse:
+    context = chat_service.get_context(request, active_chat_id, skill_slug)
 
     return TemplateResponse(
         request,

--- a/django_app/redbox_app/redbox_core/services/url.py
+++ b/django_app/redbox_app/redbox_core/services/url.py
@@ -1,0 +1,14 @@
+import uuid
+
+from django.urls import reverse
+
+
+def get_chat_url(chat_id: uuid.UUID | None = None, skill_slug: str | None = None) -> str:
+    kwargs = {}
+
+    if skill_slug:
+        kwargs["skill_slug"] = skill_slug
+    if chat_id:
+        kwargs["chat_id"] = chat_id
+
+    return reverse("chats", kwargs=kwargs)

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -101,11 +101,15 @@ class DeleteChat(View):
 
 class RecentChats(View):
     @method_decorator(login_required)
-    def get(self, request: HttpRequest, active_chat_id: uuid.UUID | None = None) -> HttpResponse:
-        return chat_service.render_recent_chats(request, active_chat_id)
+    def get(
+        self, request: HttpRequest, active_chat_id: uuid.UUID | None = None, skill_slug: str | None = None
+    ) -> HttpResponse:
+        return chat_service.render_recent_chats(request, active_chat_id, skill_slug)
 
 
 class ChatWindow(View):
     @method_decorator(login_required)
-    def get(self, request: HttpRequest, active_chat_id: uuid.UUID) -> HttpResponse:
-        return chat_service.render_chat_window(request, active_chat_id)
+    def get(
+        self, request: HttpRequest, active_chat_id: uuid.UUID | None = None, skill_slug: str | None = None
+    ) -> HttpResponse:
+        return chat_service.render_chat_window(request, active_chat_id, skill_slug)

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -186,7 +186,7 @@ def remove_all_docs_view(request):
 
 @require_http_methods(["POST"])
 @login_required
-def delete_document(request, doc_id: uuid.UUID):
+def delete_document(request, doc_id: uuid.UUID, skill_slug: str | None = None):
     try:
         doc_uuid = uuid.UUID(str(doc_id))
     except ValueError:
@@ -238,13 +238,15 @@ def delete_document(request, doc_id: uuid.UUID):
             ]
         )
 
-    return documents_service.render_your_documents(request, active_chat_id)
+    return documents_service.render_your_documents(request, active_chat_id, skill_slug)
 
 
 class YourDocuments(View):
     @method_decorator(login_required)
-    def get(self, request: HttpRequest, active_chat_id: uuid.UUID | None = None) -> HttpResponse:
-        return documents_service.render_your_documents(request, active_chat_id)
+    def get(
+        self, request: HttpRequest, active_chat_id: uuid.UUID | None = None, skill_slug: str | None = None
+    ) -> HttpResponse:
+        return documents_service.render_your_documents(request, active_chat_id, skill_slug)
 
 
 class DocumentsTitleView(View):

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -16,7 +16,7 @@
     <div class="govuk-grid-column-one-quarter rbds-side-panel">
       <div class="rb-left-column-container">
         <a role="button"
-          href="{% if skill %}{{ url('skill-chats', skill.slug) }}{% else %}{{ url('chats') }}{% endif %}"
+          href="{{ urls.chat_url }}"
           id="new-chat-button"
           class="govuk-heading-s side-panel-heading side-panel-heading-button govuk-!-margin-bottom-4 govuk-!-margin-top-4">
           New chat

--- a/django_app/redbox_app/templates/citations.html
+++ b/django_app/redbox_app/templates/citations.html
@@ -8,7 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <a class="rb-back-link govuk-!-display-block" href="{{url('chats', message.chat.id)}}">
+      <a class="rb-back-link govuk-!-display-block" href="{{ message.chat.url }}">
         &lt; <span class="govuk-breadcrumbs__link">Back to chat</span>
       </a>
       <h1 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-margin-top-5">Citing the response</h1>

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -89,7 +89,7 @@
                 At Redbox, we process your personal information securely to deliver a seamless experience that will be personalised in future iterations.
                 This includes using your information to improve our services, communicate updates, and ensure secure access.
             </p>
-            <a href="https://redbox.prod.uktrade.digital/privacy-notice/" class="govuk-link push-bottom">Personal data access policy</a>
+            <a href="https://redbox.prod.uktrade.digital/privacy-notice/" class="govuk-link rbds-push-bottom">Personal data access policy</a>
         </div>
         <div class="govuk-grid-column-one-third rbds-flex-column">
 
@@ -99,7 +99,7 @@
                 You can access, update, or delete your information at any time.
             </p>
             <a href="https://workspace.trade.gov.uk/working-at-dbt/policies-and-guidance/policies/data-protection-policy/"
-               class="govuk-link push-bottom">
+               class="govuk-link rbds-push-bottom">
                 Data protection
             </a>
         </div>
@@ -111,7 +111,7 @@
                 You're always in control and can manage your preferences anytime.
             </p>
             <a href="https://workspace.trade.gov.uk/working-at-dbt/policies-and-guidance/policies/data-processing-policy/"
-               class="govuk-link push-bottom">
+               class="govuk-link rbds-push-bottom">
                 Data processing
             </a>
         </div>

--- a/django_app/redbox_app/templates/side_panel/recent_chats_list.html
+++ b/django_app/redbox_app/templates/side_panel/recent_chats_list.html
@@ -5,13 +5,7 @@
     <div id="recent-chats" class="recent-chats rbds-scrollable">
         <ul class="chat-list">
             {% for chat in chats %}
-                {% if skill %}
-                    {% set chatUrl = url('skill-chats', skill.slug, chat.id) %}
-                {% else %}
-                    {% set chatUrl = url('chats', chat.id) %}
-                {% endif %}
-
-                {{ chat_history_item(chat, chatUrl, chat_id) }}
+                {{ chat_history_item(chat, chat.url, chat_id) }}
             {% endfor %}
         </ul>
         {{ show_more('.chat-list', 'li', 3) }}

--- a/django_app/redbox_app/templates/side_panel/your_documents_list.html
+++ b/django_app/redbox_app/templates/side_panel/your_documents_list.html
@@ -16,7 +16,7 @@
                 {% call editable_text(document_edit_url, 'document-title-change', 'your-documents', file.id) %}
                     <div class="govuk-checkboxes__item item-checkbox-container display">
                         <input class="govuk-checkboxes__input" id="file-{{ file.id }}" name="file-{{ file.id }}" type="checkbox"
-                            value="{{ file.id }}" {% if file.selected %}checked{% endif %}>
+                            value="{{ file.id }}" title="{{ file.file_name }}" {% if file.selected %}checked{% endif %}>
                         <label class="item-checkbox-label govuk-checkboxes__label title-text" for="file-{{ file.id }}"
                             title="{{ file.file_name }}">
                             {{ file.file_name }}
@@ -48,8 +48,8 @@
                                                 "active_chat_id": "{{ chat_id }}",
                                                 "file_selected": "{{ file.selected }}"
                                             }'
-                                            hx-target="#document-selector"
-                                            hx-swap="outerHTML">
+                                            hx-target="closest .side-panel-item-container"
+                                            hx-swap="delete">
                                         Yes delete
                                         <span class="govuk-visually-hidden"> delete document: {{ file.file_name }}</span>
                                     </button>

--- a/django_app/redbox_app/templates/sitemap.html
+++ b/django_app/redbox_app/templates/sitemap.html
@@ -38,7 +38,7 @@
                 <ul class="govuk-list">
                     <li><a class="govuk-link" href="{{ url('chats') }}">New chat</a></li>
                     {% for chat in chat_history %}
-                        <li><a class="govuk-link" href="{{ url('chats', chat.id) }}">Existing chat: {{ chat.name }}</a></li>
+                        <li><a class="govuk-link" href="{{ chat.url) }}">Existing chat: {{ chat.name }}</a></li>
                     {% endfor %}
                 </ul>
             {% else %}

--- a/django_app/redbox_app/templates/skills/base-skill-info.html
+++ b/django_app/redbox_app/templates/skills/base-skill-info.html
@@ -26,8 +26,8 @@
 
                 {{ govukButton(
                     text = "Use " ~ skill.name | lower,
-                    href=url('skill-chats', skill.slug),
-                    classes="push-bottom rbds-w-fit"
+                    href=skill.chat_url,
+                    classes="rbds-push-bottom rbds-w-fit"
                 ) }}
             </div>
             <div class="govuk-grid-column-one-third">

--- a/django_app/redbox_app/templates/skills/skill-banner.html
+++ b/django_app/redbox_app/templates/skills/skill-banner.html
@@ -1,4 +1,4 @@
-<div class="govuk-body govuk-!-padding-top-2 govuk-!-padding-bottom-2" data-skill-id="{{ skill.id }}">
+<div class="govuk-body govuk-!-padding-top-2 govuk-!-padding-bottom-2" data-skill-id="{{ skill.id }}" data-skill-slug="{{ skill.slug }}">
     <strong class="govuk-tag govuk-tag--red rbds-w-fit">
         {{ skill.name }}
     </strong>

--- a/django_app/redbox_app/templates/skills/skill-card.html
+++ b/django_app/redbox_app/templates/skills/skill-card.html
@@ -3,10 +3,10 @@
         <h3 class="govuk-heading-s govuk-!-margin-top-5">{{ skill.name }}</h3>
         <p class="govuk-body-s">{{ skill.description }}</p>
 
-        <div class="cta-navigation push-bottom">
+        <div class="cta-navigation rbds-push-bottom">
             {% if skill.has_info_page %}
                 <p class="govuk-body-s">
-                    <a href="{{ skill.get_info_page_url() }}"
+                    <a href="{{ skill.info_page_url }}"
                         class="govuk-link">
                         View more about {{ skill.name | lower }}
                     </a>
@@ -15,7 +15,7 @@
 
             {{ govukButton(
                 text = "Use " ~ skill.name | lower,
-                href=url('skill-chats', skill.slug),
+                href=skill.chat_url,
                 classes="rbds-w-fit govuk-!-margin-bottom-0"
             ) }}
         </div>

--- a/django_app/redbox_app/templates/skills/skill-files.html
+++ b/django_app/redbox_app/templates/skills/skill-files.html
@@ -1,6 +1,6 @@
 <h3 class="govuk-heading-s govuk-!-margin-bottom-4">Documents used in this skill</h3>
 
 {% for file in skill.get_files("ADMIN") %}
-    <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-2">{{ file.file_name }}</p>
+    <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-2 rbds-text-ellipses" title="{{ file.file_name }}">{{ file.file_name }}</p>
     <div class="rbds-divider"></div>
 {% endfor %}

--- a/django_app/redbox_app/templates/skills/skills.html
+++ b/django_app/redbox_app/templates/skills/skills.html
@@ -37,7 +37,7 @@
             {{ govukButton(
                 text = "Use Redbox default",
                 href=url('chats'),
-                classes="push-bottom rbds-w-fit govuk-!-margin-bottom-0"
+                classes="rbds-push-bottom rbds-w-fit govuk-!-margin-bottom-0"
             ) }}
         </div>
 

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -81,12 +81,32 @@ team_urlpatterns = [
     path("team/create-team/", views.create_team_view, name="create-team"),
 ]
 
+skills_route_prefix = "skills/<slug:skill_slug>/"
 skills_urlpatterns = [
     path("skills/", views.SkillsView.as_view(), name="skills"),
-    path("skills/<slug:skill_slug>/", views.skill_info_page_view, name="skill-info"),
-    path("skills/<slug:skill_slug>/chats/", views.ChatsView.as_view(), name="skill-chats"),
-    path("skills/<slug:skill_slug>/chats/<uuid:chat_id>/", views.ChatsView.as_view(), name="skill-chats"),
-    path("skills/<slug:skill_slug>/documents/upload/", views.upload_document, name="skill-document-upload"),
+    path(skills_route_prefix, views.skill_info_page_view, name="skill-info"),
+    path(f"{skills_route_prefix}chats/", views.ChatsView.as_view(), name="chats"),
+    path(f"{skills_route_prefix}chats/<uuid:chat_id>/", views.ChatsView.as_view(), name="chats"),
+    path(f"{skills_route_prefix}documents/upload/", views.upload_document, name="skill-document-upload"),
+    path(
+        f"{skills_route_prefix}documents/your-documents/", views.YourDocuments.as_view(), name="your-documents-initial"
+    ),
+    path(
+        f"{skills_route_prefix}documents/your-documents/<uuid:active_chat_id>/",
+        views.YourDocuments.as_view(),
+        name="your-documents",
+    ),
+    path(f"{skills_route_prefix}chats/recent-chats/", views.RecentChats.as_view(), name="recent-chats-initial"),
+    path(
+        f"{skills_route_prefix}chats/<uuid:active_chat_id>/recent-chats/",
+        views.RecentChats.as_view(),
+        name="recent-chats",
+    ),
+    path(f"{skills_route_prefix}chats/chat-window/", views.ChatWindow.as_view(), name="chat-window-initial"),
+    path(
+        f"{skills_route_prefix}chats/<uuid:active_chat_id>/chat-window/", views.ChatWindow.as_view(), name="chat-window"
+    ),
+    path(f"{skills_route_prefix}citations/<uuid:message_id>/", views.CitationsView.as_view(), name="citations"),
 ]
 
 admin_urlpatterns = [

--- a/django_app/tests/models/test_skill_model.py
+++ b/django_app/tests/models/test_skill_model.py
@@ -86,7 +86,7 @@ def test_get_info_page_url(client: Client, alice: User, default_skill: Skill):
     client.force_login(alice)
 
     # When
-    url = default_skill.get_info_page_url()
+    url = default_skill.info_page_url
 
     # Then
     assert url == f"/skills/{default_skill.slug}/"

--- a/django_app/tests/views/test_skills_views.py
+++ b/django_app/tests/views/test_skills_views.py
@@ -37,7 +37,7 @@ def test_user_can_see_active_skill(alice: User, client: Client, default_skill: S
     client.force_login(alice)
 
     # When
-    response = client.get(reverse("skill-chats", kwargs={"skill_slug": default_skill.slug}))
+    response = client.get(reverse("chats", kwargs={"skill_slug": default_skill.slug}))
 
     # Then
     assert response.status_code == HTTPStatus.OK
@@ -83,7 +83,7 @@ def test_user_can_see_skill_chats(alice: User, client: Client, default_skill: Sk
     client.force_login(alice)
 
     # When
-    response = client.get(reverse("skill-chats", kwargs={"skill_slug": default_skill.slug, "chat_id": chat.id}))
+    response = client.get(reverse("chats", kwargs={"skill_slug": default_skill.slug, "chat_id": chat.id}))
 
     # Then
     assert response.status_code == HTTPStatus.OK
@@ -95,7 +95,7 @@ def test_user_can_see_skill_chats(alice: User, client: Client, default_skill: Sk
 def test_user_cannot_see_other_user_skill_chats(bob: User, client: Client, default_skill: Skill, chat_with_alice: Chat):
     # Given
     client.force_login(bob)
-    url = reverse("skill-chats", kwargs={"skill_slug": default_skill.slug, "chat_id": chat_with_alice.id})
+    url = reverse("chats", kwargs={"skill_slug": default_skill.slug, "chat_id": chat_with_alice.id})
 
     # When
     response = client.get(url, follow=True)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Some urls needed updating to accommodate the new skills route. This PR adds some methods and a service for urls to reduce code duplication and centralise logic. It also fixes some document selection issues for removed documents and document upload when within a skill space

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Added js helper to retrieve active skill slug
- Updated htmx js view functions to consider active skill, also updated the relevant django view methods
- Fixed your documents panel rendering documents for the non-active skill on inline document upload
- Fixed removed documents being sent as part of the chat context if they were selected prior to removal
- Added url method to chat and skill models for easier routing
- Created url.py service to centralise any current/future url logic

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Covered by existing tests

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

- Ensure document upload within a skill space doesn't cause the documents section in the side-panel to render documents for default redbox or other skills
- Ensure selected docs don't stay in the textbox when removed
- Ensure selected and removed docs, aren't still sent as part of the chat context
- Ensure urls have the appropriate structure when within a skill space vs not
- Ensure redbox still functions as expected

## Relevant links
