### PR TITLE
add default agents

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -303,10 +303,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
                     ]
                 }
             )
-        else:
-            ai_settings = ai_settings.model_copy(
-                update={"worker_agents": [agent for agent in AISettings().worker_agents if agent.default_agent]}
-            )
 
         state = RedboxState(
             request=RedboxQuery(
@@ -531,7 +527,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
         # we remove null values so that AISettings can populate them with defaults
         ai_settings = {k: v for k, v in ai_settings.items() if v not in (None, "")}
-        return AISettings.model_validate(ai_settings)
+        ai_settings = AISettings.model_validate(ai_settings)
+        return ai_settings.model_copy(
+            update={"worker_agents": [agent for agent in AISettings().worker_agents if agent.default_agent]}
+        )
 
     async def handle_text(self, response: str) -> str:
         """Handle text chunks and British spelling conversion before sending to client."""

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -31,7 +31,7 @@ class Agent(BaseModel):
     description: str = Field(description="Name of the agent", default="")
     agents_max_tokens: int = Field(description="Maximum tokens limit for the agent", default=5000)
     prompt: str = Field(description="System prompt for the agent", default="")
-    default_agent: bool = Field(description="Is this the deafult agents", default=True)
+    default_agent: bool = Field(description="Is this the default agent", default=True)
 
 
 class AISettings(BaseModel):


### PR DESCRIPTION
## Context

Default Redbox only has access to default agents.

## What

- add property to `Agen`t class to identify default agent
- update the `consumers.py` to use a set of default agents if skill is not selected

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not) covered


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No

- Set up agents skill if you have not done so
- In default Redbox, ask a question or "hi"
- Check the log, in the planner prompt it should use a set of default agent i.e. no submission agent should not be included in the prompt

## Relevant links
