### PR TITLE
Add callback for token usage

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "django_app/redbox_app/settings.py",
         "hashed_secret": "3a07fa5a98e5eab18d39dd37f33148d45f8091dc",
         "is_verified": false,
-        "line_number": 203,
+        "line_number": 205,
         "is_secret": false
       },
       {
@@ -166,7 +166,7 @@
         "filename": "django_app/redbox_app/settings.py",
         "hashed_secret": "71ecb7a9026acd0b5c75ce1cd543c411eaa78a75",
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 206,
         "is_secret": false
       },
       {
@@ -174,7 +174,7 @@
         "filename": "django_app/redbox_app/settings.py",
         "hashed_secret": "d2aa34aa9083c20fc7eeb1f2e08dfd7f8f6c0022",
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 207,
         "is_secret": false
       },
       {
@@ -182,7 +182,7 @@
         "filename": "django_app/redbox_app/settings.py",
         "hashed_secret": "28c0d52cedc09b9e794d0e1033ca0b2a06def89a",
         "is_verified": false,
-        "line_number": 206,
+        "line_number": 208,
         "is_secret": false
       },
       {
@@ -190,7 +190,7 @@
         "filename": "django_app/redbox_app/settings.py",
         "hashed_secret": "8782f26f9343343d50facf336a0befad925537d1",
         "is_verified": false,
-        "line_number": 207,
+        "line_number": 209,
         "is_secret": false
       },
       {
@@ -198,7 +198,7 @@
         "filename": "django_app/redbox_app/settings.py",
         "hashed_secret": "1bc89245f6e26d516ddc579b00a0d59e4096a765",
         "is_verified": false,
-        "line_number": 216,
+        "line_number": 218,
         "is_secret": false
       }
     ],
@@ -281,5 +281,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-09T11:20:11Z"
+  "generated_at": "2026-04-24T10:08:43Z"
 }

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -10,7 +10,7 @@ import environ
 import sentry_sdk
 from dbt_copilot_python.database import database_from_env
 from dbt_copilot_python.error_tracking import DatadogErrorTrackingFilter
-from ddtrace import patch
+from ddtrace import patch_all
 from ddtrace.llmobs import LLMObs
 from django.urls import reverse_lazy
 from django_log_formatter_asim import ASIMFormatter
@@ -510,4 +510,4 @@ PRODUCT_NAME = env.str("PRODUCT_NAME", "Redbox at DBT")
 
 # adding manual tracing datadog
 LLMObs.enable(integrations_enabled=False, api_key=env.str("DATADOG_API_KEY", "Fake"))
-patch(langchain=True, langgraph=True, mcp=True, botocore=False)
+patch_all(botocore=False)

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -10,6 +10,8 @@ import environ
 import sentry_sdk
 from dbt_copilot_python.database import database_from_env
 from dbt_copilot_python.error_tracking import DatadogErrorTrackingFilter
+from ddtrace import patch
+from ddtrace.llmobs import LLMObs
 from django.urls import reverse_lazy
 from django_log_formatter_asim import ASIMFormatter
 from dotenv import find_dotenv, load_dotenv
@@ -505,3 +507,7 @@ FEEDBACK_LINK = env.str(
 )
 
 PRODUCT_NAME = env.str("PRODUCT_NAME", "Redbox at DBT")
+
+# adding manual tracing datadog
+LLMObs.enable(integrations_enabled=False, api_key=env.str("DATADOG_API_KEY", "Fake"))
+patch(langchain=True, langgraph=True, mcp=True, botocore=False)

--- a/django_app/start.sh
+++ b/django_app/start.sh
@@ -7,5 +7,5 @@ venv/bin/django-admin collectstatic --noinput
 venv/bin/django-admin create_admin_user
 
 echo "Starting daphne on port $PORT"
-#venv/bin/daphne --websocket_timeout 86400 -b 0.0.0.0 -p $PORT redbox_app.asgi:application
-venv/bin/ddtrace-run venv/bin/daphne --websocket_timeout 86400 -b 0.0.0.0 -p $PORT redbox_app.asgi:application
+venv/bin/daphne --websocket_timeout 86400 -b 0.0.0.0 -p $PORT redbox_app.asgi:application
+# venv/bin/ddtrace-run venv/bin/daphne --websocket_timeout 86400 -b 0.0.0.0 -p $PORT redbox_app.asgi:application

--- a/redbox/redbox/api/callbacks.py
+++ b/redbox/redbox/api/callbacks.py
@@ -37,13 +37,22 @@ class LoggerCallbackHandler(BaseCallbackHandler):
 
 
 class TokenAnnotationCallback(BaseCallbackHandler):
+    def _extract_model_name(self, response_metadata) -> str:
+        model_name = response_metadata.get("model_name", None)
+        if model_name:
+            if model_name.startswith("arn"):
+                # grab the last bit
+                model_name = model_name.split("/")[-1]
+            model_name = model_name.split(".")[-1]
+        return model_name
+
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
         if response.generations[0]:
             usage = response.generations[0][0].message
             LLMObs.annotate(
                 span=tracer.current_span(),
                 metadata={
-                    "model_name": (usage.response_metadata or {}).get("model_name", None),
+                    "model_name": self._extract_model_name(usage.response_metadata or {}),
                     "stop_reason": (usage.response_metadata or {}).get("stop_reason", None),
                 },
                 metrics={

--- a/redbox/redbox/api/callbacks.py
+++ b/redbox/redbox/api/callbacks.py
@@ -1,6 +1,8 @@
 from logging import Logger
 from typing import Any
 
+from ddtrace.llmobs import LLMObs
+from ddtrace.trace import tracer
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs.llm_result import LLMResult
 
@@ -32,3 +34,21 @@ class LoggerCallbackHandler(BaseCallbackHandler):
     def on_text(self, text: str, **kwargs: Any) -> None:  # noqa:ARG002
         """Run on arbitrary text."""
         self.logger.info("Text: %s", text)
+
+
+class TokenAnnotationCallback(BaseCallbackHandler):
+    def on_llm_end(self, response: LLMResult, **kwargs) -> None:
+        usage = response.generations[0][0].message
+        LLMObs.annotate(
+            span=tracer.current_span(),
+            metadata={
+                "model_name": (usage.response_metadata or {}).get("model_name", None),
+                "stop_reason": (usage.response_metadata or {}).get("stop_reason", None),
+            },
+            metrics={
+                "input_tokens": (usage.usage_metadata or {}).get("input_tokens", None),
+                "output_tokens": (usage.usage_metadata or {}).get("output_tokens", None),
+                "total_tokens": (usage.usage_metadata or {}).get("total_tokens", None),
+            },
+            tags={"func": "token_annotation_callback"},
+        )

--- a/redbox/redbox/api/callbacks.py
+++ b/redbox/redbox/api/callbacks.py
@@ -37,22 +37,12 @@ class LoggerCallbackHandler(BaseCallbackHandler):
 
 
 class TokenAnnotationCallback(BaseCallbackHandler):
-    def _extract_model_name(self, response_metadata) -> str:
-        model_name = response_metadata.get("model_name", None)
-        if model_name:
-            if model_name.startswith("arn"):
-                # grab the last bit
-                model_name = model_name.split("/")[-1]
-            model_name = model_name.split(".")[-1]
-        return model_name
-
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
         if response.generations[0]:
             usage = response.generations[0][0].message
             LLMObs.annotate(
                 span=tracer.current_span(),
                 metadata={
-                    "model_name": self._extract_model_name(usage.response_metadata or {}),
                     "stop_reason": (usage.response_metadata or {}).get("stop_reason", None),
                 },
                 metrics={

--- a/redbox/redbox/api/callbacks.py
+++ b/redbox/redbox/api/callbacks.py
@@ -38,17 +38,18 @@ class LoggerCallbackHandler(BaseCallbackHandler):
 
 class TokenAnnotationCallback(BaseCallbackHandler):
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
-        usage = response.generations[0][0].message
-        LLMObs.annotate(
-            span=tracer.current_span(),
-            metadata={
-                "model_name": (usage.response_metadata or {}).get("model_name", None),
-                "stop_reason": (usage.response_metadata or {}).get("stop_reason", None),
-            },
-            metrics={
-                "input_tokens": (usage.usage_metadata or {}).get("input_tokens", None),
-                "output_tokens": (usage.usage_metadata or {}).get("output_tokens", None),
-                "total_tokens": (usage.usage_metadata or {}).get("total_tokens", None),
-            },
-            tags={"func": "token_annotation_callback"},
-        )
+        if response.generations[0]:
+            usage = response.generations[0][0].message
+            LLMObs.annotate(
+                span=tracer.current_span(),
+                metadata={
+                    "model_name": (usage.response_metadata or {}).get("model_name", None),
+                    "stop_reason": (usage.response_metadata or {}).get("stop_reason", None),
+                },
+                metrics={
+                    "input_tokens": (usage.usage_metadata or {}).get("input_tokens", None),
+                    "output_tokens": (usage.usage_metadata or {}).get("output_tokens", None),
+                    "total_tokens": (usage.usage_metadata or {}).get("total_tokens", None),
+                },
+                tags={"func": "token_annotation_callback"},
+            )

--- a/redbox/redbox/chains/components.py
+++ b/redbox/redbox/chains/components.py
@@ -10,6 +10,7 @@ from langchain_core.embeddings import Embeddings, FakeEmbeddings
 from langchain_core.runnables import Runnable
 from langchain_core.tools import StructuredTool
 
+from redbox.api.callbacks import TokenAnnotationCallback
 from redbox.chains.parser import StreamingJsonOutputParser, StreamingPlanner
 from redbox.models.chain import (
     AISettings,
@@ -70,7 +71,7 @@ def get_chat_llm(
         )
         if tools:
             chat_model = chat_model.bind_tools(tools)
-        return chat_model
+        return chat_model.with_config(callbacks=[TokenAnnotationCallback()])
 
     cache_entry = _FALLBACK_CACHE.get(model.name)
     if cache_entry and cache_entry["until"] > time.time():

--- a/redbox/tests/api/test_callback.py
+++ b/redbox/tests/api/test_callback.py
@@ -43,3 +43,18 @@ class TestTokenCallback:
             metrics=metrics,
             tags={"func": "token_annotation_callback"},
         )
+
+    @pytest.mark.parametrize(
+        "metadata, expected_result",
+        [
+            (
+                {"model_name": "fake", "stop_reason": "end_turn"},
+                "fake",
+            ),
+            ({"model_name": "arn:random:blah:not-real/some.model.hello-world-01-01-1999"}, "hello-world-01-01-1999"),
+            ({}, None),
+        ],
+    )
+    def test_extract_model_name(self, metadata, expected_result):
+        chats = ChatGeneration(message=AIMessage(content="", response_metadata=metadata))
+        assert TokenAnnotationCallback()._extract_model_name(chats.message.response_metadata) == expected_result

--- a/redbox/tests/api/test_callback.py
+++ b/redbox/tests/api/test_callback.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from redbox.api.callbacks import TokenAnnotationCallback
+
+
+class TestTokenCallback:
+    @pytest.mark.parametrize(
+        "case, llm_response",
+        [
+            ("no generation", LLMResult(generations=[[]])),
+            ("empty response", LLMResult(generations=[[ChatGeneration(message=AIMessage(content=""))]])),
+            ("success", LLMResult(generations=[[ChatGeneration(message=AIMessage(content="Fake"))]])),
+        ],
+    )
+    def test_token_callback(self, case, llm_response):
+        callback = TokenAnnotationCallback()
+        callback.on_llm_end(response=llm_response)
+
+    @pytest.mark.parametrize(
+        "metadata, metrics",
+        [
+            (
+                {"model_name": "fake", "stop_reason": "end_turn"},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+        ],
+    )
+    def test_tokenn_callback_metadata(self, metadata, metrics, mocker):
+        mock_span = MagicMock()
+        mocker.patch("redbox.api.callbacks.tracer.current_span", return_value=mock_span)
+        datadog_mock = mocker.patch("redbox.api.callbacks.LLMObs.annotate")
+        chats = ChatGeneration(message=AIMessage(content="", response_metadata=metadata, usage_metadata=metrics))
+        callback = TokenAnnotationCallback()
+        callback.on_llm_end(response=LLMResult(generations=[[chats]]))
+
+        datadog_mock.assert_called_once_with(
+            span=mock_span,
+            metadata=metadata,
+            metrics=metrics,
+            tags={"func": "token_annotation_callback"},
+        )

--- a/redbox/tests/api/test_callback.py
+++ b/redbox/tests/api/test_callback.py
@@ -24,7 +24,7 @@ class TestTokenCallback:
         "metadata, metrics",
         [
             (
-                {"model_name": "fake", "stop_reason": "end_turn"},
+                {"stop_reason": "end_turn"},
                 {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
             )
         ],
@@ -43,18 +43,3 @@ class TestTokenCallback:
             metrics=metrics,
             tags={"func": "token_annotation_callback"},
         )
-
-    @pytest.mark.parametrize(
-        "metadata, expected_result",
-        [
-            (
-                {"model_name": "fake", "stop_reason": "end_turn"},
-                "fake",
-            ),
-            ({"model_name": "arn:random:blah:not-real/some.model.hello-world-01-01-1999"}, "hello-world-01-01-1999"),
-            ({}, None),
-        ],
-    )
-    def test_extract_model_name(self, metadata, expected_result):
-        chats = ChatGeneration(message=AIMessage(content="", response_metadata=metadata))
-        assert TokenAnnotationCallback()._extract_model_name(chats.message.response_metadata) == expected_result

--- a/redbox/tests/graph/test_fallback_llm.py
+++ b/redbox/tests/graph/test_fallback_llm.py
@@ -1,10 +1,11 @@
 import time
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 from botocore.exceptions import ClientError
 
-from redbox.models.chain import ChatLLMBackend, AISettings
-from redbox.chains.components import get_chat_llm, _FALLBACK_CACHE
+from redbox.chains.components import _FALLBACK_CACHE, get_chat_llm
+from redbox.models.chain import AISettings, ChatLLMBackend
 
 pytestmark = pytest.mark.usefixtures("clear_fallback_cache")
 
@@ -43,7 +44,20 @@ def test_get_chat_llm_primary_success(mocker, fake_model_backend, fake_ai_settin
 
     result = get_chat_llm(fake_model_backend, fake_ai_settings)
 
-    assert result == fake_model
+    assert result == fake_model.with_config.return_value
+    assert fake_model.bind_tools not in (None,)
+
+
+def test_get_chat_llm_token_call_back(mocker, fake_model_backend, fake_ai_settings):
+    fake_callback = MagicMock()
+    mocker.patch("redbox.chains.components.TokenAnnotationCallback", return_value=fake_callback)
+
+    fake_model = MagicMock(name="FakeChatModel")
+    mocker.patch("redbox.chains.components.init_chat_model", return_value=fake_model)
+
+    result = get_chat_llm(fake_model_backend, fake_ai_settings)
+    assert result == fake_model.with_config.return_value
+    fake_model.with_config.assert_called_once_with(callbacks=[fake_callback])
     assert fake_model.bind_tools not in (None,)
 
 


### PR DESCRIPTION
## Context

We need to provide token usage to Datadog so that it can calculate the LLM cost.

## What

- Add a callback to add annotation to the LLM span
- Change from auto instrument to manual instrument. Need to remove `botocore` from auto otherwise it will overwrite the token usage that we annotated.  
- Add tests for new callback function

## Have you written unit tests?
- [x] Yes
- [] No (add why you have not)

tested locally and in dev

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

run some prompts in dev and then check that DataDog traces calculate token costs
## Relevant links
