### PR TITLE
update pre-commit.yml

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,19 +16,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
+      - name: Upgrade pip and install
+        run: |
+            python -m pip install --upgrade pip setuptools wheel
+            pip install pyarrow
 
       - name: Install dependencies
         run: |
-          pip install pre-commit piicatcher
           sudo apt-get update
           sudo apt-get install -y git
-          git clone https://github.com/awslabs/git-secrets.git
-          cd git-secrets
-          sudo make install
+          pip install pre-commit
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry install --with dev
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Context

Updates github action > pre-commits align with local pre-commit hooks process

pre-commit was failing some python related checks as new syntax was introduced in 3.12 but checks were running on 3.10. This had been failing for a while i guess. 

## What

small changes to .github/workflows/pre-commit.yml to run same pre-commit hooks as local

## Have you written unit tests?
- [ ] Yes
- [ x ] No (add why you have not)

Tested on github, working nicely with correct python version

## Are there any specific instructions on how to test this change?

- [ ] Yes (if so provide more detail)
- [ x ] No

