### PR TITLE
feature/ASSIST-1504-unlabelled-image-controls

### DIFF
--- a/django_app/redbox_app/templates/chat/chat_interaction.html
+++ b/django_app/redbox_app/templates/chat/chat_interaction.html
@@ -13,11 +13,12 @@
                     <file-upload upload-url="{{ urls.upload_url }}">
                         <input class="govuk-file-upload govuk-!-display-none" multiple id="upload-docs" name="uploadDocs"
                             type="file" aria-describedby="upload-docs-notification upload-docs-filetypes">
-                        {{ govukButton(
-                        text=ids_icon(icon_name="attach-file.svg", icon_classes=""),
-                        classes="upload-button govuk-button--secondary ids-icon-button",
-                        id="upload-button"
-                        ) }}
+                            {% call govukButton(
+                                      text=ids_icon(icon_name="attach-file.svg", icon_classes=""),
+                                      classes="upload-button govuk-button--secondary ids-icon-button",
+                                      id="upload-button") %}
+                                <span class="govuk-visually-hidden">Upload file to chat</span>
+                            {% endcall %}
                     </file-upload>
 
                     <!-- Dictate and Send Buttons -->
@@ -26,6 +27,7 @@
                         <button type="submit" class="govuk-button govuk-button--secondary ids-icon-button dictate-button"
                             data-module="govuk-button">
                             {{ ids_icon(icon_name="mic.svg", icon_classes="") }}
+                            <span class="govuk-visually-hidden">Provide a dictation to chat</span>
                         </button>
 
                         {{ govukButton(
@@ -34,10 +36,11 @@
                         dont_submit=True
                         ) }}
 
-                        {{ govukButton(
-                        text=ids_icon(icon_name="send.svg", icon_classes="success"),
-                        classes="send-button ids-icon-button"
-                        ) }}
+                        {% call govukButton(
+                                  text=ids_icon(icon_name="send.svg", icon_classes="success"),
+                                  classes="send-button ids-icon-button") %}
+                            <span class="govuk-visually-hidden">Send message to chat</span>
+                        {% endcall %}
 
                         {{ govukButton(
                         text=ids_icon(icon_name="stop-circle.svg", icon_classes="error"),
@@ -46,11 +49,11 @@
                     </send-message-with-dictation>
                     {% else %}
                     <send-message>
-                        {{ govukButton(
-                        text=ids_icon(icon_name="send.svg", icon_classes="success"),
-                        classes="send-button ids-icon-button"
-                        ) }}
-                        <span class="govuk-visually-hidden">Send Message</span>
+                        {% call govukButton(
+                                  text=ids_icon(icon_name="send.svg", icon_classes="success"),
+                                  classes="send-button ids-icon-button") %}
+                            <span class="govuk-visually-hidden">Send message to chat</span>
+                        {% endcall %}
 
                         {{ govukButton(
                         text=ids_icon(icon_name="send.svg", icon_classes="success"),

--- a/django_app/redbox_app/templates/macros/govuk-button.html
+++ b/django_app/redbox_app/templates/macros/govuk-button.html
@@ -5,13 +5,12 @@
     {% if download %}download{% endif %} {% if id %}id="{{ id }}"{% endif %}>
     {{ text | safe }}
   </a>
-{% elif dont_submit %}
-  <button type="button" class="govuk-button {{ classes }}" data-module="govuk-button" {% if prevent_double_click %}data-prevent-double-click="true"{% endif %} {% if id %}id="{{ id }}"{% endif %}>
-    {{ text | safe }}
-  </button>
 {% else %}
-  <button type="submit" class="govuk-button {{ classes }}" data-module="govuk-button" {% if prevent_double_click %}data-prevent-double-click="true"{% endif %} {% if id %}id="{{ id }}"{% endif %}>
+  <button type="{{ 'button' if dont_submit else 'submit' }}" class="govuk-button {{ classes }}" data-module="govuk-button" {% if prevent_double_click %}data-prevent-double-click="true"{% endif %} {% if id %}id="{{ id }}"{% endif %}>
     {{ text | safe }}
+    {% if caller %}
+      {{ caller() }}
+    {% endif %}
   </button>
 {% endif %}
 

--- a/django_app/redbox_app/templates/side_panel/your_documents.html
+++ b/django_app/redbox_app/templates/side_panel/your_documents.html
@@ -37,7 +37,13 @@
                                     <span class="govuk-visually-hidden"> edit document: {{ file.file_name }}</span>
                                 </button>
                                 {% call modal() %}
-                                    <button class="ids-icon-button modal-open">{{ ids_icon(icon_name="delete.html", icon_classes="link") }}</button>
+                                    <button class="ids-icon-button modal-open">
+                                      {{ ids_icon(icon_name="delete.html", icon_classes="link") }}
+                                      <span class="govuk-visually-hidden">
+                                        Delete document:
+                                        {{ file.file_name }}</span
+                                      >
+                                    </button>
                                     <dialog>
                                         <div>
                                             <h2 class="govuk-heading-m">Are you sure you want to delete this file?</h2>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
PR to make changes for the Unlabelled image controls section of the Assist Accessibility report


## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
- Merge the duplicate `button` logic in the govuk-button macro, setting the `type` attribute based on the `dont_submit` prop being True or False
- Use the `call` template logic to set a `span` inside the `button` with a text description for the icon
- Update the delete document button to include an inner `span` for accessibility

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
