### PR TITLE
fix: fix format MCP tool response for null pages in paged_composite result type

### DIFF
--- a/redbox/redbox/api/format.py
+++ b/redbox/redbox/api/format.py
@@ -89,9 +89,10 @@ def format_mcp_tool_response(tool_response, creator_type: ChunkCreatorType) -> t
             for company, paged_activity_data in result.get("items", []):
                 deep_links.append((company.get("url"), company))
                 for paged_activity in paged_activity_data.values():
-                    deep_links += [
-                        (item.get("url"), item) for item in paged_activity.get("result", {}).get("items", [])
-                    ]
+                    if paged_activity:
+                        deep_links += [
+                            (item.get("url"), item) for item in paged_activity.get("result", {}).get("items", [])
+                        ]
 
     response = []
     for link, item in deep_links:

--- a/redbox/tests/api/test_format.py
+++ b/redbox/tests/api/test_format.py
@@ -93,6 +93,27 @@ class TestFormatMCPToolResponse:
             ),
             (
                 {
+                    "result_type": "multipaged",
+                    "result": {
+                        "companies": {
+                            "result": {
+                                "items": [{"url": "https://c.com"}, {"url": "https://d.com"}],
+                                "total": 2,
+                                "page": 0,
+                                "page_size": 10,
+                            }
+                        },
+                        "interactions": None,
+                    },
+                    "metadata": MCPResponseMetadata().model_dump(),
+                },
+                [
+                    ("https://c.com", {"url": "https://c.com"}),
+                    ("https://d.com", {"url": "https://d.com"}),
+                ],
+            ),
+            (
+                {
                     "result_type": "composite",
                     "result": [
                         {"url": "https://parent.com", "title": "Parent"},
@@ -192,6 +213,20 @@ class TestFormatMCPToolResponse:
                                     "projects": None,
                                 },
                             ),
+                            (
+                                {"url": "https://parent3.com", "title": "Parent3"},
+                                {
+                                    "interactions": {
+                                        "result": {
+                                            "items": [],
+                                            "total": 0,
+                                            "page": 0,
+                                            "page_size": 10,
+                                        }
+                                    },
+                                    "projects": None,
+                                },
+                            ),
                         ]
                     },
                     "metadata": MCPResponseMetadata().model_dump(),
@@ -203,6 +238,7 @@ class TestFormatMCPToolResponse:
                     ("https://parent2.com", {"url": "https://parent2.com", "title": "Parent2"}),
                     ("https://f2.com", {"url": "https://f2.com"}),
                     ("https://g2.com", {"url": "https://g2.com"}),
+                    ("https://parent3.com", {"url": "https://parent3.com", "title": "Parent3"}),
                 ],
             ),
         ],

--- a/redbox/tests/api/test_format.py
+++ b/redbox/tests/api/test_format.py
@@ -159,6 +159,52 @@ class TestFormatMCPToolResponse:
                     ("https://g2.com", {"url": "https://g2.com"}),
                 ],
             ),
+            (
+                {
+                    "result_type": "paged_composite",
+                    "result": {
+                        "items": [
+                            (
+                                {"url": "https://parent.com", "title": "Parent"},
+                                {
+                                    "interactions": {
+                                        "result": {
+                                            "items": [{"url": "https://f.com"}, {"url": "https://g.com"}],
+                                            "total": 2,
+                                            "page": 0,
+                                            "page_size": 10,
+                                        }
+                                    },
+                                    "projects": None,
+                                },
+                            ),
+                            (
+                                {"url": "https://parent2.com", "title": "Parent2"},
+                                {
+                                    "interactions": {
+                                        "result": {
+                                            "items": [{"url": "https://f2.com"}, {"url": "https://g2.com"}],
+                                            "total": 2,
+                                            "page": 0,
+                                            "page_size": 10,
+                                        }
+                                    },
+                                    "projects": None,
+                                },
+                            ),
+                        ]
+                    },
+                    "metadata": MCPResponseMetadata().model_dump(),
+                },
+                [
+                    ("https://parent.com", {"url": "https://parent.com", "title": "Parent"}),
+                    ("https://f.com", {"url": "https://f.com"}),
+                    ("https://g.com", {"url": "https://g.com"}),
+                    ("https://parent2.com", {"url": "https://parent2.com", "title": "Parent2"}),
+                    ("https://f2.com", {"url": "https://f2.com"}),
+                    ("https://g2.com", {"url": "https://g2.com"}),
+                ],
+            ),
         ],
     )
     def test_documents_metadata(self, data, expected):


### PR DESCRIPTION
## Context
To support null pages in paged_composite MCP result types.

## What
Avoids decoding null pages.

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
