### PR TITLE
feat: Disable debug logging in prod

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -140,7 +140,7 @@
         "filename": "django_app/redbox_app/setting_enums.py",
         "hashed_secret": "f4e7a8740db0b7a0bfd8e63077261475f61fc2a6",
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 42,
         "is_secret": false
       },
       {
@@ -148,7 +148,7 @@
         "filename": "django_app/redbox_app/setting_enums.py",
         "hashed_secret": "c8771415d13205b5d1a83970daf4ee5a3e67aaa9",
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 43,
         "is_secret": false
       }
     ],
@@ -301,5 +301,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-03T14:23:45Z"
+  "generated_at": "2025-12-08T17:32:02Z"
 }

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -92,8 +92,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
     activities: ClassVar[list[RedboxActivityEvent]] = []
     route = None
     metadata: RequestMetadata = RequestMetadata()
+    env = get_settings()
+    debug = not env.is_prod
 
-    redbox = Redbox(env=get_settings(), debug=True)
+    redbox = Redbox(env=env, debug=debug)
     chat_message = None  # incrementally updating the chat stream
 
     async def _init_session(self, data, user, user_message_text, chat_backend, temperature):

--- a/django_app/redbox_app/setting_enums.py
+++ b/django_app/redbox_app/setting_enums.py
@@ -18,6 +18,10 @@ class Environment(StrEnum):
         return self is Environment.LOCAL
 
     @property
+    def is_prod(self) -> bool:
+        return self is Environment.PROD
+
+    @property
     def uses_minio(self) -> bool:
         return self.is_test
 

--- a/django_app/redbox_app/templates/skills/skill-banner.html
+++ b/django_app/redbox_app/templates/skills/skill-banner.html
@@ -4,6 +4,6 @@
     </strong>
     <a href="{{ url('skills') }}"
        class="govuk-link govuk-!-font-weight-regular govuk-link--no-visited-state govuk-!-margin-left-4">
-        Change skill
+        Change tool
     </a>
 </div>

--- a/redbox/redbox/models/settings.py
+++ b/redbox/redbox/models/settings.py
@@ -151,6 +151,7 @@ class Settings(BaseSettings):
     allow_plan_feedback: bool = os.environ.get("ALLOW_PLAN_FEEDBACK", True)
 
     is_local: bool = ENVIRONMENT.is_local
+    is_prod: bool = ENVIRONMENT.is_prod
 
     # mcp
     caddy_mcp: MCPServerSettings = MCPServerSettings(


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR disables the debug setting in the Redbox class state when in prod. Also updates the text for "Change skill" to "Change tool".

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Create is_prod setting and conditionally set debug to True when not is_prod
- Rename "Change skill" to "Change tool"


## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

No impactful logic changes

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

When a tool is selected, ensure the banner message states "Change tool" instead of "Change skill"

## Relevant links
Before
<img width="1361" height="204" alt="image" src="https://github.com/user-attachments/assets/387e9abd-5c63-4f72-bef8-52d22f7ba7ae" />
After
<img width="1042" height="170" alt="image" src="https://github.com/user-attachments/assets/79b4cd2e-0d6f-4d52-b007-5f719b68f07e" />
