### PR TITLE
chore: add agent prompt config variable tests

### DIFF
--- a/redbox/tests/graph/agents/test_agent.py
+++ b/redbox/tests/graph/agents/test_agent.py
@@ -2,7 +2,7 @@ import pytest
 from langchain_core.messages import AIMessage
 from pytest_mock import MockerFixture
 
-from redbox.graph.agents.configs import AgentConfig, PromptConfig, PromptVariable, agent_configs
+from redbox.graph.agents.configs import AgentConfig, PromptConfig, PromptVariable, agent_configs, prompt_configs
 from redbox.graph.agents.formats import ArtifactAgent
 from redbox.graph.agents.workers import WorkerAgent
 from redbox.graph.nodes.tools import build_search_wikipedia_tool
@@ -119,3 +119,18 @@ class TestArtifactAgent:
         response = self.agent.post_processing().invoke((fake_state_with_plan, result, task))
         assert response["artifact_criteria"] == "A result"
         assert response["agent_plans"].get_task_status(task.id) == TaskStatus.COMPLETED
+
+
+@pytest.mark.parametrize(
+    "name, prompt_cfg",
+    [
+        (key, value)
+        for key, value in prompt_configs.items()
+        if key not in ["Planner_Agent", "Replanner_Agent", "Summarisation_Agent", "Evaluator_Agent"]
+    ],
+)
+def test_prompt_configs(name, prompt_cfg: PromptConfig):
+    assert "<Task>{task}</Task>" in prompt_cfg.system, f"{name} missing <Task>"
+    assert "<Expected_Output>{expected_output}</Expected_Output>" in prompt_cfg.system, (
+        f"{name} missing <Expected_Output>"
+    )


### PR DESCRIPTION
## Context
A bug in datahub agent which was not caught by tests was missing variables in prompt config. This solves that issue for future.

## What
Automatically tests agent prompt configs 

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
