### PR TITLE
fix: Planner produces plan contains 2 Evaluator tasks

### DIFF
--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -368,12 +368,12 @@ def remove_evaluator_task(state: RedboxState):
     if not state.agent_plans or not state.agent_plans.tasks:
         return state
 
-    evaluator_tasks = [t for t in state.agent_plans.tasks if t.agent_value == "Evaluator_Agent"]
+    evaluator_tasks = [t for t in state.agent_plans.tasks if t.agent.value == "Evaluator_Agent"]
 
     if evaluator_tasks:
         last = evaluator_tasks[-1]
         state.tasks_evaluator = f"{last.task} {last.expected_output}"
-        state.agent_plans.tasks = [t for t in state.agent_plans.tasks if t.agent_value != "Evaluator_Agent"]
+        state.agent_plans.tasks = [t for t in state.agent_plans.tasks if t.agent.value != "Evaluator_Agent"]
     return state
 
 

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -363,7 +363,7 @@ def create_planner(is_streamed=False):
 def remove_evaluator_task(state: RedboxState):
     """
     Removing evaluator task from a plan and update the task for evaluator
-    In the case where there are multiple evaluator tasks, all of them are removed, and tasks_elavator is populated from the last evaluator task
+    In the case where there are multiple evaluator tasks, all of them are removed, and tasks_evaluator is populated from the last evaluator task
     """
     if not state.agent_plans or not state.agent_plans.tasks:
         return state

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -363,11 +363,17 @@ def create_planner(is_streamed=False):
 def remove_evaluator_task(state: RedboxState):
     """
     Removing evaluator task from a plan and update the task for evaluator
+    In the case where there are multiple evaluator tasks, all of them are removed, and tasks_elavator is populated from the last evaluator task
     """
-    if len(state.agent_plans.tasks) > 0:
-        if state.agent_plans.tasks[-1].agent.value == "Evaluator_Agent":
-            state.tasks_evaluator = state.agent_plans.tasks[-1].task + " " + state.agent_plans.tasks[-1].expected_output
-            state.agent_plans.tasks.pop(-1)
+    if not state.agent_plans or not state.agent_plans.tasks:
+        return state
+
+    evaluator_tasks = [t for t in state.agent_plans.tasks if t.agent_value == "Evaluator_Agent"]
+
+    if evaluator_tasks:
+        last = evaluator_tasks[-1]
+        state.tasks_evaluator = f"{last.task} {last.expected_output}"
+        state.agent_plans.tasks = [t for t in state.agent_plans.tasks if t.agent_value != "Evaluator_Agent"]
     return state
 
 

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -453,7 +453,7 @@ PLANNER_PROMPT_BOTTOM = """
 1. When a user query involves finding information within selected documents (not summarising the documents), ALWAYS route to the Internal_Retrieval_Agent.
 2. Only use External_Retrieval_Agent if the query specifically requests external data sources.
 3. Only use Artifact_Builder_Agent if there is specific artifact file that match user request.
-4. The Evaluator_Agent must be used for every multi-agent response to ensure consistency and quality in the final output delivered to the user.
+4. The Evaluator_Agent must be used for exactly once in the plan, and it must be the final task. Never insert Evaluator_Agent as an intermediate step. The Evaluator_Agent at the end ensures consistency and quality in the final output delivered to the user.
 
 If a user asks to summarise a document, ALWAYS call Summarisation_Agent and do not call other agents.
 

--- a/redbox/tests/graph/test_multiagents_app.py
+++ b/redbox/tests/graph/test_multiagents_app.py
@@ -555,8 +555,8 @@ class TestRemoveEvaluatorTask:
     @staticmethod
     def _agent_classes():
         agent_options = {
-            "Web_Search_Agent": "Web_Search_agent",
-            "Internam_Retrieval_Agent": "Internal_Retrieval_Agent",
+            "Web_Search_Agent": "Web_Search_Agent",
+            "Internal_Retrieval_Agent": "Internal_Retrieval_Agent",
             "Evaluator_Agent": "Evaluator_Agent",
         }
         return configure_agent_task_plan(agent_options)

--- a/redbox/tests/graph/test_multiagents_app.py
+++ b/redbox/tests/graph/test_multiagents_app.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage
 from pytest_mock import MockerFixture
 
 from redbox import Redbox
+from redbox.graph.nodes.processes import remove_evaluator_task
 from redbox.graph.nodes.sends import run_tools_parallel
 from redbox.models.chain import (
     ChainChatMessage,
@@ -548,3 +549,66 @@ class TestNewRoutes:
         result = run_tools_parallel(ai_msg, [tool1, tool2], state)
         assert len(result) == 4
         assert result == "test"
+
+
+class TestRemoveEvaluatorTask:
+    @staticmethod
+    def _agent_classes():
+        agent_options = {
+            "Web_Search_Agent": "Web_Search_agent",
+            "Internam_Retrieval_Agent": "Internal_Retrieval_Agent",
+            "Evaluator_Agent": "Evaluator_Agent",
+        }
+        return configure_agent_task_plan(agent_options)
+
+    @staticmethod
+    def _state_with_plan(plan):
+        request = RedboxQuery(
+            question="Ask this question?",
+            s3_keys=[],
+            user_uuid=uuid4(),
+            chat_history=[],
+            permitted_s3_keys=[],
+        )
+        return RedboxState(request=request, agent_plans=plan)
+
+    def test_single_trailing_evaluator_is_removed(self):
+        AgentTask, AgentPlan = self._agent_classes()
+        tasks = [
+            AgentTask(id="task0", task="search", expected_output="hits", agent="Web_Search_Agent"),
+            AgentTask(id="task1", task="evaluate", expected_output="final answer", agent="Evaluator_Agent"),
+        ]
+
+        state = self._state_with_plan(AgentPlan(tasks=tasks))
+        result = remove_evaluator_task(state)
+
+        # Assertions
+        assert [t.agent.value for t in result.agent_plans.tasks] == ["Web_Search_Agent"]
+        assert "evaluate" in result.tasks_evaluator
+        assert "final answer" in result.tasks_evaluator
+
+    def test_multiples_evaluator_tasks_removed(self):
+        AgentTask, AgentPlan = self._agent_classes()
+        tasks = [
+            AgentTask(id="task0", task="search 0", expected_output="0", agent="Web_Search_Agent"),
+            AgentTask(id="task1", task="mid eval", expected_output="mid", agent="Evaluator_Agent"),
+            AgentTask(id="task2", task="search 1", expected_output="1", agent="Internal_Retrieval_Agent"),
+            AgentTask(id="task3", task="final eval", expected_output="final", agent="Evaluator_Agent"),
+        ]
+
+        state = self._state_with_plan(AgentPlan(tasks=tasks))
+        result = remove_evaluator_task(state)
+        remaining = [t.agent.value for t in result.agent_plans.tasks]
+
+        assert "Evaluator_Agent" not in remaining
+        assert remaining == ["Web_Search_Agent", "Internal_Retrieval_Agent"]
+        assert "final eval" in result.tasks_evaluator
+
+    def test_plan_no_eval_unchanged(self):
+        AgentTask, AgentPlan = self._agent_classes()
+        tasks = [AgentTask(id="task", task="search", expected_output="hits", agent="Web_Search_Agent")]
+
+        state = self._state_with_plan(AgentPlan(tasks=tasks))
+        result = remove_evaluator_task(state)
+
+        assert [t.agent.value for t in result.agent_plans.tasks] == ["Web_Search_Agent"]


### PR DESCRIPTION
## Context

Planner produces plan contains 2 Evaluator tasks

In the current design, we expect the planner will produce the plan that contains no more than 1 Evaluator agent task,
e.g. 
Task1: agent: Evaluator
Task1: agent: Websearch, Task2: agent: Evaluator 
Task1: agent: Websearch, Task2: agent: Websearch, Task3: agent: Evaluator 

## What

Adapted prompt as well as the remove_evaluator_task func so that in the case that there are multiple evaluator tasks, all of them are removed and the task_evaluator is populated from the last evaluator task

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
