### PR TITLE
Showing django tests in the test explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,18 @@
 {
     "[python]": {
         "editor.formatOnSave": true,
-        "editor.codeActionsOnSave": {
-            "source.fixAll": "explicit",
-            "source.organizeImports": "explicit"
-        },
+        "editor.codeActionsOnSave": {"source.fixAll": "explicit", "source.organizeImports": "explicit"},
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "python.analysis.autoImportCompletions": true,
-    "python.experiments.optOutFrom": [
-        "pythonTerminalEnvVarActivation"
-    ],
-    "python.testing.pytestArgs": [
-        "redbox"
-    ],
+    "python.experiments.optOutFrom": ["pythonTerminalEnvVarActivation"],
+    "python.testing.pytestArgs": ["redbox", "django_app"],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "workbench.colorCustomizations": {
         "activityBar.background": "#911212",
         "activityBar.foreground": "#fbfbec",
         "titleBar.activeBackground": "#911212",
-        "titleBar.activeForeground": "#fbfbec",
+        "titleBar.activeForeground": "#fbfbec"
     }
 }


### PR DESCRIPTION
## Context

The current settings only show unit tests in Redbox. Showing django tests in Test Explorer to help with easier testing and debugging.

## What

- adding django folder to the test setting

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [] No

Check that your Test Explorer contains tests under django_app folder e.g. `test_consumers`

## Relevant links
