### PR TITLE
bugfix: add qcluster task to vscode debug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,6 +47,36 @@
                     "USE_LOCAL_ENV": "true"
                 }
             }
+        },
+        {
+            "label": "Django: QCluster",
+            "type": "shell",
+            "command": "${command:python.interpreterPath} django_app/manage.py qcluster",
+            "options": {
+                "env": {
+                    "PYTHONUNBUFFERED": "1",
+                    "USE_LOCAL_ENV": "true"
+                },
+                "cwd": "${workspaceFolder}"
+            },
+            "isBackground": true,
+            "problemMatcher": [
+                {
+                    "pattern": [
+                        {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                        }
+                    ],
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": ".",
+                        "endsPattern": "."
+                    }
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Context
To allow developers to run qcluster alongside local django debug deployment to allow file IO operations.

## What
Add a task for running qcluster locally alongside the vscode launch config. __[FYI - This does not automatically get run with Django launch config, reasoning below]__

### Getting This Working
Ideally wanted to setup qcluster in a VSCode launch config to allow breakpoints via VSCode debugger alongside other django launch config. Problem I found is in these launch configs use the same debugger proc under the hood, meaning whenever one reached a breakpoint it would kill the other debug session.

The only way I managed to get this working without conflicting debuggers was to put this qcluster deploy into its own task. I also tried embedding this task as a dependency for the existing django launch config so it all is run when clicking the Debug play button - however, this seemed to affect breakpoints on the existing django debugger.

### Current Solution:
1. Run `Full Stack Dev`
2. CMD+Shift+P (Command Palette) -> Select `Tasks: Run Task` -> Select `Django: QCluster`

_Will continue to test different options to get this more automated but worth getting this starting point in for now_

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Not relevant for local launch config.

## Are there any specific instructions on how to test this change?

- [x] Yes (if so provide more detail)
- [ ] No

1. Open locally
2. Run `Full Stack Dev` from vscode debug section
3. CMD+Shift+P (Command Palette) -> Select `Tasks: Run Task` -> Select `Django: QCluster`
4. Validate file upload/retrieval works

## Relevant links
