### PR TITLE
Bugfix/validation exception

### DIFF
--- a/redbox/redbox/graph/nodes/sends.py
+++ b/redbox/redbox/graph/nodes/sends.py
@@ -74,12 +74,6 @@ def run_tools_parallel(ai_msg, tools, state, timeout=60):
         log.warning("[run_tools_parallel] No tool calls detected. Returning agent content.")
         return ai_msg.content
     else:
-        # check if functions called by tools exist
-        tool_names = [tool.name for tool in tools]
-        for tool_call in ai_msg.tool_calls:
-            tool_name = tool_call["name"]
-            if tool_name not in tool_names:
-                log.warning(f"Function name {tool_name} in tool call does not exist")
         try:
             log.warning(
                 f"[run_tools_parallel] {len(ai_msg.tool_calls)} tool call(s) detected: "


### PR DESCRIPTION
fixing Validation exception error and index error for tabular analyser.
- Validation exception was caused by LLM not outputting an answer (only calling tools). The output was not a string and was added to state messages which cause an error in the second iteration. Added a condition to check whether output is a string before adding it to the state messages.
- Index error was cause by no tool output (empty list). Upon investigation, it was found that the LLM called the wrong function (does not exist as a tool). Changed the logic for handling no tool output and added a log warning to detect if the wrong function name was called.
