### PR TITLE
feat: Align tool card heights

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/utils/utils.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/utils/utils.scss
@@ -50,6 +50,10 @@
   width: 100%;
 }
 
+.ids-height--full {
+  height: 100%;
+}
+
 .ids-width--max-content {
   width: max-content;
 }

--- a/django_app/redbox_app/templates/tools/tool-card.html
+++ b/django_app/redbox_app/templates/tools/tool-card.html
@@ -1,6 +1,6 @@
 {% if tool %}
-    <div class="ids-card--tool">
-        <div class="govuk-grid-column-one-third govuk-!-padding-4 ids-card ids-width--full">
+    <div class="ids-card ids-card--tool govuk-!-padding-4 ids-width--full">
+        <div class="ids-flex-column ids-height--full">
             <div class="ids-flex-space-between govuk-!-margin-top-2 govuk-!-margin-bottom-2">
                 <h3 class="govuk-heading-s govuk-!-margin-0">{{ tool.name }}</h3>
                 <a href="{{ tool.chat_url }}" class="govuk-link">Use this tool</a>


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR aligns the tool card heights per row.
## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Updated styling for tool card layout to display flex and set max height

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Frontend/UI only

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Check that the tool card heights are the aligned per row

## Relevant links
https://uktrade.atlassian.net/browse/ASSIST-1435

Before
<img width="2298" height="1646" alt="image" src="https://github.com/user-attachments/assets/e7383745-4951-48f4-80ae-c2bd2c9d8b7d" />


After
<img width="2554" height="1644" alt="image" src="https://github.com/user-attachments/assets/a12c86bf-d406-4a66-a31e-5109f9155fd2" />
