### PR TITLE
feature/ASSIST-1500-info-and-relationships

### DIFF
--- a/django_app/redbox_app/templates/chat/chat_feed.html
+++ b/django_app/redbox_app/templates/chat/chat_feed.html
@@ -5,9 +5,12 @@
 {% from "macros/upload_form.html" import upload_form %}
 
 <div id="chat-feed" class="ids-chat-feed" hx-swap-oob="outerHTML">
+
     {% if not messages %}
         <canned-prompts class="chat-options govuk-!-padding-top-5 govuk-!-padding-bottom-1" security-classification="{{ security }}">
+            <h1 class="govuk-visually-hidden">New chat for {{ tool if tool else product_name(request) }}</h1>
             {% if tool %}
+
                 {% include ["tools/canned_prompts/" ~ tool.slug ~ ".html", "chat/default_canned_prompt.html"] %}
             {% else %}
                 {% include "chat/default_canned_prompt.html" %}

--- a/django_app/redbox_app/templates/chat/chat_title.html
+++ b/django_app/redbox_app/templates/chat/chat_title.html
@@ -9,7 +9,8 @@
             {% call editable_text(chat_edit_url, 'chat-title-change', 'chat-title', current_chat.id) %}
                 <div class="ids-chat-title__heading-container-inner display">
                     {% if current_chat.name %}
-                        <h1 class="ids-chat-title__heading govuk-heading-s title-text">{{ current_chat.name }}</h1>
+                        <h1 class="govuk-visually-hidden">Chat for {{ current_chat.name }}</h1>
+                        <h2 class="ids-chat-title__heading govuk-heading-s title-text">{{ current_chat.name }}</h2>
                         <button id="chat-title-edit-button" class="edit-trigger ids-icon-button" type="button">
                             {{ ids_icon(icon_name="edit.html") }}
                             <span class="govuk-visually-hidden">Chat Title</span>

--- a/django_app/redbox_app/templates/chat/chat_title.html
+++ b/django_app/redbox_app/templates/chat/chat_title.html
@@ -9,7 +9,7 @@
             {% call editable_text(chat_edit_url, 'chat-title-change', 'chat-title', current_chat.id) %}
                 <div class="ids-chat-title__heading-container-inner display">
                     {% if current_chat.name %}
-                        <h2 class="ids-chat-title__heading govuk-heading-s title-text">{{ current_chat.name }}</h2>
+                        <h1 class="ids-chat-title__heading govuk-heading-s title-text">{{ current_chat.name }}</h1>
                         <button id="chat-title-edit-button" class="edit-trigger ids-icon-button" type="button">
                             {{ ids_icon(icon_name="edit.html") }}
                             <span class="govuk-visually-hidden">Chat Title</span>

--- a/django_app/redbox_app/templates/chat/default_canned_prompt.html
+++ b/django_app/redbox_app/templates/chat/default_canned_prompt.html
@@ -1,6 +1,7 @@
-<h1 class="govuk-heading-s govuk-!-margin-bottom-2">
+<h1 class="govuk-visually-hidden">Chats for {{ product_name(request) }}</h1>
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">{{ product_name(request) }}</span> can help you to:
-</h1>
+</h2>
 <ul class="govuk-list govuk-list--bullet govuk-body-s">
     <li>analyse and summarise your documents</li>
     <li>draft content and brainstorm ideas</li>

--- a/django_app/redbox_app/templates/chat/default_canned_prompt.html
+++ b/django_app/redbox_app/templates/chat/default_canned_prompt.html
@@ -1,4 +1,3 @@
-<h1 class="govuk-visually-hidden">Chats for {{ product_name(request) }}</h1>
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">{{ product_name(request) }}</span> can help you to:
 </h2>

--- a/django_app/redbox_app/templates/chat/default_canned_prompt.html
+++ b/django_app/redbox_app/templates/chat/default_canned_prompt.html
@@ -1,6 +1,6 @@
-<h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+<h1 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">{{ product_name(request) }}</span> can help you to:
-</h3>
+</h1>
 <ul class="govuk-list govuk-list--bullet govuk-body-s">
     <li>analyse and summarise your documents</li>
     <li>draft content and brainstorm ideas</li>

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -29,7 +29,7 @@
     </div>
   {% endif %}
 
-  <h2 class="govuk-heading-2 govuk-!-margin-top-0 govuk-!-margin-bottom-7">Your documents</h2>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-7">Your documents</h1>
 
   <p class="govuk-body-s govuk-!-margin-bottom-2">Manage your documents with {{ productName }}.</p>
 

--- a/django_app/redbox_app/templates/settings/profile.html
+++ b/django_app/redbox_app/templates/settings/profile.html
@@ -21,9 +21,9 @@
     <div class="govuk-form-group govuk-!-width-two-thirds govuk-!-margin-bottom-7">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-label govuk-!-font-weight-bold ids-text-s">
-          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-1 govuk-heading-m">
+          <h2 class="govuk-fieldset__heading govuk-!-margin-bottom-1 govuk-heading-m">
           {{ form.ai_experience.label }}
-          </h1>
+          </h2>
         </legend>
 
         <div class="ids-radio-groups-container">

--- a/django_app/redbox_app/templates/side_panel/conversations.html
+++ b/django_app/redbox_app/templates/side_panel/conversations.html
@@ -5,7 +5,7 @@
 <section id="conversations" class="ids-card ids-card--no-border" hx-swap-oob="outerHTML">
     <div class="ids-card__header">
         {{ ids_icon(icon_name="chat.svg") }}
-        <h3 class="side-panel-heading__text">Conversations</h3>
+        <h2 class="side-panel-heading__text govuk-heading-s govuk-!-margin-bottom-0">Conversations</h2>
     </div>
 
     <div class="ids-card__content">

--- a/django_app/redbox_app/templates/side_panel/menu.html
+++ b/django_app/redbox_app/templates/side_panel/menu.html
@@ -4,20 +4,20 @@
 <section class="ids-card ids-card--no-border">
     <div class="ids-card__header">
         {{ ids_icon(icon_name="menu.svg") }}
-        <h3 class="side-panel-heading__text">Menu</h3>
+        <h2 class="side-panel-heading__text govuk-heading-s govuk-!-margin-bottom-0">Menu</h2>
     </div>
 
     <div class="ids-card__content">
         <ul class="ids-card__list">
             {% for menu_item in get_menu_items(request.user) %}
-                <div class="ids-list-row">
+                <li class="ids-list-row">
                     <div class="ids-card__item">
                         <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"
                            href="{{ menu_item.href }}">
                             {{ menu_item.text }}
                         </a>
                     </div>
-                </div>
+                </li>
             {% endfor %}
         </ul>
     </div>

--- a/django_app/redbox_app/templates/side_panel/your_documents.html
+++ b/django_app/redbox_app/templates/side_panel/your_documents.html
@@ -5,7 +5,7 @@
 <section id="your-documents" class ="ids-card ids-card--no-border" hx-swap-oob="outerHTML">
     <div class="ids-card__header">
         {{ ids_icon(icon_name="file-present.svg") }}
-        <h3 class="side-panel-heading__text">Documents</h3>
+        <h2 class="side-panel-heading__text govuk-heading-s govuk-!-margin-bottom-0">Documents</h2>
     </div>
     <div class="ids-card__content">
         <document-selector id="document-selector" class="ids-width--full">

--- a/django_app/redbox_app/templates/tools/canned_prompts/invest-lens.html
+++ b/django_app/redbox_app/templates/tools/canned_prompts/invest-lens.html
@@ -1,7 +1,8 @@
-<h1 class="govuk-heading-s govuk-!-margin-bottom-2">
+<h1 class="govuk-visually-hidden">Chats for {{ tool.name }}</h1>
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">{{ tool.name }} </span>combines Data Hub and external sources to
     help you build briefings, join up company and sector insights, and develop strong UK investment hooks
-</h1>
+</h2>
 
 <p class="govuk-body-s">
     It pulls company data and interaction records from Data Hub, along with web search results and built-in investment documents.

--- a/django_app/redbox_app/templates/tools/canned_prompts/invest-lens.html
+++ b/django_app/redbox_app/templates/tools/canned_prompts/invest-lens.html
@@ -1,7 +1,7 @@
-<h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+<h1 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">{{ tool.name }} </span>combines Data Hub and external sources to
     help you build briefings, join up company and sector insights, and develop strong UK investment hooks
-</h3>
+</h1>
 
 <p class="govuk-body-s">
     It pulls company data and interaction records from Data Hub, along with web search results and built-in investment documents.

--- a/django_app/redbox_app/templates/tools/canned_prompts/invest-lens.html
+++ b/django_app/redbox_app/templates/tools/canned_prompts/invest-lens.html
@@ -1,4 +1,3 @@
-<h1 class="govuk-visually-hidden">Chats for {{ tool.name }}</h1>
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">{{ tool.name }} </span>combines Data Hub and external sources to
     help you build briefings, join up company and sector insights, and develop strong UK investment hooks

--- a/django_app/redbox_app/templates/tools/canned_prompts/submissions-checker.html
+++ b/django_app/redbox_app/templates/tools/canned_prompts/submissions-checker.html
@@ -1,6 +1,6 @@
-<h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+<h1 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">The {{ tool.name }} </span>acts as a 'health check' for ministerial submission drafts.
-</h3>
+</h1>
 
 <p class="govuk-body-s">
     Your submission is reviewed against 7 criteria. For each criterion, you'll receive a score along with a short

--- a/django_app/redbox_app/templates/tools/canned_prompts/submissions-checker.html
+++ b/django_app/redbox_app/templates/tools/canned_prompts/submissions-checker.html
@@ -1,4 +1,3 @@
-<h1 class="govuk-visually-hidden">Chats for {{ tool.name }}</h1>
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">The {{ tool.name }} </span>acts as a 'health check' for ministerial submission drafts.
 </h2>

--- a/django_app/redbox_app/templates/tools/canned_prompts/submissions-checker.html
+++ b/django_app/redbox_app/templates/tools/canned_prompts/submissions-checker.html
@@ -1,6 +1,7 @@
-<h1 class="govuk-heading-s govuk-!-margin-bottom-2">
+<h1 class="govuk-visually-hidden">Chats for {{ tool.name }}</h1>
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <span class="ids-text--product">The {{ tool.name }} </span>acts as a 'health check' for ministerial submission drafts.
-</h1>
+</h2>
 
 <p class="govuk-body-s">
     Your submission is reviewed against 7 criteria. For each criterion, you'll receive a score along with a short

--- a/django_app/redbox_app/templates/tools/tools.html
+++ b/django_app/redbox_app/templates/tools/tools.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <div class="govuk-width-container">
-    <h1 class="govuk-heading-m govuk-!-margin-top-7">Tools</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-7">Tools</h1>
 
     <p class="govuk-body-s govuk-!-margin-top-7 govuk-!-margin-bottom-7">
         Use DBT Assist's tools to complete routine and repeatable tasks more efficiently.


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
PR to make changes for the Info and relationships section of the Assist Accessibility report
## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
- Use `li` tags in the menu instead of using `div`
- Ensure each page has a `h1` tag to act as the pages main heading for a screen reader
- Ensure each page only has 1 `h1` tag
- Change `h3` to `h2` in the side panel to better identify the content they represent
- On the Chat pages add a hidden `h1` to assist screen readers with page context

### UI changes after applying:
#### Menu headers slightly increased in size:
<img width="280" height="517" alt="image" src="https://github.com/user-attachments/assets/fbc280b5-c2e6-493f-8b09-d9b38efc6c7c" />

#### Page headers increased to h1 size
<img width="1072" height="224" alt="image" src="https://github.com/user-attachments/assets/185c3173-d59d-4128-9dea-3e3aafbfcf5a" />
<img width="1097" height="266" alt="image" src="https://github.com/user-attachments/assets/9bfd880f-9491-408c-8048-abf1d454f6c5" />


## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
