### PR TITLE
feat: integrate background cleanup for unstructured

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - UNSTRUCTURED_MAX_WORKERS=2
       - UNSTRUCTURED_TEMP_DIR=/tmp/unstructured_temp
+      - ENV=local
     volumes:
       - ./unstructured_temp:/tmp/unstructured_temp
   redbox-django-app:

--- a/unstructured/Dockerfile
+++ b/unstructured/Dockerfile
@@ -1,6 +1,10 @@
 # Use the existing image as the base image
 FROM quay.io/unstructured-io/unstructured-api:latest
 
+ENV TMPDIR=/tmp/unstructured_temp
+ENV TEMP=/tmp/unstructured_temp
+ENV TMP=/tmp/unstructured_temp
+
 # datadog
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA

--- a/unstructured/cleanup.sh
+++ b/unstructured/cleanup.sh
@@ -1,2 +1,20 @@
 #!/bin/sh
-rm -rf /tmp/unstructured_temp/* || true
+set -e
+
+TARGET_DIR="/tmp/unstructured_temp"
+AGE_MINUTES=15
+
+if [ ! -d "$TARGET_DIR" ]; then
+    exit 0
+fi
+
+DELETED_COUNT=$(find "$TARGET_DIR" \
+    -xdev \
+    -mindepth 1 \
+    -type f \
+    -mmin +$AGE_MINUTES \
+    -print -delete | wc -l)
+
+if [ "$DELETED_COUNT" -gt 0 ]; then
+    echo "Deleted $DELETED_COUNT files older than ${AGE_MINUTES} minutes from $TARGET_DIR"
+fi

--- a/unstructured/entrypoint.sh
+++ b/unstructured/entrypoint.sh
@@ -9,9 +9,17 @@ echo "Started background cleanup"
     done
 ) &
 
+if [ "${ENV}" = "local" ] || [ "${IS_LOCAL}" = "true" ] || [ "${LOCAL_DEV}" = "1" ]; then
+    PORT=8000
+    echo "Running in local mode so the port is ${PORT}"
+else
+    PORT=8080
+    echo "Running in ECS so the port is ${PORT}"
+fi
+
 echo "Started uvicorn with unstructured io"
 
 exec uvicorn prepline_general.api.app:app \
     --host 0.0.0.0 \
-    --port 8080 \
+    --port "${PORT}" \
     --log-config logger_config.yaml


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Unstructured is running out of space as when files error, they still remain in the service.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Background task looping to cleanup redundant files

## Have you written unit tests?
- [ ] Yes
- [X] No (add why you have not)
External service with just a little bit attached

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [X] Yes (if so provide more detail)
- [ ] No
can you still upload documents


## Relevant links
