### PR TITLE
fix: refactor backtick system prompt to be more precise in usage based on response type

### DIFF
--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -13,11 +13,11 @@ While you strive to provide accurate and insightful information by fully utilisi
 # Used in all prompts for information about the caller and any query context. This is a placeholder for now.
 CALLER_INFO = ""
 
-ANSWER_INSTRUCTION_SYSTEM_PROMPT = """\nInline backticks (\`) are allowed only for exact, verbatim references to identifiers present in a code block in the same response.
+ANSWER_INSTRUCTION_SYSTEM_PROMPT = """\nInline backticks (`) are allowed only for exact, verbatim references to identifiers present in a code block in the same response, or if explicitly requested to be used.
 
-No other use of the \` character is permitted.
+No other use of the ` character is permitted.
 
-The \`\`\` sequence is allowed only as a code block delimiter.\n\n"""
+The ``` sequence is allowed only as a code block delimiter, or if explicitly requested to be used.\n\n"""
 
 CHAT_SYSTEM_PROMPT = "You are tasked with providing information objectively and responding helpfully to users"
 


### PR DESCRIPTION
## Context
Based on issue https://github.com/uktrade/redbox/issues/628 and https://github.com/uktrade/redbox/issues/404

To note - this seems to have improved a lot since the initial issue submission after testing with @will-langdale, however, was still able to replicate this when explicitly asking for backticks as it found a conflict in its instructions

Summary - The LLM has instructions indicating to never use backticks, this is circumvented easily and sometimes results in bad responses due to conflicting instructions.

### Example
#### Pre-Change
`User` > write function for calculating fibonacci of n, return full code block only in backticks

`LLM` > I cannot provide the code in the format requested due to conflicting instructions about backtick usage. As Redbox@DBT, my primary function is to assist with document analysis and information retrieval rather than code generation. If you have technical documentation or programming-related documents you'd like me to analyse, please upload them and I'll be happy to help extract relevant information.

#### Post-Change
`User` > write function for calculating fibonacci of n, return full code block only in backticks

`LLM` >
```
def fibonacci(n):
    """
    Calculate the nth Fibonacci number.

    Args:
        n: The position in the Fibonacci sequence (0-indexed)

    Returns:
        The nth Fibonacci number
    """
    if n < 0:
        raise ValueError("n must be non-negative")
    elif n == 0:
        return 0
    elif n == 1:
        return 1
    else:
        a, b = 0, 1
        for _ in range(2, n + 1):
            a, b = b, a + b
        return b

# Example usage
if __name__ == "__main__":
    for i in range(10):
        print(f"fibonacci({i}) = {fibonacci(i)}")
```

## What
This PR adds clarifying instructions on where backticks should be used. Alternatively this prompt could potentially be removed entirely.

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)


## Are there any specific instructions on how to test this change?

- [x] Yes (if so provide more detail)
- [ ] No

1. Ask a question to generate code - should always return code blocks with backticks
2. Ask to explain each line of code - should always be able to use inline code for referencing

## Relevant links
