### PR TITLE
fix: fix stale sso token passing

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -322,9 +322,13 @@ class ChatConsumer(AsyncWebsocketConsumer):
             session = self.scope.get("session")
             authbroker_token = session["_authbroker_token"]
 
-            if timezone.now().timestamp() > authbroker_token["expires_at"] - AUTH_EXPIRY_BUFFER:
+            if (
+                authbroker_token.get("expires_at") is not None
+                and timezone.now().timestamp() > authbroker_token["expires_at"] - AUTH_EXPIRY_BUFFER
+            ):
                 await self.accept()
                 await self.send_to_client("auth_expired", error_messages.AUTH_EXPIRED)
+                return None
 
             return authbroker_token["access_token"]
         except (KeyError, TypeError):

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -317,12 +317,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
         ids = [f.id for f in files]
         return list(File.objects.filter(id__in=ids).values_list("original_file", flat=True))
 
-    async def _extract_sso_token(self, check_expiry=False) -> str | None:
+    async def _extract_sso_token(self) -> str | None:
         try:
             session = self.scope.get("session")
             authbroker_token = session["_authbroker_token"]
 
-            if check_expiry and (timezone.now().timestamp() > authbroker_token["expires_at"] - AUTH_EXPIRY_BUFFER):
+            if timezone.now().timestamp() > authbroker_token["expires_at"] - AUTH_EXPIRY_BUFFER:
                 await self.accept()
                 await self.send_to_client("auth_expired", error_messages.AUTH_EXPIRED)
 
@@ -615,7 +615,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
             await self.send_to_client("error", error_messages.AUTH_REQUIRED)
             return
 
-        sso_access_token = await self._extract_sso_token(check_expiry=True)
+        sso_access_token = await self._extract_sso_token()
 
         if ChatConsumer.redbox is None:
             agents = await get_all_agents()

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -13,6 +13,7 @@ from channels.testing import WebsocketCommunicator
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Model
+from django.utils import timezone
 from langchain_core.documents import Document
 from langchain_core.language_models import BaseChatModel
 from pydantic import BaseModel
@@ -909,14 +910,31 @@ async def test_connect_with_agents_update_via_db(agents_list: list, alice: User)
         assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name == "gpt-4o"
 
 
+@pytest.mark.parametrize(
+    "mock_token, expired, expected_result",  # noqa: PT006
+    [("mock_token1", None, "mock_token1"), ("mock_token2", True, None), ("mock_token3", False, "mock_token3")],
+)
 @pytest.mark.asyncio
-async def test_extract_sso_token_success():
+async def test_extract_sso_token_success(mock_token, expired, expected_result):
     """Test successful token extraction when the session data is present."""
     consumer = ChatConsumer()
-    mock_token = "mock_token"  # noqa: S105
     consumer.scope = {"session": {"_authbroker_token": {"access_token": mock_token}}}
-    token = await consumer._extract_sso_token()  # noqa: SLF001
-    assert token == mock_token
+    if expired is not None:
+        consumer.scope = {
+            "session": {
+                "_authbroker_token": {
+                    "access_token": mock_token,
+                    "expires_at": 0 if expired else timezone.now().timestamp() + 1000,
+                }
+            }
+        }
+
+    with (
+        patch.object(ChatConsumer, "accept", return_value=None),
+        patch.object(ChatConsumer, "send_to_client", return_value=None),
+    ):
+        token = await consumer._extract_sso_token()  # noqa: SLF001
+    assert token == expected_result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context
So expiry is always checked before using a token.

## What
- Removes check_expiry flag

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
