### PR TITLE
remove non local for pararelle run

### DIFF
--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -507,7 +507,7 @@ def build_agent_with_loop(
 ):
     @RunnableLambda
     def _build_agent_with_loop(state: RedboxState):
-        nonlocal loop_condition
+        local_loop_condition = loop_condition
         agent_options = {agent.name: agent.name for agent in state.request.ai_settings.worker_agents}
         ConfiguredAgentTask, _ = configure_agent_task_plan(agent_options)
         parser = ClaudeParser(pydantic_object=ConfiguredAgentTask)
@@ -541,18 +541,18 @@ def build_agent_with_loop(
         success = "fail"
         num_iter = 0
         is_intermediate_step = False
-        has_loop = loop_condition is not None
+        has_loop = local_loop_condition is not None
         all_results = []
-        if loop_condition is None:
+        if local_loop_condition is None:
             # if there is no loop condition, we will run things once
             # loop condition must use only success and/or intermediate step
-            def loop_condition():
+            def local_loop_condition():
                 return True
 
             # loop_condition = lambda: True
             num_iter = max_attempt - 1
 
-        while loop_condition() and num_iter < max_attempt:
+        while local_loop_condition() and num_iter < max_attempt:
             num_iter += 1
             worker_agent = create_chain_agent(
                 system_prompt=system_prompt,


### PR DESCRIPTION
## Context

resource leaking due to using nonlocal in parallel operations

## What

- using a copy of object rather than nonlocal

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
