### PR TITLE
feat: add new mcp result type for citations on paged 'composite' results

### DIFF
--- a/redbox/redbox/api/format.py
+++ b/redbox/redbox/api/format.py
@@ -85,6 +85,13 @@ def format_mcp_tool_response(tool_response, creator_type: ChunkCreatorType) -> t
             paged_results = [v for v in paged_data.values() if v is not None]
             for page in paged_results:
                 deep_links += [(item.get("url"), item) for item in page.get("result", {}).get("items", [])]
+        case "paged_composite":
+            for company, paged_activity_data in result.get("items", []):
+                deep_links.append((company.get("url"), company))
+                for paged_activity in paged_activity_data.values():
+                    deep_links += [
+                        (item.get("url"), item) for item in paged_activity.get("result", {}).get("items", [])
+                    ]
 
     response = []
     for link, item in deep_links:

--- a/redbox/tests/api/test_format.py
+++ b/redbox/tests/api/test_format.py
@@ -115,6 +115,50 @@ class TestFormatMCPToolResponse:
                     ("https://g.com", {"url": "https://g.com"}),
                 ],
             ),
+            (
+                {
+                    "result_type": "paged_composite",
+                    "result": {
+                        "items": [
+                            (
+                                {"url": "https://parent.com", "title": "Parent"},
+                                {
+                                    "interactions": {
+                                        "result": {
+                                            "items": [{"url": "https://f.com"}, {"url": "https://g.com"}],
+                                            "total": 2,
+                                            "page": 0,
+                                            "page_size": 10,
+                                        }
+                                    }
+                                },
+                            ),
+                            (
+                                {"url": "https://parent2.com", "title": "Parent2"},
+                                {
+                                    "interactions": {
+                                        "result": {
+                                            "items": [{"url": "https://f2.com"}, {"url": "https://g2.com"}],
+                                            "total": 2,
+                                            "page": 0,
+                                            "page_size": 10,
+                                        }
+                                    }
+                                },
+                            ),
+                        ]
+                    },
+                    "metadata": MCPResponseMetadata().model_dump(),
+                },
+                [
+                    ("https://parent.com", {"url": "https://parent.com", "title": "Parent"}),
+                    ("https://f.com", {"url": "https://f.com"}),
+                    ("https://g.com", {"url": "https://g.com"}),
+                    ("https://parent2.com", {"url": "https://parent2.com", "title": "Parent2"}),
+                    ("https://f2.com", {"url": "https://f2.com"}),
+                    ("https://g2.com", {"url": "https://g2.com"}),
+                ],
+            ),
         ],
     )
     def test_documents_metadata(self, data, expected):


### PR DESCRIPTION
## Context
To facilitate citations on new exploratory company activity tool we need to be able to handle 'paged composite' results. 'Composite' result types are already supported and are used for results which include information about a parent datapoint and respective child datapoints.

To support exploratory querying across multiple companies we need to support paged versions of these composite results.

## What
This PR adds support for formatting and parsing for paged composite types allowing citations across all datapoints.

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

- This is currently only supported via new exploratory company activity MCP tool https://github.com/uktrade/data_hub_mcp/pull/66

## Relevant links
