### PR TITLE
Bug: Input is too long for requested model in Evaluator Agent

### DIFF
--- a/redbox/redbox/chains/runnables.py
+++ b/redbox/redbox/chains/runnables.py
@@ -1,7 +1,7 @@
 import logging
 import re
-from typing import Any, Callable, Iterable, Iterator
 from datetime import date
+from typing import Any, Callable, Iterable, Iterator
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun, dispatch_custom_event
 from langchain_core.language_models import BaseChatModel
@@ -25,7 +25,7 @@ from redbox.models.chain import ChainChatMessage, PromptSet, RedboxState, get_pr
 from redbox.models.errors import QuestionLengthError
 from redbox.models.graph import RedboxEventType
 from redbox.models.settings import ChatLLMBackend, get_settings
-from redbox.transform import bedrock_tokeniser, flatten_document_state, get_all_metadata
+from redbox.transform import bedrock_tokeniser, combine_agents_state, flatten_document_state, get_all_metadata
 
 log = logging.getLogger()
 re_string_pattern = re.compile(r"(\S+)")
@@ -105,6 +105,26 @@ def build_chat_prompt_from_messages_runnable(
         prompts_budget = bedrock_tokeniser(task_system_prompt) + bedrock_tokeniser(task_question_prompt)
 
         truncated_history = truncate_chat_history(state=state, prompts_budget=prompts_budget, tokeniser=_tokeniser)
+
+        if "agents_results" in _additional_variables:
+            chat_history_tokens = sum(_tokeniser(m["text"]) for m in truncated_history)
+            other_vars_token = _tokeniser(
+                (_additional_variables.get("artifact_criteria") or "") + _additional_variables.get("todays_date", "")
+            )
+
+            safety_margin = 2000
+            agents_budget = (
+                ai_settings.context_window_size
+                - ai_settings.llm_max_tokens
+                - prompts_budget
+                - chat_history_tokens
+                - other_vars_token
+                - safety_margin
+            )
+            _additional_variables = {
+                **additional_variables,
+                "agents_results": combine_agents_state(state.agents_results, max_tokens=agents_budget),
+            }
 
         prompt_template_context = (
             state.request.model_dump()

--- a/redbox/redbox/chains/runnables.py
+++ b/redbox/redbox/chains/runnables.py
@@ -104,10 +104,11 @@ def build_chat_prompt_from_messages_runnable(
             """
         prompts_budget = bedrock_tokeniser(task_system_prompt) + bedrock_tokeniser(task_question_prompt)
 
-        truncated_history = truncate_chat_history(state=state, prompts_budget=prompts_budget, tokeniser=_tokeniser)
+        # Agent results take priority over chat history
+        # Size the agent results first against the available budget, then chat history fits into the remainder
+        history_reservation = prompts_budget
 
         if "agents_results" in _additional_variables:
-            chat_history_tokens = sum(_tokeniser(m["text"]) for m in truncated_history)
             other_vars_token = _tokeniser(
                 (_additional_variables.get("artifact_criteria") or "") + _additional_variables.get("todays_date", "")
             )
@@ -117,14 +118,21 @@ def build_chat_prompt_from_messages_runnable(
                 ai_settings.context_window_size
                 - ai_settings.llm_max_tokens
                 - prompts_budget
-                - chat_history_tokens
                 - other_vars_token
                 - safety_margin
             )
+            combine_agents_results = combine_agents_state(state.agents_results, max_tokens=agents_budget)
+
             _additional_variables = {
                 **additional_variables,
-                "agents_results": combine_agents_state(state.agents_results, max_tokens=agents_budget),
+                "agents_results": combine_agents_results,
             }
+            agent_results_tokens = (
+                _tokeniser(combine_agents_results.get("all_result", "")) if combine_agents_results else 0
+            )
+            history_reservation += agent_results_tokens + other_vars_token + safety_margin
+
+        truncated_history = truncate_chat_history(state=state, prompts_budget=history_reservation, tokeniser=_tokeniser)
 
         prompt_template_context = (
             state.request.model_dump()

--- a/redbox/redbox/chains/runnables.py
+++ b/redbox/redbox/chains/runnables.py
@@ -113,7 +113,7 @@ def build_chat_prompt_from_messages_runnable(
                 (_additional_variables.get("artifact_criteria") or "") + _additional_variables.get("todays_date", "")
             )
 
-            safety_margin = 2000
+            safety_margin = 2000  # Buffer for chat template scaffolding and a difference in the token count from bedrock's and the models tokeniser
             agents_budget = (
                 ai_settings.context_window_size
                 - ai_settings.llm_max_tokens

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -6,12 +6,12 @@ import re
 import sqlite3
 import time
 from collections.abc import Callable
+from datetime import date
 from functools import reduce
 from io import StringIO
 from random import uniform
 from typing import Any, Iterable
 from uuid import uuid4
-from datetime import date
 
 import pandas as pd
 from botocore.exceptions import EventStreamError
@@ -29,6 +29,7 @@ from redbox.chains.components import get_chat_llm, get_structured_response_with_
 from redbox.chains.parser import ClaudeParser
 from redbox.chains.runnables import CannedChatLLM, build_llm_chain, chain_use_metadata, create_chain_agent
 from redbox.graph.nodes.sends import run_tools_parallel
+from redbox.graph.nodes.tools import get_datahub_mcp_tools
 from redbox.models import ChatRoute
 from redbox.models.chain import (
     DocumentState,
@@ -40,12 +41,13 @@ from redbox.models.chain import (
     configure_agent_task_plan,
     get_plan_fix_prompts,
     get_plan_fix_suggestion_prompts,
+    get_prompts,
 )
 from redbox.models.graph import ROUTE_NAME_TAG, RedboxActivityEvent, RedboxEventType
 from redbox.models.prompts import USER_FEEDBACK_EVAL_PROMPT
 from redbox.models.settings import ChatLLMBackend
-from redbox.graph.nodes.tools import get_datahub_mcp_tools
 from redbox.transform import (
+    bedrock_tokeniser,
     combine_agents_state,
     combine_documents,
     flatten_document_state,
@@ -778,8 +780,26 @@ def build_datahub_agent_with_loop(
 
 def create_evaluator():
     def _create_evaluator(state: RedboxState):
+        ai_settings = state.request.ai_settings
+        system_prompt, question_prompt, _ = get_prompts(state, PromptSet.NewRoute)
+        chat_history_tokens = sum(bedrock_tokeniser(m["text"]) for m in state.request.chat_history)
+
+        other_vars_token = bedrock_tokeniser((state.artifact_criteria or "") + date.today().isoformat())
+
+        safety_margin = 2000
+
+        agents_budget = (
+            ai_settings.context_window_size
+            - ai_settings.llm_max_tokens
+            - bedrock_tokeniser(system_prompt)
+            - bedrock_tokeniser(question_prompt)
+            - chat_history_tokens
+            - other_vars_token
+            - safety_margin
+        )
+
         _additional_variables = {
-            "agents_results": combine_agents_state(state.agents_results),
+            "agents_results": combine_agents_state(state.agents_results, max_tokens=agents_budget),
             "artifact_criteria": state.artifact_criteria,
             "todays_date": date.today().isoformat(),
         }

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -41,18 +41,11 @@ from redbox.models.chain import (
     configure_agent_task_plan,
     get_plan_fix_prompts,
     get_plan_fix_suggestion_prompts,
-    get_prompts,
 )
 from redbox.models.graph import ROUTE_NAME_TAG, RedboxActivityEvent, RedboxEventType
 from redbox.models.prompts import USER_FEEDBACK_EVAL_PROMPT
 from redbox.models.settings import ChatLLMBackend
-from redbox.transform import (
-    bedrock_tokeniser,
-    combine_agents_state,
-    combine_documents,
-    flatten_document_state,
-    join_result_with_token_limit,
-)
+from redbox.transform import combine_documents, flatten_document_state, join_result_with_token_limit
 
 log = logging.getLogger(__name__)
 re_keyword_pattern = re.compile(r"@(\w+)")
@@ -780,29 +773,6 @@ def build_datahub_agent_with_loop(
 
 def create_evaluator():
     def _create_evaluator(state: RedboxState):
-        ai_settings = state.request.ai_settings
-        system_prompt, question_prompt, _ = get_prompts(state, PromptSet.NewRoute)
-        chat_history_tokens = sum(bedrock_tokeniser(m["text"]) for m in state.request.chat_history)
-
-        other_vars_token = bedrock_tokeniser((state.artifact_criteria or "") + date.today().isoformat())
-
-        safety_margin = 2000
-
-        agents_budget = (
-            ai_settings.context_window_size
-            - ai_settings.llm_max_tokens
-            - bedrock_tokeniser(system_prompt)
-            - bedrock_tokeniser(question_prompt)
-            - chat_history_tokens
-            - other_vars_token
-            - safety_margin
-        )
-
-        _additional_variables = {
-            "agents_results": combine_agents_state(state.agents_results, max_tokens=agents_budget),
-            "artifact_criteria": state.artifact_criteria,
-            "todays_date": date.today().isoformat(),
-        }
         citation_parser, format_instructions = get_structured_response_with_citations_parser()
         evaluator_agent = build_stuff_pattern(
             prompt_set=PromptSet.NewRoute,
@@ -810,7 +780,11 @@ def create_evaluator():
             output_parser=citation_parser,
             format_instructions=format_instructions,
             final_response_chain=False,
-            additional_variables=_additional_variables,
+            additional_variables={
+                "agents_results": None,
+                "artifact_criteria": state.artifact_criteria,
+                "todays_date": date.today().isoformat(),
+            },
         )
         return evaluator_agent
 

--- a/redbox/redbox/transform.py
+++ b/redbox/redbox/transform.py
@@ -343,9 +343,41 @@ def sort_documents(documents: list[Document]) -> list[Document]:
     return list(itertools.chain.from_iterable(all_sorted_blocks_by_max_score))
 
 
-def combine_agents_state(agents_results: Dict[str, AnyMessage]):
-    """Combine a list of agent results into a string."""
+TRUNCATION_MARKER = " ...[truncated]"
+
+
+def combine_agents_state(agents_results: Dict[str, AnyMessage], max_tokens: int) -> dict:
+    """
+    Combine a list of agent results into a string.
+    OR if it is over the max amount, truncating proportially
+    A truncation marker is appended to any block, so the downstream LLM knows that the content is incomplete
+    """
     if not agents_results:
         return {}
-    flatten_agent_results = "\n\n".join([msg.content for msg in agents_results.values()])
-    return {"all_result": flatten_agent_results}
+    sizes = {aid: bedrock_tokeniser(msg.content) for aid, msg in agents_results.values()}
+    total_tokens = sum(sizes.valuesU())
+
+    if max_tokens <= 0:
+        log.warning("combine_agents_state: non-positive token budget, returning empty result!")
+
+    if total_tokens <= max_tokens:
+        flatten_agent_results = "\n\n".join([msg.content for msg in agents_results.values()])
+        return {"all_result": flatten_agent_results}
+
+    marker_cost = bedrock_tokeniser(TRUNCATION_MARKER)
+    parts: list[str] = []
+    for agent_id, msg in agents_results.items():
+        original_tokens = sizes[agent_id]
+        share = max(1, int(max_tokens * original_tokens / total_tokens))
+        if original_tokens <= share:
+            parts.append(msg.content)
+        else:
+            budget = max(1, share - marker_cost)
+            truncated, _ = truncate_to_tokens(msg.content, budget)
+            parts.append(truncated + TRUNCATION_MARKER)
+            log.warning(
+                "combine_agents_state: truncated agent %s from %d to ~%d tokens.",
+                agent_id,
+                original_tokens,
+                share,
+            )

--- a/redbox/redbox/transform.py
+++ b/redbox/redbox/transform.py
@@ -382,4 +382,7 @@ def combine_agents_state(agents_results: Dict[str, AnyMessage], max_tokens: int)
                 original_tokens,
                 share,
             )
-    return {"all_result": "\n\n".join(parts)}
+    joined = "/n/n".join(parts)
+    if bedrock_tokeniser(joined) > max_tokens:
+        joined, _ = truncate_to_tokens(joined, max_tokens)
+    return {"all_result": joined}

--- a/redbox/redbox/transform.py
+++ b/redbox/redbox/transform.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import re
+import math
 from typing import Dict, Iterable
 from uuid import NAMESPACE_DNS, UUID, uuid5
 
@@ -369,7 +370,7 @@ def combine_agents_state(agents_results: Dict[str, AnyMessage], max_tokens: int)
     parts: list[str] = []
     for agent_id, msg in agents_results.items():
         original_tokens = sizes[agent_id]
-        share = max(1, int(max_tokens * original_tokens / total_tokens))
+        share = max(1, math.floor(max_tokens * original_tokens / total_tokens))
         if original_tokens <= share:
             parts.append(msg.content)
         else:

--- a/redbox/redbox/transform.py
+++ b/redbox/redbox/transform.py
@@ -382,7 +382,7 @@ def combine_agents_state(agents_results: Dict[str, AnyMessage], max_tokens: int)
                 original_tokens,
                 share,
             )
-    joined = "/n/n".join(parts)
+    joined = "\n\n".join(parts)
     if bedrock_tokeniser(joined) > max_tokens:
         joined, _ = truncate_to_tokens(joined, max_tokens)
     return {"all_result": joined}

--- a/redbox/redbox/transform.py
+++ b/redbox/redbox/transform.py
@@ -354,11 +354,12 @@ def combine_agents_state(agents_results: Dict[str, AnyMessage], max_tokens: int)
     """
     if not agents_results:
         return {}
-    sizes = {aid: bedrock_tokeniser(msg.content) for aid, msg in agents_results.values()}
-    total_tokens = sum(sizes.valuesU())
+    sizes = {aid: bedrock_tokeniser(msg.content) for aid, msg in agents_results.items()}
+    total_tokens = sum(sizes.values())
 
     if max_tokens <= 0:
         log.warning("combine_agents_state: non-positive token budget, returning empty result!")
+        return {}
 
     if total_tokens <= max_tokens:
         flatten_agent_results = "\n\n".join([msg.content for msg in agents_results.values()])
@@ -381,3 +382,4 @@ def combine_agents_state(agents_results: Dict[str, AnyMessage], max_tokens: int)
                 original_tokens,
                 share,
             )
+    return {"all_result": "\n\n".join(parts)}

--- a/redbox/tests/test_transform.py
+++ b/redbox/tests/test_transform.py
@@ -509,7 +509,7 @@ EVALUATOR_AGENT_RESULT_MAX = CONTEXT_WINDOW - LLM_MAX_TOKENS - PROMPT_SCAFFOLDIN
     ],
 )
 def test_combine_agents_state_fits_within_eval_agent_max(test_name, agents_results):
-    combined = combine_agents_state(agents_results)
+    combined = combine_agents_state(agents_results, max_tokens=EVALUATOR_AGENT_RESULT_MAX)
     output_tokens = bedrock_tokeniser(combined["all_results"])
     assert output_tokens <= EVALUATOR_AGENT_RESULT_MAX
 
@@ -519,9 +519,9 @@ def test_combine_agents_small_inputs_pass_through_unchanged():
         "Agent_A": AIMessage("result a"),
         "Agent_B": AIMessage("result b"),
     }
-    combined = combine_agents_state(agents_results)
+    combined = combine_agents_state(agents_results, max_tokens=EVALUATOR_AGENT_RESULT_MAX)
     assert combined == {"all_result": "result a\n\nresult b"}
 
 
 def test_combine_agents_state_empty_input_returns_empty_dict():
-    assert combine_agents_state({}) == {}
+    assert combine_agents_state({}, max_tokens=EVALUATOR_AGENT_RESULT_MAX) == {}

--- a/redbox/tests/test_transform.py
+++ b/redbox/tests/test_transform.py
@@ -12,6 +12,7 @@ from redbox.models.chain import DocumentState, LLMCallMetadata, RequestMetadata
 from redbox.retriever.retrievers import filter_by_elbow
 from redbox.test.data import generate_docs
 from redbox.transform import (
+    TRUNCATION_MARKER,
     bedrock_tokeniser,
     combine_agents_state,
     combine_documents,
@@ -525,3 +526,15 @@ def test_combine_agents_small_inputs_pass_through_unchanged():
 
 def test_combine_agents_state_empty_input_returns_empty_dict():
     assert combine_agents_state({}, max_tokens=EVALUATOR_AGENT_RESULT_MAX) == {}
+
+
+def test_combine_agents_state_marks_truncated():
+    agents_results = {"Huge": AIMessage(" ".join(["x"] * 2000000))}
+    combined = combine_agents_state(agents_results, max_tokens=EVALUATOR_AGENT_RESULT_MAX)
+    assert TRUNCATION_MARKER in combined["all_result"]
+
+
+def test_combine_agents_state_marks_not_truncated():
+    agents_results = {"Small": AIMessage("Hello world!")}
+    combined = combine_agents_state(agents_results, max_tokens=EVALUATOR_AGENT_RESULT_MAX)
+    assert TRUNCATION_MARKER not in combined["all_result"]

--- a/redbox/tests/test_transform.py
+++ b/redbox/tests/test_transform.py
@@ -510,7 +510,7 @@ EVALUATOR_AGENT_RESULT_MAX = CONTEXT_WINDOW - LLM_MAX_TOKENS - PROMPT_SCAFFOLDIN
 )
 def test_combine_agents_state_fits_within_eval_agent_max(test_name, agents_results):
     combined = combine_agents_state(agents_results, max_tokens=EVALUATOR_AGENT_RESULT_MAX)
-    output_tokens = bedrock_tokeniser(combined["all_results"])
+    output_tokens = bedrock_tokeniser(combined["all_result"])
     assert output_tokens <= EVALUATOR_AGENT_RESULT_MAX
 
 

--- a/redbox/tests/test_transform.py
+++ b/redbox/tests/test_transform.py
@@ -12,14 +12,16 @@ from redbox.models.chain import DocumentState, LLMCallMetadata, RequestMetadata
 from redbox.retriever.retrievers import filter_by_elbow
 from redbox.test.data import generate_docs
 from redbox.transform import (
+    bedrock_tokeniser,
+    combine_agents_state,
     combine_documents,
+    join_result_with_token_limit,
     merge_documents,
     sort_documents,
     structure_documents_by_file_name,
     structure_documents_by_group_and_indices,
     to_request_metadata,
     truncate_to_tokens,
-    join_result_with_token_limit,
 )
 
 document_created = datetime.now(UTC)
@@ -481,3 +483,45 @@ def test_join_result_with_token_limit(
 ):
     result = join_result_with_token_limit(result=input_result_list, max_tokens=input_max_tokens, log_stub="")
     assert result == expected_result, f"{test_name} - Expected Text: {expected_result!r}, Got: {result!r}"
+
+
+CONTEXT_WINDOW = 128000
+LLM_MAX_TOKENS = 1024
+PROMPT_SCAFFOLDING_MAX = 8000
+EVALUATOR_AGENT_RESULT_MAX = CONTEXT_WINDOW - LLM_MAX_TOKENS - PROMPT_SCAFFOLDING_MAX
+
+
+@pytest.mark.parametrize(
+    ("test_name", "agents_results"),
+    [
+        (
+            "single-huge-agent-output--exceeds-context-window",
+            {"DataHub_Agent": AIMessage(" ".join(["word"] * 130000))},
+        ),
+        (
+            "multiple-medium-agent-outputs--aggregate-exceeds-context-window",
+            {f"Agent_{i}": AIMessage(" ".join(["filler"] * 15000)) for i in range(10)},
+        ),
+        (
+            "mixed-small-and-huge-agent-outputs--combined-exceeds-context-window",
+            {"Small_Agent": AIMessage("Short result"), "Huge_Agent": AIMessage(" ".join(["x"] * 200000))},
+        ),
+    ],
+)
+def test_combine_agents_state_fits_within_eval_agent_max(test_name, agents_results):
+    combined = combine_agents_state(agents_results)
+    output_tokens = bedrock_tokeniser(combined["all_results"])
+    assert output_tokens <= EVALUATOR_AGENT_RESULT_MAX
+
+
+def test_combine_agents_small_inputs_pass_through_unchanged():
+    agents_results = {
+        "Agent_A": AIMessage("result a"),
+        "Agent_B": AIMessage("result b"),
+    }
+    combined = combine_agents_state(agents_results)
+    assert combined == {"all_result": "result a\n\nresult b"}
+
+
+def test_combine_agents_state_empty_input_returns_empty_dict():
+    assert combine_agents_state({}) == {}


### PR DESCRIPTION
## Context

Error generated from sending too long input to Claude model in Evaluator agent.

At the present the evaluator only accounts for the size of previous chat history, however it does not account for the size of the inputs from other agents, therefore the input size could exceed the context limit.

## What

Implement the fix so that we post process information sent from upstream agents if the context size is exceeded.
Before: the input size check only counted the chat history, and not the agents output, so the total prompt could exceed the context limit and error.
What was done:
- updated combinre_agents_state to truncate each agent's output if it is too big, with a [truncated] marker so the model knows that the output was truncated / is incomplete
- updated evaluator to calculate the size available remaining and pass that on as the budget
- trimmed the joined result so rounding and markers doesn't push it over the limit 

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
