### PR TITLE
fix: update unstructured service name in vscode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "docker-compose up deps",
             "type": "shell",
-            "command": "docker compose up -d unstructured db minio opensearch opensearch-dashboards",
+            "command": "docker compose up -d redbox-unstructured db minio opensearch opensearch-dashboards",
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
@@ -15,7 +15,7 @@
         {
             "label": "docker-compose down deps",
             "type": "shell",
-            "command": "docker compose down unstructured db minio opensearch opensearch-dashboards",
+            "command": "docker compose down redbox-unstructured db minio opensearch opensearch-dashboards",
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {


### PR DESCRIPTION
## Context
Unstructured service was renamed to `redbox-unstructured` in docker-compose.yml and so respective references in VSCode docker-compose tasks need to be updated to match

## What
Updates unstructured service name

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Not needed here

## Are there any specific instructions on how to test this change?

- [ ] Yes (if so provide more detail)
- [x] No


## Relevant links
