### PR TITLE
Added structured log events for datahub_agent

### DIFF
--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -6,15 +6,16 @@ import re
 import sqlite3
 import time
 from collections.abc import Callable
+from datetime import date
 from functools import reduce
 from io import StringIO
 from random import uniform
 from typing import Any, Iterable
 from uuid import uuid4
-from datetime import date
 
 import pandas as pd
 from botocore.exceptions import EventStreamError
+from ddtrace import tracer
 from langchain.schema import StrOutputParser
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.documents import Document
@@ -29,6 +30,7 @@ from redbox.chains.components import get_chat_llm, get_structured_response_with_
 from redbox.chains.parser import ClaudeParser
 from redbox.chains.runnables import CannedChatLLM, build_llm_chain, chain_use_metadata, create_chain_agent
 from redbox.graph.nodes.sends import run_tools_parallel
+from redbox.graph.nodes.tools import get_datahub_mcp_tools
 from redbox.models import ChatRoute
 from redbox.models.chain import (
     DocumentState,
@@ -44,7 +46,6 @@ from redbox.models.chain import (
 from redbox.models.graph import ROUTE_NAME_TAG, RedboxActivityEvent, RedboxEventType
 from redbox.models.prompts import USER_FEEDBACK_EVAL_PROMPT
 from redbox.models.settings import ChatLLMBackend
-from redbox.graph.nodes.tools import get_datahub_mcp_tools
 from redbox.transform import (
     combine_agents_state,
     combine_documents,
@@ -604,14 +605,31 @@ def build_datahub_agent_with_loop(
 ):
     @RunnableLambda
     async def _build_datahub_agent_with_loop(state: RedboxState):
-        tools = []
-        if sso_token_getter := state.request.sso_token_getter:
-            tools = await get_datahub_mcp_tools(sso_token_getter=sso_token_getter)
+        started_at = time.monotonic()
+        # DataDog spam - will give latency, error rate and throughput
+        with tracer.trace("assist.datahub_agent.run", service="assist", resource=agent_name) as span:
+            span.set_tag("assist.agent", agent_name)
+            span.set_tag("assist.user_uuid", str(getattr(state.request, "user_uuid", "")))
 
-        if not tools:
-            log.error(f"[{agent_name}] No tools available")
+            tools = []
+            if sso_token_getter := state.request.sso_token_getter:
+                tools = await get_datahub_mcp_tools(sso_token_getter=sso_token_getter)
 
-        log.warning(f"[{agent_name}] Starting datahub_agent_with_loop run. Tools: {[t.name for t in tools]}")
+            log.info(
+                "datahub_agent.invoked",
+                extra={
+                    "event": "datahub_agent.invoked",
+                    "agent": agent_name,
+                    "tool_count": len(tools),
+                    "user_uuid": str(getattr(state.request, "user_uuid", "")),
+                },
+            )
+            span.set_tag("assist.tool_count", len(tools))
+
+            if not tools:
+                log.error(f"[{agent_name}] No tools available")
+
+            log.warning(f"[{agent_name}] Starting datahub_agent_with_loop run. Tools: {[t.name for t in tools]}")
 
         local_loop_condition = loop_condition
         agent_options = state.request.ai_settings.get_worker_agents_options
@@ -668,6 +686,16 @@ def build_datahub_agent_with_loop(
 
         if len(tools) == 0:
             all_results = "Error. Unable to complete request the '{agent_name}' agent has no tools."
+            log.warning(
+                "datahub_agent.completed",
+                extra={
+                    "event": "datahub_agent.completed",
+                    "agent": agent_name,
+                    "outcome": "failed_no_tools",
+                    "iterations": 0,
+                    "duration": int(time.monotonic - started_at),
+                },
+            )
             return {
                 "agents_results": {
                     task.id: AIMessage(content=f"<{agent_name}_Result>{all_results}</{agent_name}_Result>")
@@ -732,6 +760,16 @@ def build_datahub_agent_with_loop(
 
                 if feedback_reasons:
                     combined_feedback = "\n\n".join(feedback_reasons)
+                    log.info(
+                        "datahub_agent.completed",
+                        extra={
+                            "event": "datahub_agent.completed",
+                            "agent": agent_name,
+                            "outcome": "requires_user_feedback",
+                            "iterations": num_iter,
+                            "duration": int(time.monotonic - started_at),
+                        },
+                    )
                     return {
                         "agents_results": {
                             task.id: AIMessage(
@@ -766,6 +804,16 @@ def build_datahub_agent_with_loop(
             log.warning(f"{log_stub} Completed agent run.")
 
         log.warning(f"[{agent_name}] Completed agent_with_loop run.")
+        log.info(
+            "datahub_agent.completed",
+            extra={
+                "event": "datahub_agent.completed",
+                "agent": agent_name,
+                "outcome": "completed",
+                "iterations": num_iter,
+                "duration": int(time.monotonic - started_at),
+            },
+        )
         all_results = join_result_with_token_limit(result=all_results, max_tokens=max_tokens, log_stub=log_stub)
         return {
             "agents_results": {task.id: AIMessage(content=f"<{agent_name}_Result>{all_results}</{agent_name}_Result>")},

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -693,7 +693,7 @@ def build_datahub_agent_with_loop(
                     "agent": agent_name,
                     "outcome": "failed_no_tools",
                     "iterations": 0,
-                    "duration": int(time.monotonic - started_at),
+                    "duration": int(time.monotonic() - started_at),
                 },
             )
             return {
@@ -767,7 +767,7 @@ def build_datahub_agent_with_loop(
                             "agent": agent_name,
                             "outcome": "requires_user_feedback",
                             "iterations": num_iter,
-                            "duration": int(time.monotonic - started_at),
+                            "duration": int(time.monotonic() - started_at),
                         },
                     )
                     return {
@@ -811,7 +811,7 @@ def build_datahub_agent_with_loop(
                 "agent": agent_name,
                 "outcome": "completed",
                 "iterations": num_iter,
-                "duration": int(time.monotonic - started_at),
+                "duration": int(time.monotonic() - started_at),
             },
         )
         all_results = join_result_with_token_limit(result=all_results, max_tokens=max_tokens, log_stub=log_stub)

--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -982,7 +982,7 @@ def build_legislation_search_tool():
 
 async def get_datahub_mcp_tools(sso_token_getter: Callable[[], str] | None = None, agent_loop=True):
     try:
-        log.info("get_datahub_mcp_tools - Loading Datahub MCP tools...")
+        log.info("datahub_mcp.connect.started", extra={"event": "datahub_mcp.connect.started"})
 
         mcp_settings = get_settings().datahub_mcp
         datahub_mcp_url = mcp_settings.url
@@ -1020,7 +1020,11 @@ async def get_datahub_mcp_tools(sso_token_getter: Callable[[], str] | None = Non
                     if "is_intermediate_step" not in tool.args_schema["required"]:
                         tool.args_schema["required"].append("is_intermediate_step")
 
+            log.info(
+                "datahub_mcp.connect.suceeded",
+                extra={"event": "datahub_mcp.connect.suceeded", "tool_count": len(tools)},
+            )
             return tools
     except Exception as e:
-        log.error("get_datahub_mcp_tools - Unable to connect to MCP server - %s", e)
+        log.error("datahub_mcp.connect.failed", extra={"event": "datahub_mcp.connect.failed", "error": str(e)})
         return []

--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -1021,8 +1021,8 @@ async def get_datahub_mcp_tools(sso_token_getter: Callable[[], str] | None = Non
                         tool.args_schema["required"].append("is_intermediate_step")
 
             log.info(
-                "datahub_mcp.connect.suceeded",
-                extra={"event": "datahub_mcp.connect.suceeded", "tool_count": len(tools)},
+                "datahub_mcp.connect.succeeded",
+                extra={"event": "datahub_mcp.connect.succeeded", "tool_count": len(tools)},
             )
             return tools
     except Exception as e:


### PR DESCRIPTION
## Context

Added structured log events for datahub_agent and an APM sapan around the Datahub agent run (this will give us outcome, duration and iterations)
Dashboard widget will be added to datadog once the events are live, then we can track the update and usage here.


## What

Added structured log events for datahub_agent so we can track uptake of the Data Hub agent in Assist.

There should be no behaviour changes - it is just adding to the logs so that we can trace the events in datadog and therefore observe the usage on a dashboard.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)
No tests added but please do suggest if think there would be any useful to add for this


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
