### PR TITLE
feature/ASSIST-1502-conversation-structure

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/events/events.js
+++ b/django_app/frontend/src/interaction_design_system/ids/events/events.js
@@ -10,6 +10,9 @@ export const Events = /** @type {const} */ ({
     /** When the stream "end" event is sent from the server **/
     CHAT_RESPONSE_END: "chat-response-end",
 
+    /** When the streaming connection errors **/
+    CHAT_RESPONSE_ERROR: "chat-response-error",
+
     /** When a document status changes to "complete" **/
     DOC_COMPLETE: "doc-complete",
 
@@ -51,6 +54,7 @@ export const Events = /** @type {const} */ ({
  * @typedef {{
  *  "chat-response-start": undefined,
  *  "chat-response-end": {title:string, session_id:string, is_new_chat:boolean},
+ *  "chat-response-error": undefined,
  *  "doc-complete": {fileStatus:HTMLElement},
  *  "selected-docs-change": {id:string, name:string}[],
  *  "start-streaming": undefined,

--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -20,14 +20,14 @@ import "./web-components/documents/file-upload.js";
 import { syncUrlWithContent, refreshUI } from "./services";
 import { ChatHistory } from "./web-components/chats/chat-history.js";
 import { getActiveChatId } from "./utils/active-chat.js";
+import { Events, listenEvent } from "../interaction_design_system/ids/events/events.js";
 
-document.addEventListener("chat-response-start", (evt) => {
-  document.getElementById("chat-feed")?.setAttribute("aria-busy","true")
-})
+listenEvent(Events.CHAT_RESPONSE_START, (evt) => setAriaBusy(true));
+listenEvent(Events.CHAT_RESPONSE_ERROR, (evt) => setAriaBusy(false));
 
-document.addEventListener("chat-response-error", (evt) => {
-  document.getElementById("chat-feed")?.setAttribute("aria-busy","false")
-})
+const setAriaBusy = (val) => {
+  document.getElementById("chat-feed")?.setAttribute("aria-busy",val)
+}
 
 document.addEventListener("chat-response-end", (evt) => {
   const event = /** @type {CustomEvent} */ (evt);

--- a/django_app/frontend/src/js/chats.js
+++ b/django_app/frontend/src/js/chats.js
@@ -21,6 +21,13 @@ import { syncUrlWithContent, refreshUI } from "./services";
 import { ChatHistory } from "./web-components/chats/chat-history.js";
 import { getActiveChatId } from "./utils/active-chat.js";
 
+document.addEventListener("chat-response-start", (evt) => {
+  document.getElementById("chat-feed")?.setAttribute("aria-busy","true")
+})
+
+document.addEventListener("chat-response-error", (evt) => {
+  document.getElementById("chat-feed")?.setAttribute("aria-busy","false")
+})
 
 document.addEventListener("chat-response-end", (evt) => {
   const event = /** @type {CustomEvent} */ (evt);

--- a/django_app/frontend/src/js/web-components/chats/chat-controller.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-controller.js
@@ -21,9 +21,9 @@ class ChatController extends HTMLElement {
         document.querySelector("chat-controller")
       );
 
-      const messageContainer = chatController.querySelector(".js-message-container");
+      const messageContainer = chatController.querySelector("#chat-message-list");
       messageContainer?.classList.add("test-update-dom");
-      const insertPosition = chatController.querySelector(".js-response-feedback");
+      const insertPosition = messageContainer?.querySelector("li[data-role='chat-message-list-item']:last-child")
       const feedbackButtons = /** @type {HTMLElement | null} */ (
         chatController.querySelector("feedback-buttons")
       );
@@ -47,7 +47,10 @@ class ChatController extends HTMLElement {
       );
       userMessage.setAttribute("data-text", userText);
       userMessage.setAttribute("data-role", "user");
-      messageContainer?.insertBefore(userMessage, insertPosition);
+      userMessage.setAttribute("aria-label", "User message");
+      userMessage.setAttribute("role", "listitem");
+
+      messageContainer?.appendChild(userMessage);
 
       let documents = [];
       if (selectedDocuments.length) {
@@ -63,8 +66,10 @@ class ChatController extends HTMLElement {
       );
       aiMessage.setAttribute("data-role", "ai");
       aiMessage.setAttribute("data-logout-url", this.dataset.logoutUrl || "/");
+      aiMessage.setAttribute("aria-label", "AI response");
+      aiMessage.setAttribute("role", "listitem");
 
-      messageContainer?.insertBefore(aiMessage, insertPosition);
+      messageContainer?.appendChild(aiMessage);
 
       const llm =
         /** @type {HTMLInputElement | null}*/ (

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -266,6 +266,7 @@ export class ChatMessage extends HTMLElement {
         })
 
       } else if (response.type === "error") {
+        emitEvent(Events.CHAT_RESPONSE_ERROR);
         this.showError(response.data);
       } else if (response.type === "auth_expired") {
         if (this.LOGOUT_URL) {

--- a/django_app/redbox_app/templates/chat/chat_feed.html
+++ b/django_app/redbox_app/templates/chat/chat_feed.html
@@ -40,9 +40,13 @@
                 </template>
 
                 {# SSR messages #}
-                    {% for message in messages %}
+                <ol id="chat-message-list" aria-label="AI agent conversation" class="govuk-list">
+                  {% for message in messages %}
+                  <li data-role="chat-message-list-item">
                     {{ message_box(message=message) }}
-                    {% endfor %}
+                  </li>
+                  {% endfor %}
+                </ol>
                 {# CSR messages are inserted here #}
 
             </div>

--- a/django_app/redbox_app/templates/chat/chat_feed.html
+++ b/django_app/redbox_app/templates/chat/chat_feed.html
@@ -33,14 +33,14 @@
                             data-tool-id="{{ tool.id }}"
                             data-tool-slug="{{ tool.slug }}"
                         {% endif %}>
-            <div role="log" class="ids-chat-message__container ids-flex-column js-message-container">
+            <div role="log">
 
                 <template id="template-route-display">
                     {{ route_display() }}
                 </template>
 
                 {# SSR messages #}
-                <ol id="chat-message-list" aria-label="AI agent conversation" class="govuk-list">
+                <ol id="chat-message-list" aria-label="AI agent conversation" class="govuk-list ids-chat-message__container ids-flex-column">
                   {% for message in messages %}
                   <li data-role="chat-message-list-item">
                     {{ message_box(message=message) }}

--- a/django_app/redbox_app/templates/chat/chat_feed.html
+++ b/django_app/redbox_app/templates/chat/chat_feed.html
@@ -4,7 +4,7 @@
 {% from "macros/icon.html" import ids_icon %}
 {% from "macros/upload_form.html" import upload_form %}
 
-<div id="chat-feed" class="ids-chat-feed" hx-swap-oob="outerHTML">
+<div id="chat-feed" class="ids-chat-feed" hx-swap-oob="outerHTML" aria-busy="false">
 
     {% if not messages %}
         <canned-prompts class="chat-options govuk-!-padding-top-5 govuk-!-padding-bottom-1" security-classification="{{ security }}">
@@ -33,7 +33,7 @@
                             data-tool-id="{{ tool.id }}"
                             data-tool-slug="{{ tool.slug }}"
                         {% endif %}>
-            <div class="ids-chat-message__container ids-flex-column js-message-container">
+            <div role="log" class="ids-chat-message__container ids-flex-column js-message-container">
 
                 <template id="template-route-display">
                     {{ route_display() }}

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -28,15 +28,13 @@
 {% macro message_box(message) %}
 
 
-{% set role_text = message.role %}
+{% set role_text = "AI response" %}
 {% if message.role == "ai" %}
-{% set role_text = "Redbox" %}
-{% elif message.role == "user" %}
-{% set role_text = "You" %}
+{% set role_text = "User message" %}
 {% endif %}
 
 
-<div class="ids-message-container govuk-body" data-role="{{ message.role }}" tabindex="-1" id="chat-message-{{ message.id }}">
+<section class="ids-message-container govuk-body" aria-label="{{role_text }}" data-role="{{ message.role }}" tabindex="-1" id="chat-message-{{ message.id }}">
   <div class="{% if message.role == "user" %}ids-message-container__right ids-border{% else %}ids-message-container__left{% endif %}">
     <markdown-converter class="ids-chat-message__text">{{ message.text }}</markdown-converter>
     {% set citations = message.get_citations() %}
@@ -81,5 +79,5 @@
     </div>
   {% endif %}
 
-</div>
+</section>
 {% endmacro %}

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -28,8 +28,10 @@
 {% macro message_box(message) %}
 
 
-{% set role_text = "AI response" %}
+{% set role_text = "System response" %}
 {% if message.role == "ai" %}
+{% set role_text = "AI Response" %}
+{% elif message.role == "user" %}
 {% set role_text = "User message" %}
 {% endif %}
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
PR to make changes for the Conversation structure section of the Assist Accessibility report


## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Make use of the aria-busy attribute to indicate to a screen reader that the chat with the LLM is ongoing. This value is set to `true` when the conversation starts and is set to `false` when either the response from the LLM ends or an error occurs
- Render the chats as an `li` inside an `ol` to help screen readers identify the order of the chats
- Add an aria-label to each chat to highlight to a screen reader who the message belongs to


## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
