### PR TITLE
bug: Hide first-time-user upload component on message

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { getActiveToolId } from "../../utils";
+import { getActiveToolId, hideElement } from "../../utils";
 import { ChatMessage } from "./chat-message";
 
 class ChatController extends HTMLElement {
@@ -34,6 +34,13 @@ class ChatController extends HTMLElement {
       const hasContent = Boolean(userText || messageInput?.hasUploadedFiles());
 
       if (!messageInput || !hasContent) return;
+
+      // Input is valid, prepare to stream
+
+      const firstTimeUploadElement = /** @type {HTMLFormElement | null} */ (
+          document.querySelector("#first-time-user-upload")
+      );
+      if (firstTimeUploadElement) hideElement(firstTimeUploadElement);
 
       let userMessage = /** @type {ChatMessage} */ (
         document.createElement("rbds-chat-message")

--- a/django_app/frontend/src/redbox_design_system/rbds/layouts/side-panel.scss
+++ b/django_app/frontend/src/redbox_design_system/rbds/layouts/side-panel.scss
@@ -2,7 +2,6 @@
   --collapsed-width: calc(var(--side-panel-collapsed-width, 54px) - var(--header-border-width));
   width: var(--side-panel-width, 373px);
   display: flex;
-  flex-shrink: 0;
   position: sticky;
   top: 0;
   align-self: flex-start;

--- a/django_app/redbox_app/templates/upload_form.html
+++ b/django_app/redbox_app/templates/upload_form.html
@@ -1,4 +1,4 @@
-<form method="post" enctype="multipart/form-data">
+<form id="first-time-user-upload" method="post" enctype="multipart/form-data">
 
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR hides the upload component visible to first time users when a message is sent.
## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

UI / Frontend only

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Send a message as a first time user and the component should disappear straight away. (can use "enable_first_time_user" flag to test)
## Relevant links
