### PR TITLE
feat: add todays date to planner and evaluator system prompts

### DIFF
--- a/redbox/redbox/chains/runnables.py
+++ b/redbox/redbox/chains/runnables.py
@@ -396,14 +396,9 @@ def chain_use_metadata(
         tabular_metadata = get_tabular_metadata_retriever(get_settings()).invoke(state)
         return tabular_metadata
 
-    # `    @chain
-    #     def get_todays_date(state: RedboxState):
-    #         return date.today().isoformat()`
-
     @chain
     def use_result(input):
         additional_variables = {}
-        # additional_variables["todays_date"] = date.today().isoformat()
         if input.get("metadata") is not None:
             additional_variables["metadata"] = input["metadata"]
         if input.get("knowledge_base_metadata") is not None:
@@ -428,7 +423,6 @@ def chain_use_metadata(
     return (
         RunnableParallel(
             state=RunnablePassthrough(),
-            # todays_date=get_todays_date,
             metadata=get_metadata,
             knowledge_base_metadata=get_knowledge_base_metadata,
             tabular_knowledge_base_metadata=get_tabular_knowledge_base_metadata,
@@ -437,7 +431,6 @@ def chain_use_metadata(
         if use_knowledge_base
         else RunnableParallel(
             state=RunnablePassthrough(),
-            # todays_date=get_todays_date,
             metadata=get_metadata,
             tabular_metadata=get_tabular_metadata,
         )

--- a/redbox/redbox/chains/runnables.py
+++ b/redbox/redbox/chains/runnables.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from typing import Any, Callable, Iterable, Iterator
+from datetime import date
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun, dispatch_custom_event
 from langchain_core.language_models import BaseChatModel
@@ -343,6 +344,7 @@ def basic_chat_chain(
         context = {
             "question": state.request.question,
             "chat_history": truncated_history if using_chat_history else "",
+            "todays_date": date.today().isoformat(),
         } | _additional_variables
         if parser:
             if isinstance(parser, StrOutputParser):
@@ -394,10 +396,16 @@ def chain_use_metadata(
         tabular_metadata = get_tabular_metadata_retriever(get_settings()).invoke(state)
         return tabular_metadata
 
+    # `    @chain
+    #     def get_todays_date(state: RedboxState):
+    #         return date.today().isoformat()`
+
     @chain
     def use_result(input):
+        additional_variables = {}
+        # additional_variables["todays_date"] = date.today().isoformat()
         if input.get("metadata") is not None:
-            additional_variables = {"metadata": input["metadata"]}
+            additional_variables["metadata"] = input["metadata"]
         if input.get("knowledge_base_metadata") is not None:
             additional_variables["knowledge_base_metadata"] = input["knowledge_base_metadata"]
         if input.get("tabular_knowledge_base_metadata") is not None:
@@ -420,6 +428,7 @@ def chain_use_metadata(
     return (
         RunnableParallel(
             state=RunnablePassthrough(),
+            # todays_date=get_todays_date,
             metadata=get_metadata,
             knowledge_base_metadata=get_knowledge_base_metadata,
             tabular_knowledge_base_metadata=get_tabular_knowledge_base_metadata,
@@ -428,6 +437,7 @@ def chain_use_metadata(
         if use_knowledge_base
         else RunnableParallel(
             state=RunnablePassthrough(),
+            # todays_date=get_todays_date,
             metadata=get_metadata,
             tabular_metadata=get_tabular_metadata,
         )

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -11,6 +11,7 @@ from io import StringIO
 from random import uniform
 from typing import Any, Iterable
 from uuid import uuid4
+from datetime import date
 
 import pandas as pd
 from botocore.exceptions import EventStreamError
@@ -777,6 +778,7 @@ def create_evaluator():
         _additional_variables = {
             "agents_results": combine_agents_state(state.agents_results),
             "artifact_criteria": state.artifact_criteria,
+            "todays_date": date.today().isoformat(),
         }
         citation_parser, format_instructions = get_structured_response_with_citations_parser()
         evaluator_agent = build_stuff_pattern(

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -467,6 +467,7 @@ class RedboxState(BaseModel):
     tasks_evaluator: Annotated[list[AnyMessage], add_messages] = Field(default_factory=list)
     tabular_schema: str = ""
     artifact_criteria: Annotated[str | None, artifact_criteria_reducer] = None
+    # todays_date: date = Field(default_factory=date.today().isoformat)
 
     @property
     def last_message(self) -> AnyMessage:

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -467,7 +467,6 @@ class RedboxState(BaseModel):
     tasks_evaluator: Annotated[list[AnyMessage], add_messages] = Field(default_factory=list)
     tabular_schema: str = ""
     artifact_criteria: Annotated[str | None, artifact_criteria_reducer] = None
-    # todays_date: date = Field(default_factory=date.today().isoformat)
 
     @property
     def last_message(self) -> AnyMessage:

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -212,6 +212,7 @@ AGENTIC_RETRIEVAL_QUESTION_PROMPT = "<User question>{question}</User question>"
 NEW_ROUTE_RETRIEVAL_QUESTION_PROMPT = (
     "<User question> {question} </User question> \n\n <Context>: \n\n {agents_results} \n\n </Context> \n\n."
     "<Artifact_Criteria>{artifact_criteria}</Artifact_Criteria>"
+    "<Todays_Date>{todays_date}</Todays_Date>"
 )
 
 AGENTIC_GIVE_UP_QUESTION_PROMPT = "{question}"
@@ -244,6 +245,7 @@ Execution Strategy:
 """
 
 PREVIOUS_AGENT_RESULTS = """<Previous_Agents_Results>{previous_agents_results}</Previous_Agents_Results>"""
+TODAYS_DATE = """<Todays_Date>{todays_date}</Todays_Date>"""
 METADATA = """<Document_Metadata>{metadata}</Document_Metadata>"""
 KNOWLEDGE_BASE_METADTA = """<Knowledge_Base_Metadata>{knowledge_base_metadata}</Knowledge_Base_Metadata> <Tabular_Knowledge_Base_Metadata>{tabular_knowledge_base_metadata}</Tabular_Knowledge_Base_Metadata>"""
 TABULAR_METADATA = """<Tabular_Document_Metadata>{tabular_metadata}</Tabular_Document_Metadata> If no tabular metadata found. Please advise user to reupload their tabular document."""
@@ -469,7 +471,7 @@ If a user asks to summarise a document, ALWAYS call Summarisation_Agent and do n
 Remember that your primary value is in effective coordination and integration - your role is to ensure that the specialised capabilities of each agent are leveraged optimally to achieve the user's goal.
 
 <previous_chat_history>{chat_history}</previous_chat_history>
-
+<Todays_Date>{todays_date}</Todays_Date>
 """
 
 PLANNER_QUESTION_PROMPT = """User question: <Question>{question}</Question>.
@@ -477,6 +479,7 @@ User selected documents: {document_filenames}
 User uploaded documents metadata:<Document_Metadata>{metadata}</Document_Metadata>.
 Contain Knowledge Base: <Contain_Knowledge_Base>{knowledge_base_metadata}</Contain_Knowledge_Base>
 Artifact files: {artifact_files}
+Today's Date: <Todays_Date>{todays_date}</Todays_Date>
 """
 
 PLANNER_FORMAT_PROMPT = """## Output Format
@@ -618,6 +621,18 @@ Guidelines for Tool Usage:
        1-based position in the displayed list — never as a field value.
    3.2 Always retrieve the ID for that item from <previous_tool_results>.
        Never infer, guess, or recall an ID from memory.
+4. Temporal Questions - Date Processing: When the current date is already known, process temporal references directly:
+   4.1 Process:
+     - Use the provided current date
+     - Calculate exact date ranges for temporal references
+     - Always explicitly state the date ranges used in your response
+     - Apply these ranges to search/retrieval tools
+   4.2 Temporal references include: "last month", "this year", "last quarter", "recently", "yesterday", "next week", etc.
+       Example: Current date: 15 Jan 2025 User asks: "What happened last month?"
+     - Calculate: 1 Dec 2024 to 31 Dec 2024
+     - State in response: "Searching for events from 1 December 2024 to 31 December 2024…"
+     - Search using these specific dates
+   4.3 Critical: Always indicate the calculated date ranges in your answer so users understand the exact time period being analysed.
 """
 
 DATAHUB_QUESTION_PROMPT = """ Here is the user question: {question}. Retrieve the relevant information from the database that would answer this question.
@@ -627,4 +642,5 @@ Existing information:
 <previous_chat_history>{chat_history}</previous_chat_history>
 <previous_tool_error>{previous_tool_error}</previous_tool_error>
 <previous_tool_results>{previous_tool_results}</previous_tool_results>
+<Todays_Date>{todays_date}</Todays_Date>
 """

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -245,7 +245,6 @@ Execution Strategy:
 """
 
 PREVIOUS_AGENT_RESULTS = """<Previous_Agents_Results>{previous_agents_results}</Previous_Agents_Results>"""
-TODAYS_DATE = """<Todays_Date>{todays_date}</Todays_Date>"""
 METADATA = """<Document_Metadata>{metadata}</Document_Metadata>"""
 KNOWLEDGE_BASE_METADTA = """<Knowledge_Base_Metadata>{knowledge_base_metadata}</Knowledge_Base_Metadata> <Tabular_Knowledge_Base_Metadata>{tabular_knowledge_base_metadata}</Tabular_Knowledge_Base_Metadata>"""
 TABULAR_METADATA = """<Tabular_Document_Metadata>{tabular_metadata}</Tabular_Document_Metadata> If no tabular metadata found. Please advise user to reupload their tabular document."""


### PR DESCRIPTION
## Context
So agent's can reason about temporal questions.

Previously datahub MCP had its own date tool, but this would clash with planner prompt which would hallucinate dates. This update ensures it is injected into planner, evaluator, and datahub agent promtps.

## What
Injects todays date in ISO format (YYYY-MM-DD) into system prompts.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
