### PR TITLE
Rename 'Golden Rules' Document Reference

### DIFF
--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -501,5 +501,5 @@ After evaluating all seven criteria, provide the following:
 - AVERAGE SCORE: A simple mean of the score across all 7 criteria.
 - ASSESSMENT SUMMARY: A brief statement of the overall quality of the submission. Be critical but constructive in your feedback.
 - Make reference or citations to the knowledge base information.
-    - when referenceing to template guidance, references should consistently use ‘Ministerial Submission Template Guidance’
+    - when referencing to template guidance, references should consistently use ‘Ministerial Submission Template Guidance’
 """


### PR DESCRIPTION
## Context

As a user of the Submissions Checker tool, I want clear, professional document naming so that I understand what guidance is being referenced.

## What

- updated wording in submission prompt from `golden rules` to `Ministerial Submission Template Guidance`
- revised prompt to ensure the specific wording is used for reference

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No


## Relevant links
