### PR TITLE
fix: updated response validation in run_tools_parallel to explicitly check is None

### DIFF
--- a/redbox/redbox/graph/nodes/sends.py
+++ b/redbox/redbox/graph/nodes/sends.py
@@ -143,7 +143,7 @@ def run_tools_parallel(ai_msg, tools, state, parallel_timeout=60, per_tool_timeo
                 try:
                     response = future.result(timeout=result_timeout)
                     log.warning(f"{log_stub} This is what I got from tool '{future_tool_name}': {response}")
-                    if response:  # if response is not None, meaning tool did not fail or timeout
+                    if response is not None:  # if response is not None, meaning tool did not fail or timeout
                         responses.append(AIMessage(response))
                     else:
                         log.warning(f"{future_tool_name} Tool has failed or timed out")


### PR DESCRIPTION
## Context
When parsing tool responses, we checked if result was "falsey" rather than strictly Nonetype - meaning validation would fail for "falsey" values (ie. empty list)

This means if search documents tool returned empty list would result in Nonetype response exception

## What
Updates response validation to check is Nonetype explicitly

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

1. Do a document query that returns no results
2. Check no errors and response that no information was found

## Relevant links
