### PR TITLE
Feat: Hide activity event message on stream start

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { hideElement } from "../../utils/dom-utils.js";
+import { hideElement, showElement } from "../../utils/dom-utils.js";
 import { LoadingMessage } from "../../../redbox_design_system/rbds/components/loading-message.js";
 
 window.addEventListener('load', () => {
@@ -271,6 +271,7 @@ export class ChatMessage extends HTMLElement {
       if (response.type === "text") {
         this.streamedContent += sanitiseText(response.data);
         this.responseContainer?.update(this.streamedContent);
+        hideElement(this.loadingElement);
       } else if (response.type === "session-id") {
         chatControllerRef.dataset.sessionId = sanitiseId(response.data);
       } else if (response.type === "source") {
@@ -354,6 +355,7 @@ export class ChatMessage extends HTMLElement {
    */
   addActivity = (message) => {
     this.loadingElement.loadingText.textContent = message;
+    showElement(this.loadingElement);
   };
 
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR hides the activity event messages when the stream response starts

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Hide activity events on text response, show on activity response


## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

frontend

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Ensure that the activity event loading messages are hidden once the stream response starts. (requires feature flag: enable_activity_events)

## Relevant links
[REDBOX-1222](https://uktrade.atlassian.net/browse/REDBOX-1222)

[REDBOX-1222]: https://uktrade.atlassian.net/browse/REDBOX-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ