### PR TITLE
Update New Conversation button url

### DIFF
--- a/django_app/redbox_app/templates/chat/chat_actions.html
+++ b/django_app/redbox_app/templates/chat/chat_actions.html
@@ -11,7 +11,7 @@
     {% endif %}
     {{ govukButton(
         text=rbds_icon(icon_name='chat-add-on.svg') ~ "New conversation",
-        href=url('chats'),
+        href=urls.new_chat_url,
         classes="govuk-button--secondary rbds-icon-text-button"
         ) }}
 </div>


### PR DESCRIPTION
## Context

The `New Conversation` button route to the incorrect URL when in the tool.  

## What

- update the button link to the correct URL

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No

- check that when clicking the `New Conversation` button, the new chat is still inside the tool.

## Relevant links
