### PR TITLE
Update docker compose to allow opensearch dashboard access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,10 @@ services:
       - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
     networks:
       - redbox-app-network
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    restart: unless-stopped
 
 networks:
   redbox-app-network:


### PR DESCRIPTION
## What

Small update to get opensearch dashboard working locally

## Have you written unit tests?
- [ ] Yes
- [ x ] No (add why you have not)

## Are there any specific instructions on how to test this change?

- [ x ] Yes (if so provide more detail)
- [ ] No

run 'docker compose up' and go to http://0.0.0.0:5601/ to get to the dashboard. 

## Relevant links
