### PR TITLE
feat: add vscode launch with no container teardown

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,13 +23,20 @@
                 "pattern": "Starting development server",
                 "action": "openExternally",
                 "uriFormat": "http://localhost:8080"
-            },
-            "postDebugTask": "docker-compose down deps"
+            }
         }
     ],
     "compounds": [
         {
             "name": "Full Stack Dev (Frontend + Django)",
+            "type": "compound",
+            "configurations": [
+                "Django: Runserver"
+            ],
+            "preLaunchTask": "start-dev"
+        },
+        {
+            "name": "Full Stack Dev (Frontend + Django) [WITH TEARDOWN]",
             "type": "compound",
             "configurations": [
                 "Django: Runserver"


### PR DESCRIPTION
## Context
So developers can easily restart app without restarting containers every time.

## What
Adds launch config without teardown of dependency containers.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
