### PR TITLE
bug: re-add user scroll detection

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/stream-scroller.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/stream-scroller.js
@@ -20,6 +20,7 @@ export class StreamScroller extends HTMLElement {
     }
 
     disconnectedCallback() {
+        this.scrollContainer?.removeEventListener("scroll", () => this.#onScroll());
         this._observer?.disconnect();
     }
 
@@ -29,7 +30,28 @@ export class StreamScroller extends HTMLElement {
     }
 
 
+    #onScroll() {
+        if (this.programmaticScroll) return;
+        this.autoScrollEnabled = this.#isAtBottom();
+    }
+
+
+    #isAtBottom(threshold = 10) {
+        if (!this.scrollContainer) return false;
+
+        let scrollElement;
+        if (this.scrollContainer instanceof Document) {
+            scrollElement = this.scrollContainer.documentElement;
+        } else {
+            scrollElement = this.scrollContainer;
+        }
+
+        return scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight <= threshold;
+    }
+
+
     #bindScrollEvents() {
+        this.scrollContainer?.addEventListener("scroll", () => this.#onScroll(), { passive: true });
         listenEvent(Events.SCROLL_TO_BOTTOM, (evt) => this.scheduleScroll(evt.detail));
     }
 
@@ -52,10 +74,6 @@ export class StreamScroller extends HTMLElement {
             if (!entry.isIntersecting && !this.programmaticScroll && this.autoScrollEnabled) {
                 this.scheduleScroll();
             }
-
-            // Update autoScrollEnabled based on visibility
-            this.autoScrollEnabled = entry.isIntersecting;
-
         }, { root: null, threshold: 0 });
 
         this._observer.observe(this._anchor);


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
User scroll detection was accidentally removed during the scrollElement and window-size calculation fix [PR](https://github.com/uktrade/redbox/pull/923).

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
 - Re-added user-scroll detection methods and listener. 

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Frontend/UI only

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Ensure the page scrolls normally when the page is scrollable

Before/After
https://github.com/user-attachments/assets/8053c6d8-7488-44c4-8781-5f4bf1fc9131

## Relevant links
https://github.com/uktrade/redbox/pull/923