### PR TITLE
fix: fix datahub agent task context, and handling of temporal questions

### DIFF
--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -637,7 +637,7 @@ Guidelines for Tool Usage:
    4.3 Critical: Always indicate the date ranges in your answer so users understand the exact time period being analysed.
 """
 
-DATAHUB_QUESTION_PROMPT = """ Here is the user question: {question}. Your goal is to complete the task <Task>{task}</Task> with the expected output: <Expected_Output>{expected_output}</Expected_Output>. Retrieve the relevant information from the database that would answer this question.
+DATAHUB_QUESTION_PROMPT = """ Your goal is to complete the task <Task>{task}</Task> with the expected output: <Expected_Output>{expected_output}</Expected_Output>. Retrieve the relevant information from the database that would complete this task.
 Expected output: Raw data retrieved from database. Output the raw data and do not output any explanation.
 Please analyse your previous actions in the chat history before you perform the next tool execution.
 Existing information:

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -466,6 +466,10 @@ If a user asks to summarise a document, ALWAYS call Summarisation_Agent and do n
 5. If a user request cannot be fulfilled with the available agents, explain the limitations and suggest an alternative approach.
 6. Always verify that the final integrated response fully addresses the user's original request.
 7. Adapt your plan based on the quality and relevance of each agent's output.
+8. For temporal questions, when a date range is provided in the agent context, pass that exact date range
+   to each task. Do not calculate or interpret temporal references — use the provided range as-is so all
+   tasks operate on the same time period (e.g., "last year" could refer to the last calendar year, or
+   year from today, so the range must be pre-calculated and passed explicitly).
 
 Remember that your primary value is in effective coordination and integration - your role is to ensure that the specialised capabilities of each agent are leveraged optimally to achieve the user's goal.
 
@@ -620,21 +624,20 @@ Guidelines for Tool Usage:
        1-based position in the displayed list — never as a field value.
    3.2 Always retrieve the ID for that item from <previous_tool_results>.
        Never infer, guess, or recall an ID from memory.
-4. Temporal Questions - Date Processing: When the current date is already known, process temporal references directly:
+4. Temporal Questions - Date Processing:
    4.1 Process:
-     - Use the provided current date
-     - Calculate exact date ranges for temporal references
+     - When a date range is provided in the task information, use that range directly
+     - Do not calculate or derive date ranges from temporal references
      - Always explicitly state the date ranges used in your response
      - Apply these ranges to search/retrieval tools
    4.2 Temporal references include: "last month", "this year", "last quarter", "recently", "yesterday", "next week", etc.
-       Example: Current date: 15 Jan 2025 User asks: "What happened last month?"
-     - Calculate: 1 Dec 2024 to 31 Dec 2024
+       Example: Task provides date range: 1 Dec 2024 to 31 Dec 2024
      - State in response: "Searching for events from 1 December 2024 to 31 December 2024…"
      - Search using these specific dates
-   4.3 Critical: Always indicate the calculated date ranges in your answer so users understand the exact time period being analysed.
+   4.3 Critical: Always indicate the date ranges in your answer so users understand the exact time period being analysed.
 """
 
-DATAHUB_QUESTION_PROMPT = """ Here is the user question: {question}. Retrieve the relevant information from the database that would answer this question.
+DATAHUB_QUESTION_PROMPT = """ Here is the user question: {question}. Your goal is to complete the task <Task>{task}</Task> with the expected output: <Expected_Output>{expected_output}</Expected_Output>. Retrieve the relevant information from the database that would answer this question.
 Expected output: Raw data retrieved from database. Output the raw data and do not output any explanation.
 Please analyse your previous actions in the chat history before you perform the next tool execution.
 Existing information:


### PR DESCRIPTION
## Context
Updated datahub agent prompt to include missing task and expected_output prompt variables.

Updated the planner prompt to assert date ranges in tasks to avoid ambiguous ranges (ie. "last year" could refer to last year 2025, or last year from today) clashing across multiple tasks.

## What
- Fixes missing prompt vars in datahub agent
- Updates prompts for handling temporal questions

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
