### PR TITLE
feature: add verbose logging to django vscode launch and tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
             "envFile": "${workspaceFolder}/.env",
             "env": {
                 "PYTHONUNBUFFERED": "1",
-                "USE_LOCAL_ENV": "true"
+                "USE_LOCAL_ENV": "true",
+                "DJANGO_LOG_FORMAT": "verbose"
             },
             "serverReadyAction": {
                 "pattern": "Starting development server",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,7 +55,8 @@
             "options": {
                 "env": {
                     "PYTHONUNBUFFERED": "1",
-                    "USE_LOCAL_ENV": "true"
+                    "USE_LOCAL_ENV": "true",
+                    "DJANGO_LOG_FORMAT": "verbose"
                 },
                 "cwd": "${workspaceFolder}"
             },


### PR DESCRIPTION
## Context
For local debugging logs are quite difficult to read in default `asim` format - this PR sets `verbose` django logging for vscode launch and tasks

ie. everything is inline:
```
2025-12-02 09:41:57,146 DEBUG base: > None
2025-12-02 09:41:57,146 DEBUG base: < 
2025-12-02 09:41:57,147 DEBUG connectionpool: Starting new HTTP connection (1): localhost:9200
```

## What
Better visibility of logs on local vscode deployments

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

No tests needed

## Are there any specific instructions on how to test this change?

- [x] Yes (if so provide more detail)
- [ ] No

Run vscode launch and see if logs display inline

## Relevant links
