### PR TITLE
bug: side-panel scroll overflow issue

### DIFF
--- a/django_app/frontend/src/redbox_design_system/rbds/layouts/side-panel.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/layouts/side-panel.scss
@@ -7,6 +7,7 @@
   top: 0;
   align-self: flex-start;
   height: 100vh;
+  overflow: hidden;
 
   &--collapsed {
     width: var(--side-panel-collapsed-width);


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Fix for the side-panel extending past the view height when many chats/documents are expanded
## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Hid the overflow for the side-panel wrapper

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Frontend/UI only

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No


Have multiple chats/documents and click "show more..." the page height shouldn't shift

## Relevant links

Before:
<img width="1917" height="934" alt="image" src="https://github.com/user-attachments/assets/338c40d3-c867-4aeb-92a2-ca565cde4a7e" />
After:
<img width="1704" height="924" alt="image" src="https://github.com/user-attachments/assets/8ed84de5-10c2-4c17-82e4-24df524139c5" />
