### PR TITLE
bugfix: fix OpenSearch client loader to use Requests for AWS and optimise index management

### DIFF
--- a/redbox/redbox/models/settings.py
+++ b/redbox/redbox/models/settings.py
@@ -326,7 +326,6 @@ class Settings(BaseSettings):
     def elasticsearch_client(self) -> Union[Elasticsearch, OpenSearch]:
         logger.info("Testing OpenSearch is definitely being used")
 
-        # Setup the client
         if ENVIRONMENT.is_local:
             client = OpenSearch(
                 hosts=[


### PR DESCRIPTION
## Context
Was seeing some 400s from worker trying to talk to OpenSearch indicating stale credentials. Likely due to Urllib3 due to not handling rotated credentials.

## What
- Update to Requests
- Cleanup index management

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
