### PR TITLE
feat: Chats page redesign 2

### DIFF
--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -17,7 +17,7 @@ import "./web-components/chats/profile-overlay.js";
 import "./web-components/chats/exit-feedback.js";
 import "./web-components/documents/file-upload.js";
 
-import { updateChatWindow, syncUrlWithContent, updateRecentChatHistory } from "./services";
+import { syncUrlWithContent, refreshUI } from "./services";
 import { ChatHistory } from "./web-components/chats/chat-history.js";
 import { getActiveChatId } from "./utils/active-chat.js";
 
@@ -27,18 +27,23 @@ document.addEventListener("chat-response-end", (evt) => {
 
   const sessionId = event.detail.session_id;
   const isNewChat = event.detail.is_new_chat;
+  let chatId = getActiveChatId();
+  let fragmentsToRefresh = [];
 
   // If new chat or first message was stopped prematurely
-  if (isNewChat || !getActiveChatId()) {
-    // Update Recent chats section
-    updateRecentChatHistory(sessionId);
+  if (isNewChat || !chatId) {
+    // Update Conversations and cta section
+    chatId = sessionId;
+    fragmentsToRefresh.push("chat-cta");
+    fragmentsToRefresh.push("conversations");
   } else {
     // Move current chat to top of list
-    /** @type {ChatHistory} */ (document.querySelector("chat-history")).moveToTop(sessionId);
+    /** @type {ChatHistory} */ (document.querySelector("chat-history"))?.moveToTop(sessionId);
   }
 
-  // Reload chat window to fix citation references
-  updateChatWindow(sessionId);
+  // Refresh chat window to fix citation references
+  fragmentsToRefresh.push("chat-window");
+  refreshUI(fragmentsToRefresh, chatId);
 });
 
 syncUrlWithContent();

--- a/django_app/frontend/src/js/custom-events.md
+++ b/django_app/frontend/src/js/custom-events.md
@@ -8,6 +8,7 @@ Custom events are used for communication between web components. Here is a list 
 | chat-response-end    | /chats                | title: string<br/>session_id: string                    | When the stream "end" event is sent from the server                                       |
 | doc-complete         | /chats<br/>/documents | file-status: HTMLElement                                | When a document status changes to "complete"                                              |
 | selected-docs-change | /chats                | {id: string, name: string}[]                            | When a user selects or deselects a document                                               |
+| start-streaming      | /chats                | (none)                                                  | When a user submits a message                                                             |
 | stop-streaming       | /chats                | (none)                                                  | When a user presses the stop-streaming button, or an unexpected disconnection has occured |
 | chat-title-change    | /chats                | title: string<br/>session_id: string<br/>sender: string | When the chat title is changed by the user                                                |
 | file-upload-processed    | /chats                | (none) | When a individual file has finished processing processing                                                |

--- a/django_app/frontend/src/js/services/navigation.js
+++ b/django_app/frontend/src/js/services/navigation.js
@@ -15,7 +15,7 @@ export function syncUrlWithContent() {
         switch (template.id) {
 
             // Update URL whenever content is updated
-            case "recent-chats":
+            case "conversations":
             case "chat-window":
                 const selectedUUID = getSelectedChatId();
                 const currentUUID = getChatIdFromUrl();

--- a/django_app/frontend/src/js/services/views.js
+++ b/django_app/frontend/src/js/services/views.js
@@ -3,53 +3,6 @@
 import htmx from "htmx.org";
 import { getActiveChatId, getActiveToolSlug } from "../utils";
 
-/**
- * Reloads chat window component
- * @param {string | null} chatId - Active chat ID
-*/
-export function updateChatWindow(chatId = getActiveChatId(), slug = getActiveToolSlug()) {;
-    const tool_url_fragment = slug ? `/tools/${slug}` : "";
-    const chat_url_fragment = chatId ? `/${chatId}` : "";
-    const url = `${tool_url_fragment}/chats${chat_url_fragment}/chat-window/`;
-
-    return htmx.ajax('get', url, {
-    target: '#chat-window',
-    swap: 'outerHTML',
-    });
-}
-
-
-/**
- * Reloads recent chats side-panel template
- * @param {string | null} chatId - Active chat ID
-*/
-export function updateRecentChatHistory(chatId = getActiveChatId(), slug = getActiveToolSlug()) {;
-    const tool_url_fragment = slug ? `/tools/${slug}` : "";
-    const chat_url_fragment = chatId ? `/${chatId}` : "";
-    const url = `${tool_url_fragment}/chats${chat_url_fragment}/recent-chats/`;
-
-    return htmx.ajax('get', url, {
-      target: '.recent-chats',
-      swap: 'outerHTML',
-    });
-}
-
-
-/**
- * Reloads Your documents side-panel template
- * @param {string | null} chatId - Active chat ID
-*/
-export function updateYourDocuments(chatId = getActiveChatId(), slug = getActiveToolSlug()) {;
-    const tool_url_fragment = slug ? `/tools/${slug}` : "";
-    const chat_url_fragment = chatId ? `/${chatId}` : "";
-    const url = `${tool_url_fragment}/documents/your-documents${chat_url_fragment}/`;
-
-    return htmx.ajax('get', url, {
-      target: 'document-selector',
-      swap: 'outerHTML settle:0ms',
-    });
-}
-
 
 /**
  * Fetch the icon svg for a given file extension
@@ -62,4 +15,26 @@ export async function loadIcon(ext) {
     if (!response.ok) throw new Error(`Icon not found for extension: ${ext}`);
     const html = await response.text();
     return html;
+}
+
+
+/**
+ * Reloads page fragments
+ * @param {(string|any)[]} fragments - List of page section/element id's to reload
+ * @param {string | null} chatId - Active chat ID
+ * @param {string | undefined} slug - Tool slug
+*/
+export function refreshUI(fragments, chatId = getActiveChatId(), slug = getActiveToolSlug()) {
+    const params = new URLSearchParams()
+    if (chatId) params.set("chat", chatId);
+    if (slug) params.set("tool", slug);
+
+    fragments.forEach((/** @type {string | any} */ fragment) =>
+        params.append("fragments", fragment)
+    );
+
+    return htmx.ajax('get', `/ui/refresh?${params}`, {
+      target: 'body',
+      swap: 'none settle:0ms',
+    });
 }

--- a/django_app/frontend/src/js/web-components/chats/canned-prompts.js
+++ b/django_app/frontend/src/js/web-components/chats/canned-prompts.js
@@ -1,29 +1,12 @@
 // @ts-check
 
+import { hideElement } from "../../utils";
+
 class CannedPrompts extends HTMLElement {
   connectedCallback() {
-    this.securityClassification = this.getAttribute("security-classification");
-
-    let buttons = this.querySelectorAll("button");
-    buttons.forEach((button) => {
-      button.addEventListener("click", () => {
-        this.#prepopulateMessageBox(button.textContent?.trim() || "");
-      });
+    document.addEventListener("start-streaming", () => {
+      hideElement(this);
     });
-  }
-
-
-  /**
-   * @param {string} prompt
-   */
-  #prepopulateMessageBox = (prompt) => {
-    /** @type HTMLInputElement | null */
-    let chatInput = document.querySelector(".rbds-message-input");
-    if (chatInput) {
-      chatInput.textContent = prompt;
-      chatInput.focus();
-      chatInput.selectionStart = chatInput.value.length;
-    }
   }
 }
 

--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -62,6 +62,9 @@ class ChatController extends HTMLElement {
           document.querySelector("#llm-selector")
         )?.value || "";
 
+      const startStreamingEvent = new CustomEvent("start-streaming");
+      document.dispatchEvent(startStreamingEvent);
+
       aiMessage.stream(
         userText,
         selectedDocuments.map(doc => doc.id),

--- a/django_app/frontend/src/js/web-components/chats/document-selector.js
+++ b/django_app/frontend/src/js/web-components/chats/document-selector.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { updateChatWindow } from "../../services";
+import { refreshUI } from "../../services";
 
 class DocumentSelector extends HTMLElement {
   selectedDocuments = [];
@@ -90,7 +90,7 @@ class DocumentSelector extends HTMLElement {
             );
 
             if (inputElementChecked) {
-              updateChatWindow();
+              refreshUI(["chat-window"]);
               this.#sendDocSelectionChangeEvent(inputElementChecked);
               this.#bindDocumentListeners();
               this.#getSelectedDocuments();

--- a/django_app/frontend/src/js/web-components/chats/send-message.js
+++ b/django_app/frontend/src/js/web-components/chats/send-message.js
@@ -13,39 +13,40 @@ export class SendMessage extends HTMLElement {
     );
 
     hideElement(this.buttonStop);
-      this.buttonStop.addEventListener("click", () => {
-        const stopStreamingEvent = new CustomEvent("stop-streaming");
-        document.dispatchEvent(stopStreamingEvent);
-      });
 
-      document.addEventListener("chat-response-start", () => {
-        hideElement(this.buttonSend);
-        showElement(this.buttonStop);
-      });
+    this.buttonStop.addEventListener("click", () => {
+      const stopStreamingEvent = new CustomEvent("stop-streaming");
+      document.dispatchEvent(stopStreamingEvent);
+    });
 
-      document.addEventListener("chat-response-end", () => {
-        this.showSendButton();
-      });
-
-      document.addEventListener("stop-streaming", this.showSendButton);
-    }
-
-
-    /**
-     * Show Send button and hide stop send button
-     */
-    showSendButton = () => {
-      showElement(this.buttonSend);
-      hideElement(this.buttonStop);
-    };
-
-
-    /**
-     * Hide Send button and show stop send button
-     */
-    hideSendButton() {
+    document.addEventListener("chat-response-start", () => {
       hideElement(this.buttonSend);
       showElement(this.buttonStop);
-    }
+    });
+
+    document.addEventListener("chat-response-end", () => {
+      this.showSendButton();
+    });
+
+    document.addEventListener("stop-streaming", this.showSendButton);
   }
-  customElements.define("send-message", SendMessage);
+
+
+  /**
+   * Show Send button and hide stop send button
+   */
+  showSendButton = () => {
+    showElement(this.buttonSend);
+    hideElement(this.buttonStop);
+  };
+
+
+  /**
+   * Hide Send button and show stop send button
+   */
+  hideSendButton() {
+    hideElement(this.buttonSend);
+    showElement(this.buttonStop);
+  }
+}
+customElements.define("send-message", SendMessage);

--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { UploadedFiles, UploadedFile } from "../../../redbox_design_system/rbds/components";
-import { pollFileStatus, updateYourDocuments } from "../../services";
+import { pollFileStatus, refreshUI } from "../../services";
 import { getCsrfToken } from "../../utils";
 import { MessageInput } from "../chats/message-input";
 
@@ -147,7 +147,7 @@ class FileUpload extends HTMLElement {
 
             uploadedFile.status = UploadedFile.StatusTypes.COMPLETE;
 
-            updateYourDocuments().finally(() => this.#checkDocuments(id));
+            refreshUI(["your-documents"]).finally(() => this.#checkDocuments(id));
         });
 
         document.body.addEventListener("doc-error", (evt) => {
@@ -177,7 +177,7 @@ class FileUpload extends HTMLElement {
                 uploadedDocument.status = UploadedFile.StatusTypes.COMPLETE;
 
                 uploadedDocument.removeElement.addEventListener("click", () => {
-                    updateYourDocuments().finally(() => {
+                    refreshUI(["your-documents"]).finally(() => {
                         this.#uncheckDocument(uploadedDocument?.fileId);
                         this.#checkDocuments();
                     });
@@ -243,7 +243,7 @@ class FileUpload extends HTMLElement {
 
         uploadedFile.removeElement.addEventListener("click", () => {
             if (uploadedFile.status !== UploadedFile.StatusTypes.COMPLETE) return;
-            updateYourDocuments().finally(() => {
+            refreshUI(["your-documents"]).finally(() => {
                 this.#uncheckDocument(uploadedFile.fileId);
                 this.#checkDocuments();
             });
@@ -279,7 +279,7 @@ class FileUpload extends HTMLElement {
 
                 if (responseStatus === UploadedFile.StatusTypes.COMPLETE) {
                     uploadedFile.status = UploadedFile.StatusTypes.COMPLETE;
-                    updateYourDocuments().finally(() => { this.#checkDocuments(response.file_id) });
+                    refreshUI(["your-documents"]).finally(() => { this.#checkDocuments(response.file_id) });
                 }
 
                 if (responseStatus === UploadedFile.StatusTypes.PROCESSING) pollFileStatus(response.file_id);

--- a/django_app/frontend/src/redbox_design_system/rbds/components/card.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/components/card.scss
@@ -7,11 +7,12 @@
   &--no-border {
     border: none;
   }
+  border-radius: var(--border-radius);
 }
 
 /* Card variants */
 .rbds-card--block {
-  max-height: 204px;
+  max-height: 230px;
 }
 
 // .rbds-card--conversations {

--- a/django_app/frontend/src/redbox_design_system/rbds/components/chat-message.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/components/chat-message.scss
@@ -30,7 +30,5 @@ rbds-chat-message {
 }
 
 .rbds-chat-message__container {
-  // margin-top: -1rem;
-  padding-bottom: 32px;
   gap: var(--chat-message-gap);
 }

--- a/django_app/frontend/src/redbox_design_system/rbds/components/chat-title.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/components/chat-title.scss
@@ -1,7 +1,5 @@
 .rbds-chat-title {
-  margin-top: 1rem;
   display: block;
-  margin-bottom: var(--chat-message-gap);
   justify-content: space-between;
 
 }
@@ -29,4 +27,5 @@
 .rbds-chat-title__actions {
   display: flex;
   gap: 15px;
+  min-width: fit-content;
 }

--- a/django_app/frontend/src/redbox_design_system/rbds/components/message-input.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/components/message-input.scss
@@ -1,6 +1,8 @@
 rbds-message-input {
-    --input-line-height: 1.25rem;
-    --input-min-height: calc(var(--input-line-height) * 5);
+    --input-font-size: var(--font-size-s);
+    // --input-line-height-real: 25px;
+    --input-expanded-height: 130px; //calc(calc(var(--input-line-height-real) * 3) + 0px);
+    --input-expanded-border-bottom: 30px;
 
     [contentEditable=true]:empty:not(:focus):before {
         content: attr(data-text)
@@ -12,28 +14,33 @@ rbds-message-input {
         font-size: 16px;
         font-size: 1rem;
         margin-bottom: 0;
-        padding: 4px;
-        font-family: var(--font-family-primary);
 
-        padding-right: 20px;//120px;
-        padding-bottom: 40px;
+        font-family: var(--font-family-primary);
+        background-color: var(--color-background-white);
+        padding-top: 7.5px;
+        padding-left: 10px;
+        padding-right: 10px;
+        padding-bottom: 7.5px;
+        line-height: var(--input-line-height);
 
         &:focus {
             outline: 4px solid #fd0;
             outline-offset: 0;
             box-shadow: inset 0 0 0 2px;
-            min-height: var(--input-min-height);
+            min-height: var(--input-expanded-height);
+            padding-bottom: var(--input-expanded-border-bottom);
         }
 
         &.rbds-message-input__expanded {
-            min-height: var(--input-min-height);
+            min-height: var(--input-expanded-height);
+            padding-bottom: var(--input-expanded-border-bottom);
         }
     }
 
     .rbds-message-input__actions {
         position: absolute;
-        right: 10px;
-        bottom: 10px;
+        right: 7.5px;
+        bottom: 7.5px;
         display: flex;
         gap: 10px;
     }

--- a/django_app/frontend/src/redbox_design_system/rbds/components/side-panel.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/components/side-panel.scss
@@ -1,7 +1,7 @@
 .rbds-side-panel {
   background-color: var(--color-background-light-blue);
   padding-left: 15px;
-  padding-right: 30px;
+  padding-right: 25px;
 
   --color-side-panel-text: var(--color-text);
   --color-side-panel-link-text: var(--color-link-text);

--- a/django_app/frontend/src/redbox_design_system/rbds/elements/icon-button.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/elements/icon-button.scss
@@ -19,6 +19,13 @@
   &--focused {
     @include govuk-focused-text;
   }
+
+  &--active {
+    @include govuk-focused-text;
+
+    background-color: transparent;
+    box-shadow: inset 0 0 0 1px var(--color-focus);
+  }
 }
 
 .rbds-icon-text-button {

--- a/django_app/frontend/src/redbox_design_system/rbds/layouts/card.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/layouts/card.scss
@@ -6,6 +6,10 @@
     margin-right: 0;
 }
 
+.rbds-card-grid--2-col > .rbds-card {
+    flex: 0 0 calc(50% - var(--card-gap));
+}
+
 .rbds-card-grid--3-col > .rbds-card {
     flex: 0 0 calc(33.333% - var(--card-gap));
 }

--- a/django_app/frontend/src/redbox_design_system/rbds/layouts/chat.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/layouts/chat.scss
@@ -1,37 +1,92 @@
 .rbds-chat-window {
-    width: var(--screen-size-xl);
+    width: var(--screen-width-xl);
     max-width: 100%;
     min-height: calc(100vh);
     flex: 1;
     display: flex;
     align-items: stretch;
-    // gap: 55px;
 }
 
 .rbds-chat-cta {
-    --cta-container-height: 95px;
+    --cta-container-height: 15px;
 
     width: var(--screen-width-xl);
     height: var(--cta-container-height);
-    display: grid;
-    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    padding-top: 20px;
+    padding-bottom: 60px;
+    margin-bottom: 10px;
 
-    &--active {
-        display: block;
+    position: sticky;
+    top: 0;
+    background-color: var(--color-background-white);
+    z-index: 200;
+
+    &--centered {
+        .rbds-chat-cta__row--top {
+            justify-content: center;
+        }
+    }
+
+    &__row {
+        display: flex;
+        align-items: center;
+        width: 100%;
+    }
+
+    &__row--top {
         justify-content: space-between;
+    }
+
+    &__row--bottom {
+        padding-top: 10px;
+    }
+
+    &__left {
+        display: flex;
+    }
+
+    &__row {
+        display: flex;
+        align-items: center;
+        margin-left: auto;
     }
 }
 
 .rbds-chat-interaction {
-    --interaction-container-height: 110px;
+    --interaction-container-height: 30px;
+    --interaction-container-width: var(--screen-width-xl);
 
-
-    width: var(--screen-width-xl);
-    height: var(--interaction-container-height);
-    display: grid;
-    justify-content: center;
-
-    position: fixed;
+    position: sticky;
     bottom: 0;
+    background-color: var(--color-background-white);
     background-color: white;
+    z-index: 200;
+
+    width: var(--interaction-container-width);
+    min-height: var(--interaction-container-height);
+
+    padding-top: 30px;
+    padding-bottom: 30px;
+    padding-left: 10px;
+    padding-right: 10px;
+    // display: flex;
+    // justify-content: center;
+
+    &__inner {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+
+        max-height: 200px;
+        // overflow: hidden;
+
+        // position: sticky;
+        // top: 0;
+        // z-index: 100;
+        // bottom: 20px;
+        // padding-top: 7.5px;
+        // width:  100%;
+    }
 }

--- a/django_app/frontend/src/redbox_design_system/rbds/styles/chat-styles.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/styles/chat-styles.scss
@@ -102,7 +102,7 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   scroll-margin-bottom: 16rem;
   padding-right: 0;
 }
-main:has(.govuk-inset-text) .chat-options {
+main:has(.redbox-message-container) .chat-options {
   display: none;
 }
 @media (min-width: 641px) {
@@ -346,6 +346,7 @@ main:has(.iai-chat-bubble[data-role="ai"]) .exit-feedback {
   z-index: 100;
   bottom: 20px;
   padding-top: 7.5px;
+  width: 100%;
 }
 
 .redbox-message-route {

--- a/django_app/frontend/src/variables.scss
+++ b/django_app/frontend/src/variables.scss
@@ -82,6 +82,7 @@
   // --color-icon-light-foreground-secondary: var(--dbt-black);
   --color-icon-success: var(--redbox-green);
   --color-file-icon: var(--redbox-black);
+  --color-focus: var(--gds-yellow);
 
   // Typography
   --font-family-primary: Arial;

--- a/django_app/redbox_app/redbox_core/services/chats.py
+++ b/django_app/redbox_app/redbox_core/services/chats.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
-from django.template.response import TemplateResponse
 from waffle import flag_is_active
 from yarl import URL
 
@@ -135,28 +134,4 @@ def render_chats(request: HttpRequest, context: dict) -> HttpResponse:
         request,
         template_name="chats.html",
         context=context,
-    )
-
-
-def render_recent_chats(
-    request: HttpRequest, active_chat_id: UUID | None = None, slug: str | None = None
-) -> TemplateResponse:
-    context = get_context(request, active_chat_id, slug)
-
-    return TemplateResponse(
-        request,
-        "side_panel/conversations.html",
-        context,
-    )
-
-
-def render_chat_window(
-    request: HttpRequest, active_chat_id: UUID | None = None, slug: str | None = None
-) -> TemplateResponse:
-    context = get_context(request, active_chat_id, slug)
-
-    return TemplateResponse(
-        request,
-        "chat/chat_window.html",
-        context,
     )

--- a/django_app/redbox_app/redbox_core/services/documents.py
+++ b/django_app/redbox_app/redbox_core/services/documents.py
@@ -61,7 +61,7 @@ def render_your_documents(request, active_chat_id, slug: str | None = None) -> T
 
     return TemplateResponse(
         request,
-        "side_panel/your_documents_list.html",
+        "side_panel/your_documents.html",
         context,
     )
 

--- a/django_app/redbox_app/redbox_core/types.py
+++ b/django_app/redbox_app/redbox_core/types.py
@@ -60,3 +60,29 @@ class TabRegistry:
 
     def get(self, key: str, default=None):
         return self._lookup.get(key, default)
+
+
+@dataclass(frozen=True)
+class UIFragment:
+    id: str
+    template: str
+
+
+FRAGMENTS = {
+    "chat-window": UIFragment(
+        id="chat-window",
+        template="chat/chat_window.html",
+    ),
+    "chat-cta": UIFragment(
+        id="chat-cta",
+        template="chat/cta.html",
+    ),
+    "conversations": UIFragment(
+        id="conversations",
+        template="side_panel/conversations.html",
+    ),
+    "your-documents": UIFragment(
+        id="your-documents",
+        template="side_panel/your_documents.html",
+    ),
+}

--- a/django_app/redbox_app/redbox_core/utils.py
+++ b/django_app/redbox_app/redbox_core/utils.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date
 
 from django import forms
@@ -22,7 +23,7 @@ def render_with_oob(templates: list[RenderTemplateItem]) -> HttpResponse:
     Using HTMX Out of bounds swap method.
 
     Args:
-        templates (List[RenderTemplateItem]): A list of dicts like:
+        templates (List[RenderTemplateItem]): A list of objects like:
             {
                 "template": str,
                 "context": dict,
@@ -74,3 +75,12 @@ def resolve_instance(value, model, lookup="pk", raise_404=False):
             raise Http404(msg) from err
         msg = f"Cannot resolve {model.__name__} from value: {lookup}='{value}'"
         raise ValueError(msg) from err
+
+
+def parse_uuid(value: str | None) -> uuid.UUID | None:
+    if not value or value == "None":
+        return None
+    try:
+        return uuid.UUID(value)
+    except (ValueError, TypeError):
+        return None

--- a/django_app/redbox_app/redbox_core/views/__init__.py
+++ b/django_app/redbox_app/redbox_core/views/__init__.py
@@ -32,6 +32,7 @@ from redbox_app.redbox_core.views.file_views import (
 )
 from redbox_app.redbox_core.views.info_views import accessibility_statement_view, privacy_notice_view, support_view
 from redbox_app.redbox_core.views.misc_views import (
+    RefreshFragmentsView,
     SecurityTxtRedirectView,
     faq_view,
     health,
@@ -64,6 +65,7 @@ __all__ = [
     "DocumentsTitleView",
     "RatingsView",
     "RecentChats",
+    "RefreshFragmentsView",
     "SecurityTxtRedirectView",
     "SettingsView",
     "Signup1",

--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -90,7 +90,8 @@ class DeleteChat(View):
             return render_with_oob(
                 [
                     {"template": "side_panel/conversations.html", "context": context, "request": request},
-                    {"template": "side_panel/your_documents_list.html", "context": oob_context, "request": request},
+                    {"template": "side_panel/your_documents.html", "context": oob_context, "request": request},
+                    {"template": "chat/cta.html", "context": oob_context, "request": request},
                     {"template": "chat/chat_window.html", "context": oob_context, "request": request},
                 ]
             )
@@ -111,3 +112,11 @@ class ChatWindow(View):
         self, request: HttpRequest, active_chat_id: uuid.UUID | None = None, slug: str | None = None
     ) -> HttpResponse:
         return chat_service.render_chat_window(request, active_chat_id, slug)
+
+
+class ChatCta(View):
+    @method_decorator(login_required)
+    def get(
+        self, request: HttpRequest, active_chat_id: uuid.UUID | None = None, slug: str | None = None
+    ) -> HttpResponse:
+        return chat_service.render_cta(request, active_chat_id, slug)

--- a/django_app/redbox_app/redbox_core/views/document_views.py
+++ b/django_app/redbox_app/redbox_core/views/document_views.py
@@ -230,7 +230,7 @@ def delete_document(request, doc_id: uuid.UUID, slug: str | None = None):
 
         return render_with_oob(
             [
-                {"template": "side_panel/your_documents_list.html", "context": context, "request": request},
+                {"template": "side_panel/your_documents.html", "context": context, "request": request},
                 {"template": "chat/chat_window.html", "context": oob_context, "request": request},
             ]
         )

--- a/django_app/redbox_app/redbox_core/views/misc_views.py
+++ b/django_app/redbox_app/redbox_core/views/misc_views.py
@@ -2,12 +2,17 @@ import logging
 from http import HTTPStatus
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
+from django.utils.decorators import method_decorator
+from django.views import View
 from django.views.decorators.http import require_http_methods
 from django.views.generic.base import RedirectView
 
 from redbox_app.redbox_core.services import chats as chat_service
+from redbox_app.redbox_core.types import FRAGMENTS, RenderTemplateItem
+from redbox_app.redbox_core.utils import parse_uuid, render_with_oob
 
 logger = logging.getLogger(__name__)
 
@@ -51,3 +56,32 @@ def faq_view(request):
         template_name="faq.html",
         context=chat_service.get_context(request),
     )
+
+
+class RefreshFragmentsView(View):
+    @method_decorator(login_required)
+    def get(self, request: HttpRequest) -> HttpResponse:
+        fragments = request.GET.getlist("fragments")
+        active_chat_id = parse_uuid(request.GET.get("chat"))
+        slug = request.GET.get("tool")
+
+        context = chat_service.get_context(request, active_chat_id, slug)
+        context["oob"] = True
+
+        renders: list[RenderTemplateItem] = []
+
+        for fragment_id in fragments:
+            fragment = FRAGMENTS.get(fragment_id)
+
+            if not fragment:
+                continue
+
+            renders.append(
+                RenderTemplateItem(
+                    template=fragment.template,
+                    context=context,
+                    request=request,
+                )
+            )
+
+        return render_with_oob(renders)

--- a/django_app/redbox_app/templates/chat/chat_actions.html
+++ b/django_app/redbox_app/templates/chat/chat_actions.html
@@ -2,16 +2,16 @@
 {% from "macros/govuk-button.html" import govukButton %}
 
 <div class="rbds-chat-title__actions">
-    {% if promoted_tool %}
+    {% if promoted_tool and not tool %}
         {{ govukButton(
             text="Try " ~ promoted_tool.name,
             href=promoted_tool.chat_url,
-            classes="govuk-button--secondary rbds-flex-align-center"
+            classes="govuk-button--secondary govuk-!-margin-0 rbds-flex-align-center"
             ) }}
     {% endif %}
     {{ govukButton(
         text=rbds_icon(icon_name='chat-add-on.svg') ~ "New conversation",
-        href=url('chats'),
-        classes="govuk-button--secondary rbds-icon-text-button"
+        href=urls.new_chat_url,
+        classes="govuk-button--secondary govuk-!-margin-0 rbds-icon-text-button"
         ) }}
 </div>

--- a/django_app/redbox_app/templates/chat/chat_title.html
+++ b/django_app/redbox_app/templates/chat/chat_title.html
@@ -32,5 +32,4 @@
             <h2 class="rbds-chat-title__heading govuk-visually-hidden" hidden>Current Chat</h2>
         </div>
     {% endif %}
-    {% include "chat/chat_actions.html" %}
 </div>

--- a/django_app/redbox_app/templates/chat/chat_window.html
+++ b/django_app/redbox_app/templates/chat/chat_window.html
@@ -3,16 +3,10 @@
 {% from "macros/govuk-warning.html" import govuk_warning %}
 {% from "macros/icon.html" import rbds_icon %}
 
-<div id="chat-window" name="swapped" class="govuk-grid-column-three-quarters rbds-chat-window rbds-flex-column" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
-    {% if tool %}{% include "tools/tool-banner.html" %}{% endif %}
-
-    <div class="rbds-chat-cta {% if current_chat %}rbds-chat-cta--active{% endif %}">
-        {% include "chat/chat_title.html" %}
-    </div>
-
+<div id="chat-window" class="rbds-chat-window" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
     {% if not messages %}
         <canned-prompts class="chat-options govuk-!-padding-top-5 govuk-!-padding-bottom-1" security-classification="{{ security }}">
-            <h3 class="govuk-heading-s">Hello, <span class="rbds-text--product">{{ productName }}</span> can help you analyse your documents.</h3>
+            <h3 class="govuk-heading-s">Hello, <span class="rbds-text--product">{{ product_name(request) }}</span> can help you analyse your documents.</h3>
         </canned-prompts>
     {% endif %}
 
@@ -39,62 +33,5 @@
             {% if chat_id %}<input type="hidden" name="session-id" value="{{ chat_id }}" />{% endif %}
 
         </chat-controller>
-    </div>
-    <div class="chat-input__input-container">
-        <rbds-message-input>
-            <div class="govuk-textarea rbds-message-input rbds-border {% if not messages %}rbds-message-input__expanded {% endif %}rbds-drop-zone" id="message" name="message" contenteditable="true" role="textbox"
-                aria-multiline="true" data-text="Type your message here..."></div>
-                <div class="rbds-message-input__actions">
-                    <!-- Upload Button -->
-                    <file-upload upload-url="{{ urls.upload_url }}">
-                        <input class="govuk-file-upload govuk-!-display-none" multiple id="upload-docs" name="uploadDocs" type="file" aria-describedby="upload-docs-notification upload-docs-filetypes">
-                        {{ govukButton(
-                            text=rbds_icon(icon_name="attach-file.svg", icon_classes=""),
-                            classes="upload-button govuk-button--secondary rbds-icon-button",
-                            id="upload-button"
-                        ) }}
-                    </file-upload>
-
-                    <!-- Dictate and Send Buttons -->
-                    {% if enable_dictation_flag_is_active %}
-                        <send-message-with-dictation class="chat-actions-container" data-api-key="{{ redbox_api_key }}">
-                            <button type="submit"
-                                class="govuk-button govuk-button--secondary rbds-icon-button dictate-button"
-                                data-module="govuk-button">
-                                {{ rbds_icon(icon_name="mic.svg", icon_classes="") }}
-                            </button>
-
-                            {{ govukButton(
-                            text=rbds_icon(icon_name="mic.svg", icon_classes=""),
-                            classes="govuk-button--secondary rbds-icon-button rbds-icon-button--focused govuk-!-display-none",
-                            dont_submit=True
-                            ) }}
-
-                            {{ govukButton(
-                            text=rbds_icon(icon_name="send.svg", icon_classes="success"),
-                            classes="send-button rbds-icon-button"
-                            ) }}
-
-                            {{ govukButton(
-                            text=rbds_icon(icon_name="send.svg", icon_classes="success"),
-                            classes="rbds-icon-button rbds-icon-button--focused govuk-!-display-none"
-                            ) }}
-                        </send-message-with-dictation>
-                    {% else %}
-                        <send-message>
-                            {{ govukButton(
-                            text=rbds_icon(icon_name="send.svg", icon_classes="success"),
-                            classes="send-button rbds-icon-button"
-                            ) }}
-                            <span class="govuk-visually-hidden">Send Message</span>
-
-                            {{ govukButton(
-                            text="Stop",
-                            classes="govuk-!-display-none"
-                            ) }}
-                        </send-message>
-                    {% endif %}
-                </div>
-        </rbds-message-input>
     </div>
 </div>

--- a/django_app/redbox_app/templates/chat/cta.html
+++ b/django_app/redbox_app/templates/chat/cta.html
@@ -1,0 +1,20 @@
+<div id="chat-cta" class="rbds-chat-cta {% if not tool and not current_chat %}rbds-chat-cta--centered{% endif %}" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
+    <div class="rbds-chat-cta__row rbds-chat-cta__row--top">
+        <div class="rbds-chat-cta__left">
+            {% if tool %}
+            {% include "tools/tool-banner.html" %}
+            {% elif current_chat %}
+            {% include "chat/chat_title.html" %}
+            {% endif %}
+        </div>
+        <div class="rbds-chat-cta__right">
+            {% include "chat/chat_actions.html" %}
+        </div>
+    </div>
+
+    {% if tool and current_chat %}
+    <div class="rbds-chat-cta__row rbds-chat-cta__row--bottom">
+        {% include "chat/chat_title.html" %}
+    </div>
+    {% endif %}
+</div>

--- a/django_app/redbox_app/templates/chat/message_input.html
+++ b/django_app/redbox_app/templates/chat/message_input.html
@@ -1,0 +1,68 @@
+{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/icon.html" import rbds_icon %}
+
+<div class="rbds-chat-interaction">
+    <div class="rbds-chat-interaction__inner">
+        <form id="chats-form" class="js-message-input" action="/submit" method="post">
+            <rbds-message-input>
+                <div class="govuk-textarea rbds-message-input rbds-border {% if not messages %}rbds-message-input__expanded {% endif %}rbds-drop-zone"
+                    id="message" name="message" contenteditable="true" role="textbox" aria-multiline="true"
+                    data-text="Type your message here..."></div>
+                <div class="rbds-message-input__actions">
+                    <!-- Upload Button -->
+                    <file-upload upload-url="{{ urls.upload_url }}">
+                        <input class="govuk-file-upload govuk-!-display-none" multiple id="upload-docs" name="uploadDocs"
+                            type="file" aria-describedby="upload-docs-notification upload-docs-filetypes">
+                        {{ govukButton(
+                        text=rbds_icon(icon_name="attach-file.svg", icon_classes=""),
+                        classes="upload-button govuk-button--secondary rbds-icon-button",
+                        id="upload-button"
+                        ) }}
+                    </file-upload>
+
+                    <!-- Dictate and Send Buttons -->
+                    {% if enable_dictation_flag_is_active %}
+                    <send-message-with-dictation class="chat-actions-container" data-api-key="{{ redbox_api_key }}">
+                        <button type="submit" class="govuk-button govuk-button--secondary rbds-icon-button dictate-button"
+                            data-module="govuk-button">
+                            {{ rbds_icon(icon_name="mic.svg", icon_classes="") }}
+                        </button>
+
+                        {{ govukButton(
+                        text=rbds_icon(icon_name="mic.svg", icon_classes=""),
+                        classes="govuk-button--secondary rbds-icon-button rbds-icon-button--active govuk-!-display-none",
+                        dont_submit=True
+                        ) }}
+
+                        {{ govukButton(
+                        text=rbds_icon(icon_name="send.svg", icon_classes="success"),
+                        classes="send-button rbds-icon-button"
+                        ) }}
+
+                        {{ govukButton(
+                        text=rbds_icon(icon_name="send.svg", icon_classes="success"),
+                        classes="rbds-icon-button rbds-icon-button--active govuk-!-display-none"
+                        ) }}
+                    </send-message-with-dictation>
+                    {% else %}
+                    <send-message>
+                        {{ govukButton(
+                        text=rbds_icon(icon_name="send.svg", icon_classes="success"),
+                        classes="send-button rbds-icon-button"
+                        ) }}
+                        <span class="govuk-visually-hidden">Send Message</span>
+
+                        {{ govukButton(
+                        text=rbds_icon(icon_name="send.svg", icon_classes="success"),
+                        classes="rbds-icon-button rbds-icon-button--active govuk-!-display-none"
+                        ) }}
+                    </send-message>
+                    {% endif %}
+                </div>
+            </rbds-message-input>
+
+            {% if chat_id %}<input type="hidden" name="session-id" value="{{ chat_id }}" />{% endif %}
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
+        </form>
+    </div>
+</div>

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -12,13 +12,11 @@
 {% endif %}
 #}
 
-<div class="rbds-page-content--xl">
-  <form id="chats-form" class="govuk-width-container rbds-width-container rbds-chat-layout js-message-input" action="/submit" method="post">
-    {% include "chat/chat_window.html" %}
-  </form>
+<div class="govuk-width-container rbds-width-container rbds-page-content--xl">
+  {% include "chat/cta.html" %}
+  {% include "chat/chat_window.html" %}
+  {% include "chat/message_input.html" %}
   <exit-feedback class="exit-feedback" data-chatid="{{ current_chat.id }}" data-csrf="{{ csrf_token }}"></exit-feedback>
-
-  <div class="rbds-chat-interaction"></div>
 </div>
 
 {# Templates #}

--- a/django_app/redbox_app/templates/citations.html
+++ b/django_app/redbox_app/templates/citations.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<div class="govuk-width-container rbds-width-container">
+<div class="govuk-width-container rbds-width-container rbds-page-content--xl govuk-!-margin-top-3">
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/django_app/redbox_app/templates/macros/chat-history-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-history-macros.html
@@ -3,16 +3,16 @@
 {% from "macros/icon.html" import rbds_icon %}
 
 {% macro chat_history_item (chat, link, active_chat_id) %}
-    <li class="side-panel-item-container rbds-list-row {% if chat.id == active_chat_id %}rbds-list-row--selected {% endif %}govuk-!-display-none" id="chat-{{ chat.id }}" data-chatid="{{ chat.id }}">
+    <li class="rbds-list-row {% if chat.id == active_chat_id %}rbds-list-row--selected {% endif %}govuk-!-display-none" id="chat-{{ chat.id }}" data-chatid="{{ chat.id }}">
         {% set chat_edit_url = url('chat-titles', chat.id) %}
-        {% call editable_text(chat_edit_url, 'chat-title-change', 'recent-chats', chat.id) %}
+        {% call editable_text(chat_edit_url, 'chat-title-change', 'conversations', chat.id) %}
             <div class="chat-list-item rbds-card__item {% if chat.id == active_chat_id %}selected{% endif %}" data-chatid="{{ chat.id }}">
                 <span class="item-text-container">
                     <a class="item-link govuk-link govuk-link--no-visited-state govuk-link--no-underline display title-text"
                     href="{{ link }}" {% if chat.id == active_chat_id %}aria-current="page"{% endif %} title="{{ chat.name }}">
                         {{ chat.name }}
                     </a>
-                    <div class="item-text-input govuk-!-display-none edit-input-wrapper">
+                    <div class="govuk-!-display-none edit-input-wrapper">
                         <label class="govuk-visually-hidden" for="chat-title-text-input-{{ chat.id }}">Chat title</label>
                         <input class="chat-title-text-input edit-input" type="text" id="chat-title-text-input-{{ chat.id }}"/>
                     </div>

--- a/django_app/redbox_app/templates/side_panel/conversations.html
+++ b/django_app/redbox_app/templates/side_panel/conversations.html
@@ -2,7 +2,7 @@
 {% from "rbds/components/show-more.html" import show_more %}
 {% from "macros/icon.html" import rbds_icon %}
 
-<section class="recent-chats rbds-card rbds-card--no-border rbds-card--block rbds-scrollable" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
+<section id="conversations" class="rbds-card rbds-card--no-border rbds-card--block rbds-scrollable" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
     <div class="rbds-card__header">
         {{ rbds_icon(icon_name="chat.svg") }}
         <h3 class="side-panel-heading__text">Conversations</h3>
@@ -10,15 +10,13 @@
 
     <div class="rbds-card__content">
         <chat-history class="rbds-full-width">
-            <div id="recent-chats" class="recent-chats">
-                <ul class="chat-list rbds-card__list">
-                    {% for chat in chats %}
-                        {{ chat_history_item(chat, chat.url, chat_id) }}
-                    {% endfor %}
-                </ul>
-                <div class="rbds-card__item">
-                    {{ show_more('.chat-list', 'li', 5) }}
-                </div>
+            <ul class="chat-list rbds-card__list">
+                {% for chat in chats %}
+                    {{ chat_history_item(chat, chat.url, chat_id) }}
+                {% endfor %}
+            </ul>
+            <div class="rbds-card__item">
+                {{ show_more('.chat-list', 'li', 5) }}
             </div>
         </chat-history>
     </div>

--- a/django_app/redbox_app/templates/side_panel/menu.html
+++ b/django_app/redbox_app/templates/side_panel/menu.html
@@ -1,7 +1,7 @@
 {% from "macros/chat-history-macros.html" import chat_history_item %}
 {% from "rbds/components/show-more.html" import show_more %}
 
-<section class="recent-chats rbds-card rbds-card--no-border rbds-card--block rbds-scrollable">
+<section class="rbds-card rbds-card--no-border rbds-card--block rbds-scrollable">
     <div class="rbds-card__header">
         {{ rbds_icon(icon_name="menu.svg") }}
         <h3 class="side-panel-heading__text">Menu</h3>

--- a/django_app/redbox_app/templates/side_panel/side_panel.html
+++ b/django_app/redbox_app/templates/side_panel/side_panel.html
@@ -12,7 +12,7 @@
         <div class="rbds-side-panel__content">
             {% include "side_panel/conversations.html" %}
             {% include "side_panel/model_selector.html" %}
-            {% include "side_panel/your_documents_list.html" %}
+            {% include "side_panel/your_documents.html" %}
             {% include "side_panel/menu.html" %}
         </div>
 

--- a/django_app/redbox_app/templates/side_panel/your_documents.html
+++ b/django_app/redbox_app/templates/side_panel/your_documents.html
@@ -2,7 +2,7 @@
 {% from "rbds/components/editable-text.html" import editable_text %}
 {% from "rbds/components/modal.html" import modal %}
 {% from "macros/icon.html" import rbds_icon %}
-<section class ="documents rbds-card rbds-card--no-border rbds-card--block rbds-scrollable" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
+<section id="your-documents" class ="documents rbds-card rbds-card--no-border rbds-card--block rbds-scrollable" {% if oob %}hx-swap-oob="outerHTML"{% endif %}>
     <div class="rbds-card__header">
         {{ rbds_icon(icon_name="file-present.svg") }}
         <h3 class="side-panel-heading__text">Documents</h3>
@@ -10,10 +10,10 @@
     <div class="rbds-card__content">
         <document-selector id="document-selector" class="rbds-full-width">
             <fieldset class="govuk-fieldset">
-                <div id="your-documents" class="your-documents rbds-card__list govuk-checkboxes govuk-checkboxes--small rbds-checkbox rbds-checkbox--side-panel"
+                <div class="rbds-card__list govuk-checkboxes govuk-checkboxes--small rbds-checkbox rbds-checkbox--side-panel"
                     data-module="govuk-checkboxes">
                     {% for file in completed_files %}
-                    <div class="side-panel-item-container rbds-list-row govuk-!-display-none">
+                    <div class="rbds-list-row govuk-!-display-none">
                         {% set document_edit_url = url('document-titles', doc_id=file.id) %}
                         {% call editable_text(document_edit_url, 'document-title-change', 'your-documents', file.id) %}
                             <div class="govuk-checkboxes__item item-checkbox-container display">
@@ -27,11 +27,11 @@
                                     {% endif %}
                                 </label>
                             </div>
-                            <div class="item-text-input govuk-!-display-none edit-input-wrapper">
+                            <div class="govuk-!-display-none edit-input-wrapper">
                                 <label class="govuk-visually-hidden" for="item-title-text-input-{{ file.id }}">Document name</label>
                                 <input class="edit-input" type="text" id="item-title-text-input-{{ file.id }}" />
                             </div>
-                            <div class="side-panel-item-actions rbds-item-actions">
+                            <div class="rbds-item-actions">
                                 <button class="rbds-icon-button edit-trigger" type="button" data-action="rename">
                                     {{ rbds_icon(icon_name="edit.html", icon_classes="link") }}
                                     <span class="govuk-visually-hidden"> edit document: {{ file.file_name }}</span>
@@ -50,7 +50,7 @@
                                                         "active_chat_id": "{{ chat_id }}",
                                                         "file_selected": "{{ file.selected }}"
                                                     }'
-                                                    hx-target="closest .side-panel-item-container"
+                                                    hx-target="closest .rbds-list-row"
                                                     hx-swap="delete">
                                                 Yes delete
                                                 <span class="govuk-visually-hidden"> delete document: {{ file.file_name }}</span>
@@ -81,7 +81,7 @@
                         </div>
                         {% endfor %}
                     </div>
-                    {{ show_more('.your-documents', '.side-panel-item-container', 3) }}
+                    {{ show_more('#your-documents', '.rbds-list-row', 3) }}
                 </div>
             </fieldset>
         </document-selector>

--- a/django_app/redbox_app/templates/tools/tool-banner.html
+++ b/django_app/redbox_app/templates/tools/tool-banner.html
@@ -1,9 +1,9 @@
-<div class="govuk-body govuk-!-padding-top-2 govuk-!-padding-bottom-2" data-tool-id="{{ tool.id }}" data-tool-slug="{{ tool.slug }}">
+<div class="govuk-body govuk-!-margin-0" data-tool-id="{{ tool.id }}" data-tool-slug="{{ tool.slug }}">
     <strong class="govuk-tag govuk-tag--red rbds-w-fit">
         {{ tool.name }}
     </strong>
     <a href="{{ url('tools') }}"
-       class="govuk-link govuk-!-font-weight-regular govuk-link--no-visited-state govuk-!-margin-left-4">
+       class="govuk-link govuk-link--no-visited-state govuk-!-margin-left-4">
         Change tool
     </a>
 </div>

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -57,10 +57,6 @@ chat_urlpatterns = [
     path("ratings/<uuid:message_id>/", views.RatingsView.as_view(), name="ratings"),
     path("chats/<uuid:chat_id>/update-chat-feedback", views.UpdateChatFeedback.as_view(), name="chat-feedback"),
     path("chats/<uuid:chat_id>/delete-chat/", views.DeleteChat.as_view(), name="delete-chat"),
-    path("chats/recent-chats/", views.RecentChats.as_view(), name="recent-chats"),
-    path("chats/<uuid:active_chat_id>/recent-chats/", views.RecentChats.as_view(), name="recent-chats"),
-    path("chats/chat-window/", views.ChatWindow.as_view(), name="chat-window"),
-    path("chats/<uuid:active_chat_id>/chat-window/", views.ChatWindow.as_view(), name="chat-window"),
 ]
 
 notification_urlpatterns = [
@@ -84,22 +80,6 @@ tools_urlpatterns = [
     path(f"{tools_route_prefix}chats/", views.ChatsView.as_view(), name="chats"),
     path(f"{tools_route_prefix}chats/<uuid:chat_id>/", views.ChatsView.as_view(), name="chats"),
     path(f"{tools_route_prefix}documents/upload/", views.upload_document, name="document-upload"),
-    path(f"{tools_route_prefix}documents/your-documents/", views.YourDocuments.as_view(), name="your-documents"),
-    path(
-        f"{tools_route_prefix}documents/your-documents/<uuid:active_chat_id>/",
-        views.YourDocuments.as_view(),
-        name="your-documents",
-    ),
-    path(f"{tools_route_prefix}chats/recent-chats/", views.RecentChats.as_view(), name="recent-chats"),
-    path(
-        f"{tools_route_prefix}chats/<uuid:active_chat_id>/recent-chats/",
-        views.RecentChats.as_view(),
-        name="recent-chats",
-    ),
-    path(f"{tools_route_prefix}chats/chat-window/", views.ChatWindow.as_view(), name="chat-window"),
-    path(
-        f"{tools_route_prefix}chats/<uuid:active_chat_id>/chat-window/", views.ChatWindow.as_view(), name="chat-window"
-    ),
     path(
         f"{tools_route_prefix}chats/<uuid:chat_id>/citations/<uuid:message_id>/",
         views.CitationsView.as_view(),
@@ -128,8 +108,8 @@ other_urlpatterns = [
     path("faq/", views.faq_view, name="faq"),
     path("file-icon/<str:ext>/", views.file_icon_view, name="file-icon"),
     path("settings/", views.SettingsView.as_view(), name="settings"),
+    path("ui/refresh/", views.RefreshFragmentsView.as_view(), name="refresh"),
 ]
-
 
 api_url_patterns = [
     path("api/v0/users/", views.user_view_pre_alpha, name="user-view"),

--- a/django_app/tests/views/test_chat_views.py
+++ b/django_app/tests/views/test_chat_views.py
@@ -4,7 +4,8 @@ import uuid
 from http import HTTPStatus
 
 import pytest
-from bs4 import BeautifulSoup
+
+# from bs4 import BeautifulSoup
 from django.contrib.auth import get_user_model
 from django.test import Client
 from django.urls import reverse
@@ -132,78 +133,78 @@ def test_staff_user_can_see_route(chat_with_files: Chat, client: Client):
     assert b"redbox-message-route govuk-!-display-none" not in response.content
 
 
-@pytest.mark.django_db
-def test_recent_chats_with_chat(user_with_chats_with_messages_over_time: User, client: Client):
-    # Given
-    user = user_with_chats_with_messages_over_time
-    client.force_login(user)
-    chats = Chat.get_ordered_by_last_message_date(user)
+# @pytest.mark.django_db
+# def test_recent_chats_with_chat(user_with_chats_with_messages_over_time: User, client: Client):
+#     # Given
+#     user = user_with_chats_with_messages_over_time
+#     client.force_login(user)
+#     chats = Chat.get_ordered_by_last_message_date(user)
 
-    # When
-    response = client.get(reverse("recent-chats", kwargs={"active_chat_id": chats[0].id}))
-    soup = BeautifulSoup(response.content)
-    selected_chat = soup.find(
-        "div",
-        class_=["chat-list-item", "selected"],
-        attrs={"data-chatid": str(chats[0].id)},
-    )
+#     # When
+#     response = client.get(reverse("conversations", kwargs={"active_chat_id": chats[0].id}))
+#     soup = BeautifulSoup(response.content)
+#     selected_chat = soup.find(
+#         "div",
+#         class_=["chat-list-item", "selected"],
+#         attrs={"data-chatid": str(chats[0].id)},
+#     )
 
-    # Then
-    assert response.status_code == HTTPStatus.OK
-    assert list(response.context_data["chats"]) == list(chats)
-    assert selected_chat is not None
-
-
-@pytest.mark.django_db
-def test_recent_chats_without_chat(user_with_chats_with_messages_over_time: User, client: Client):
-    # Given
-    user = user_with_chats_with_messages_over_time
-    client.force_login(user)
-    chats = Chat.get_ordered_by_last_message_date(user)
-
-    # When
-    response = client.get(reverse("recent-chats"))
-    soup = BeautifulSoup(response.content)
-    chat_items = soup.find_all("div", class_="chat-list-item")
-    rendered_ids = [item["data-chatid"] for item in chat_items]
-
-    # Then
-    assert response.status_code == HTTPStatus.OK
-    assert list(response.context_data["chats"]) == list(chats)
-    for chat in chats:
-        assert str(chat.id) in rendered_ids
-    for chat_item in chat_items:
-        assert "selected" not in chat_item.get("class", [])
+#     # Then
+#     assert response.status_code == HTTPStatus.OK
+#     assert list(response.context_data["chats"]) == list(chats)
+#     assert selected_chat is not None
 
 
-@pytest.mark.django_db
-def test_chat_window_with_chat(chat_with_message: Chat, client: Client):
-    # Given
-    user = chat_with_message.user
-    client.force_login(user)
-    message = ChatMessage.objects.filter(chat=chat_with_message).first()
+# @pytest.mark.django_db
+# def test_recent_chats_without_chat(user_with_chats_with_messages_over_time: User, client: Client):
+#     # Given
+#     user = user_with_chats_with_messages_over_time
+#     client.force_login(user)
+#     chats = Chat.get_ordered_by_last_message_date(user)
 
-    # When
-    response = client.get(reverse("chat-window", kwargs={"active_chat_id": chat_with_message.id}))
-    response_content = response.content.decode()
+#     # When
+#     response = client.get(reverse("conversations"))
+#     soup = BeautifulSoup(response.content)
+#     chat_items = soup.find_all("div", class_="chat-list-item")
+#     rendered_ids = [item["data-chatid"] for item in chat_items]
 
-    # Then
-    assert response.status_code == HTTPStatus.OK
-    assert response.context_data["current_chat"] == chat_with_message
-    assert f"{message.id}" in response_content
+#     # Then
+#     assert response.status_code == HTTPStatus.OK
+#     assert list(response.context_data["chats"]) == list(chats)
+#     for chat in chats:
+#         assert str(chat.id) in rendered_ids
+#     for chat_item in chat_items:
+#         assert "selected" not in chat_item.get("class", [])
 
 
-@pytest.mark.django_db
-def test_chat_window_without_chat(alice: User, client: Client):
-    # Given
-    client.force_login(alice)
+# @pytest.mark.django_db
+# def test_chat_window_with_chat(chat_with_message: Chat, client: Client):
+#     # Given
+#     user = chat_with_message.user
+#     client.force_login(user)
+#     message = ChatMessage.objects.filter(chat=chat_with_message).first()
 
-    # When
-    response = client.get(reverse("chat-window"))
-    soup = BeautifulSoup(response.content)
-    canned_prompt = soup.find("canned-prompts")
+#     # When
+#     response = client.get(reverse("chat-window", kwargs={"active_chat_id": chat_with_message.id}))
+#     response_content = response.content.decode()
 
-    # Then
-    assert response.status_code == HTTPStatus.OK
-    assert not response.context_data["current_chat"]
-    assert canned_prompt is not None
+#     # Then
+#     assert response.status_code == HTTPStatus.OK
+#     assert response.context_data["current_chat"] == chat_with_message
+#     assert f"{message.id}" in response_content
+
+
+# @pytest.mark.django_db
+# def test_chat_window_without_chat(alice: User, client: Client):
+#     # Given
+#     client.force_login(alice)
+
+#     # When
+#     response = client.get(reverse("chat-window"))
+#     soup = BeautifulSoup(response.content)
+#     canned_prompt = soup.find("canned-prompts")
+
+#     # Then
+#     assert response.status_code == HTTPStatus.OK
+#     assert not response.context_data["current_chat"]
+#     assert canned_prompt is not None


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR adds some QOL fixes for the chats page redesign MVP.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Centralised htmx calls to swap more efficiently and removed redundant js views
- Added start-streaming custom event hook
- Renamed “recent-chats” to “conversations”
- Simplified cannedPrompts by moving prompt to html and auto-hide on stream start
-  Fixed card height to 230px max for now and added default border-radius
- Removed some unnecessary padding and adjusted some margins
- Restructured cta container components to follow desired layout
- Hardcoded expanded textbox height to 130px for now
- Added govuk active styling for icon-button

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

###

- Ensure site functions as expected.
- Ensure chat title and promoted tool button (Try submissions checker) are updated appropriately on chat message or page load.
- Ensure conversations and documents sections in side panel still update correctly on chat/document interaction.


## Relevant links
[REDBOX-1340](https://uktrade.atlassian.net/browse/REDBOX-1340)
[REDBOX-1332](https://uktrade.atlassian.net/browse/REDBOX-1332)
[REDBOX-1333](https://uktrade.atlassian.net/browse/REDBOX-1333)
[REDBOX-1337](https://uktrade.atlassian.net/browse/REDBOX-1337)

[REDBOX-1340]: https://uktrade.atlassian.net/browse/REDBOX-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ