### PR TITLE
fix: Update search doc/knowledgebase related tools to not returned empty list.

### DIFF
--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -206,12 +206,17 @@ def build_search_documents_tool(
     no_selection_msg = (
         "No documents have been selected, so no search was performed. Ask the user to select at least one document."
     )
-
     no_results_msg = "No relevant information was found in the selected documents. Try to rephrase your prompt or proceed without information from the selected document(s)"
+    no_permission_msg = (
+        "User does not have permission to access documents. Ask the user to select a document they are permitted to use"
+    )
 
     def search_repo(query, selected_files, permitted_files, ai_settings, start_time=time.time()):
         if not selected_files:
             return no_selection_msg, []
+
+        if not permitted_files:
+            return no_permission_msg, []
 
         query_vector = embedding_model.embed_query(query)
         # Initial pass

--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -203,7 +203,16 @@ def build_search_documents_tool(
 ) -> Tool:
     """Constructs a tool that searches the index and sets state.documents."""
 
+    no_selection_msg = (
+        "No documents have been selected, so no search was performed. Ask the user to select at least one document."
+    )
+
+    no_results_msg = "No relevant information was found in the selected documents. Try to rephrase your prompt or proceed without information from the selected document(s)"
+
     def search_repo(query, selected_files, permitted_files, ai_settings, start_time=time.time()):
+        if not selected_files:
+            return no_selection_msg, []
+
         query_vector = embedding_model.embed_query(query)
         # Initial pass
         initial_query = build_document_query(
@@ -223,7 +232,7 @@ def build_search_documents_tool(
 
         # Handle nothing found (as when no files are permitted)
         if not initial_documents:
-            return "", []
+            return no_results_msg, []
 
         # Adjacent documents
         with_adjacent_query = add_document_filter_scores_to_query(

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -454,6 +454,8 @@ PLANNER_PROMPT_BOTTOM = """
 2. Only use External_Retrieval_Agent if the query specifically requests external data sources.
 3. Only use Artifact_Builder_Agent if there is specific artifact file that match user request.
 4. The Evaluator_Agent must be used for exactly once in the plan, and it must be the final task. Never insert Evaluator_Agent as an intermediate step. The Evaluator_Agent at the end ensures consistency and quality in the final output delivered to the user.
+5. If the user has not selected any documents; do NOT route to Internal_Retrieval_Agent, Tabular_Agent or Summarisation_Agent. Instead ask Evaluator_Agent to inform the user that they have not selected any documents, and will need to if they want to use these agents.
+6. If the knowledge base is emptry; do NOT route to Knowledge_Base_Agent or Artifact_builder_Agent.
 
 If a user asks to summarise a document, ALWAYS call Summarisation_Agent and do not call other agents.
 

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -455,7 +455,7 @@ PLANNER_PROMPT_BOTTOM = """
 3. Only use Artifact_Builder_Agent if there is specific artifact file that match user request.
 4. The Evaluator_Agent must be used for exactly once in the plan, and it must be the final task. Never insert Evaluator_Agent as an intermediate step. The Evaluator_Agent at the end ensures consistency and quality in the final output delivered to the user.
 5. If the user has not selected any documents; do NOT route to Internal_Retrieval_Agent, Tabular_Agent or Summarisation_Agent. Instead ask Evaluator_Agent to inform the user that they have not selected any documents, and will need to if they want to use these agents.
-6. If the knowledge base is emptry; do NOT route to Knowledge_Base_Agent or Artifact_builder_Agent.
+6. If the knowledge base is empty; do NOT route to Knowledge_Base_Retrieval_Agent or Artifact_Builder_Agent.
 
 If a user asks to summarise a document, ALWAYS call Summarisation_Agent and do not call other agents.
 

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -210,7 +210,12 @@ def test_knowledge_base_search_documents_tool(
         )
     )
 
-    print(result_state["messages"][0])
+    # Tool must return non-empty list so downstream calls do NOT fail
+    message = result_state["messages"][0]
+    assert message.content
+    if not stored_file_knowledge_base.query.knowledge_base_s3_keys:
+        assert "No documents have been selected" in message.content
+        assert message.artifact == []
 
 
 @pytest.mark.parametrize("chain_params", TEST_CHAIN_PARAMETERS)
@@ -290,10 +295,12 @@ def test_search_documents_tool(
     )
 
     if not permission:
-        assert result_state["messages"][0].content == ""
+        # Documents selected but none are permitted - tool must return a non-empty message
+        assert "No relevant information was found in" in result_state["messages"][0].content
         assert result_state["messages"][0].artifact == []
     elif not selected:
-        assert result_state["messages"][0].content == ""
+        # No documents selected - must short circuit before hitting Opensearch and return non-empty message
+        assert "No documents have been selected" in result_state["messages"][0].content
         assert result_state["messages"][0].artifact == []
     else:
         print(result_state["messages"][0])
@@ -312,6 +319,66 @@ def test_search_documents_tool(
         if selected:
             assert {c.page_content for c in result_flat} <= {c.page_content for c in selected_docs}
             assert {c.metadata["uri"] for c in result_flat} <= set(stored_file_parameterised.query.s3_keys)
+
+
+def _make_search_tool_state(
+    question: str, *, s3_keys, permitted_s3_keys, knowledge_base_s3_keys=None, tool_name="_search_documents"
+):
+    """
+    Helper function to build RedboxState invoking a search tool by name
+    """
+    return RedboxState(
+        request=RedboxQuery(
+            question=question,
+            s3_keys=s3_keys,
+            user_uuid=uuid4(),
+            chat_history=[],
+            ai_settings=AISettings(),
+            permitted_s3_keys=permitted_s3_keys,
+            knowledge_base_s3_keys=knowledge_base_s3_keys or [],
+        ),
+        messages=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": tool_name,
+                        "args": {"query": question},
+                        "id": "1",
+                    }
+                ],
+            )
+        ],
+    )
+
+
+def test_search_documents_tool_empty_opensearch_reponse_returns_text(mocker: MockerFixture, env: Settings):
+    """
+    When Opensearch returns no chunks, tool must return non-empty string.
+    """
+    mock_es_client = mocker.MagicMock(spec=OpenSearch)
+    mock_es_client.search.return_value = {"hits": {"hits": []}}
+    embedding_model = FakeEmbeddings(size=1024)
+
+    search = build_search_documents_tool(
+        es_client=mock_es_client,
+        index_name="index",
+        embedding_model=embedding_model,
+        embedding_field_name=env.embedding_document_field_name,
+        chunk_resolution=ChunkResolution.normal,
+    )
+
+    tool_node = ToolNode(tools=[search])
+    result_state = tool_node.invoke(
+        _make_search_tool_state("example question", s3_keys=["s3_key"], permitted_s3_keys=["s3_key"])
+    )
+
+    message = result_state["messages"][0]
+
+    assert message.content
+    assert "No relevant information was found" in message.content
+    assert message.artifact == []
+    mock_es_client.search.assert_called()
 
 
 @pytest.mark.xfail(reason="calls api")

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -387,7 +387,6 @@ def test_search_documents_tool_no_s3_key_skip_opensearch(mocker: MockerFixture, 
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     embedding_model = FakeEmbeddings(size=1024)
-    embed_spy = mocker.spy(embedding_model, "embed_query")
 
     search = build_search_documents_tool(
         es_client=mock_es_client,
@@ -408,7 +407,6 @@ def test_search_documents_tool_no_s3_key_skip_opensearch(mocker: MockerFixture, 
     assert "No documents have been selected" in message.content
     assert message.artifact == []
     mock_es_client.search.assert_not_called()
-    embed_spy.assert_not_called()
 
 
 def test_search_knowledge_base_tool_no_keys_skip_opensearch(mocker: MockerFixture, env: Settings):

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -296,7 +296,7 @@ def test_search_documents_tool(
 
     if not permission:
         # Documents selected but none are permitted - tool must return a non-empty message
-        assert "No relevant information was found in" in result_state["messages"][0].content
+        assert "does not have permission" in result_state["messages"][0].content
         assert result_state["messages"][0].artifact == []
     elif not selected:
         # No documents selected - must short circuit before hitting Opensearch and return non-empty message

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -39,7 +39,6 @@ from redbox.models.file import ChunkCreatorType, ChunkMetadata, ChunkResolution,
 from redbox.models.settings import Settings
 from redbox.test.data import RedboxChatTestCase
 from redbox.transform import bedrock_tokeniser, combine_documents, flatten_document_state
-from tests.conftest import es_client
 from tests.retriever.test_retriever import TEST_CHAIN_PARAMETERS
 
 
@@ -391,7 +390,7 @@ def test_search_documents_tool_no_s3_key_skip_opensearch(mocker: MockerFixture, 
     embed_spy = mocker.spy(embedding_model, "embed_query")
 
     search = build_search_documents_tool(
-        es_client=es_client,
+        es_client=mock_es_client,
         index_name="index",
         embedding_model=embedding_model,
         embedding_field_name=env.embedding_document_field_name,
@@ -400,7 +399,7 @@ def test_search_documents_tool_no_s3_key_skip_opensearch(mocker: MockerFixture, 
 
     tool_node = ToolNode(tools=[search])
     result_state = tool_node.invoke(
-        _make_search_tool_state("example question", s3_keys=["s3_key"], permitted_s3_keys=["s3_key"])
+        _make_search_tool_state("example question", s3_keys=[], permitted_s3_keys=["s3_key"])
     )
 
     message = result_state["messages"][0]
@@ -414,13 +413,13 @@ def test_search_documents_tool_no_s3_key_skip_opensearch(mocker: MockerFixture, 
 
 def test_search_knowledge_base_tool_no_keys_skip_opensearch(mocker: MockerFixture, env: Settings):
     """
-    When the knowledge_base_s3_keys is emptry, the tool must NOT call opensearch and respond with a non-empty message
+    When the knowledge_base_s3_keys is empty, the tool must NOT call opensearch and respond with a non-empty message
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     embedding_model = FakeEmbeddings(size=1024)
 
     knowledge_base_search = build_search_documents_tool(
-        es_client=es_client,
+        es_client=mock_es_client,
         index_name="index",
         embedding_model=embedding_model,
         embedding_field_name=env.embedding_document_field_name,

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -39,6 +39,7 @@ from redbox.models.file import ChunkCreatorType, ChunkMetadata, ChunkResolution,
 from redbox.models.settings import Settings
 from redbox.test.data import RedboxChatTestCase
 from redbox.transform import bedrock_tokeniser, combine_documents, flatten_document_state
+from tests.conftest import es_client
 from tests.retriever.test_retriever import TEST_CHAIN_PARAMETERS
 
 
@@ -352,7 +353,7 @@ def _make_search_tool_state(
     )
 
 
-def test_search_documents_tool_empty_opensearch_reponse_returns_text(mocker: MockerFixture, env: Settings):
+def test_search_documents_tool_empty_opensearch_response_returns_text(mocker: MockerFixture, env: Settings):
     """
     When Opensearch returns no chunks, tool must return non-empty string.
     """
@@ -371,6 +372,106 @@ def test_search_documents_tool_empty_opensearch_reponse_returns_text(mocker: Moc
     tool_node = ToolNode(tools=[search])
     result_state = tool_node.invoke(
         _make_search_tool_state("example question", s3_keys=["s3_key"], permitted_s3_keys=["s3_key"])
+    )
+
+    message = result_state["messages"][0]
+
+    assert message.content
+    assert "No relevant information was found" in message.content
+    assert message.artifact == []
+    mock_es_client.search.assert_called()
+
+
+def test_search_documents_tool_no_s3_key_skip_opensearch(mocker: MockerFixture, env: Settings):
+    """
+    When there is no s3 key, the tool should short circuit and Opensearch should NOT be called, and a non-empty message returned
+    """
+    mock_es_client = mocker.MagicMock(spec=OpenSearch)
+    embedding_model = FakeEmbeddings(size=1024)
+    embed_spy = mocker.spy(embedding_model, "embed_query")
+
+    search = build_search_documents_tool(
+        es_client=es_client,
+        index_name="index",
+        embedding_model=embedding_model,
+        embedding_field_name=env.embedding_document_field_name,
+        chunk_resolution=ChunkResolution.normal,
+    )
+
+    tool_node = ToolNode(tools=[search])
+    result_state = tool_node.invoke(
+        _make_search_tool_state("example question", s3_keys=["s3_key"], permitted_s3_keys=["s3_key"])
+    )
+
+    message = result_state["messages"][0]
+
+    assert message.content
+    assert "No documents have been selected" in message.content
+    assert message.artifact == []
+    mock_es_client.search.assert_not_called()
+    embed_spy.assert_not_called()
+
+
+def test_search_knowledge_base_tool_no_keys_skip_opensearch(mocker: MockerFixture, env: Settings):
+    """
+    When the knowledge_base_s3_keys is emptry, the tool must NOT call opensearch and respond with a non-empty message
+    """
+    mock_es_client = mocker.MagicMock(spec=OpenSearch)
+    embedding_model = FakeEmbeddings(size=1024)
+
+    knowledge_base_search = build_search_documents_tool(
+        es_client=es_client,
+        index_name="index",
+        embedding_model=embedding_model,
+        embedding_field_name=env.embedding_document_field_name,
+        chunk_resolution=ChunkResolution.normal,
+        repository="knowledge_base",
+    )
+
+    tool_node = ToolNode(tools=[knowledge_base_search])
+    result_state = tool_node.invoke(
+        _make_search_tool_state(
+            "example question",
+            s3_keys=["s3_key"],
+            permitted_s3_keys=["s3_key"],
+            knowledge_base_s3_keys=[],
+            tool_name="_search_knowledge_base",
+        )
+    )
+
+    message = result_state["messages"][0]
+
+    assert "No documents have been selected" in message.content
+    assert message.artifact == []
+    mock_es_client.search.assert_not_called()
+
+
+def test_search_knowledge_base_tool_empty_opensearch_response_returns_text(mocker: MockerFixture, env: Settings):
+    """
+    When Opensearch returns no matching documents / hits, the tool must return non-empty string.
+    """
+    mock_es_client = mocker.MagicMock(spec=OpenSearch)
+    mock_es_client.search.return_value = {"hits": {"hits": []}}
+    embedding_model = FakeEmbeddings(size=1024)
+
+    knowledge_base_search = build_search_documents_tool(
+        es_client=mock_es_client,
+        index_name="index",
+        embedding_model=embedding_model,
+        embedding_field_name=env.embedding_document_field_name,
+        chunk_resolution=ChunkResolution.normal,
+        repository="knowledge_base",
+    )
+
+    tool_node = ToolNode(tools=[knowledge_base_search])
+    result_state = tool_node.invoke(
+        _make_search_tool_state(
+            "example question",
+            s3_keys=[],
+            permitted_s3_keys=[],
+            knowledge_base_s3_keys=["knowledge_base_key"],
+            tool_name="_search_knowledge_base",
+        )
     )
 
     message = result_state["messages"][0]


### PR DESCRIPTION
When performing query to Opensearch and no chunks were found, Assist will return an empty list which will cause the tool to fail causing the application to fail.

## What
- Fix the tools (both search for document, and knowledge base) to return a text indicating that no relevant chunks/information are found.
- When a user does not select any document i.e. s3_keys = [] , Assist should not call Opensearch but let the user know that they have not selected any document. Ideally, the planner should have identified that document is not selected and therefore search-related agents should not be used.
- Write relevant tests

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
