### PR TITLE
bug: Fixed missing loading-message import

### DIFF
--- a/django_app/frontend/src/js/web-components/documents/upload-button.js
+++ b/django_app/frontend/src/js/web-components/documents/upload-button.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import "../loading-message.js";
+import "../../../redbox_design_system/rbds/components/loading-message.js";
 
 /** So completed docs can be added to this list */
 class UploadButton extends HTMLElement {


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR fixes a missing import for the loading-message component.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Updated loading-message import path in upload-button component.

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

config related

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No

Not really necessary but you can check uploading via the (legacy) documents page and ensure the "Uploading" message shows as expected.

## Relevant links
