### PR TITLE
feature/ASSIST-1506-custom-links

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.html
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.html
@@ -1,9 +1,22 @@
+{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/icon.html" import ids_icon %}
+
 <template id="ids-uploaded-file-template">
     <div class="uploaded-file-wrapper" data-id="">
         <div class="uploaded-file" contenteditable="false" aria-readonly="true" tabindex="-1">
             <div data-icon></div>
             <span class="file-name" title="" data-name></span>
-            <a class="ids-action-link govuk-link govuk-link--no-visited-state govuk-link--no-underline" data-remove>Remove</a>
+            {% call govukButton(
+                text=ids_icon(icon_name="close.svg", icon_classes="link"),
+                classes="govuk-button--secondary ids-icon-button",
+                prevent_double_click=True,
+                dont_submit=True,
+                attributes={"data-remove":""}
+            ) %}
+                <span class="govuk-visually-hidden">
+                    Remove document: <span data-name></span>
+                </span>
+            {% endcall %}
         </div>
         <div class="upload-progress">
             <div class="upload-progress-text" data-status-text>Processing...</div>

--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.js
@@ -16,6 +16,7 @@ export class UploadedFile extends HTMLElement {
         ERROR: "error",
     });
 
+    /** @type {Readonly<Record<string, string>>} */
     static FileStatusDisplay = Object.freeze({
         [UploadedFile.StatusTypes.COMPLETE]: "Ready to use",
         [UploadedFile.StatusTypes.PROCESSING]: "Processing",

--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.js
@@ -89,8 +89,10 @@ export class UploadedFile extends HTMLElement {
      */
     set fileName(value) {
         this._fileName = value;
-        this.nameElement.innerText = value;
-        this.nameElement.title = value;
+        this.nameElements.forEach((nameElement) => {
+            nameElement.innerText = value;
+            nameElement.title = value;
+        })
         this.#updateIconDisplay();
     }
 
@@ -118,11 +120,9 @@ export class UploadedFile extends HTMLElement {
         return /** @type {HTMLElement} */ (this.querySelector('[data-icon]'));
     }
 
-
-    get nameElement() {
-        return /** @type {HTMLElement} */ (this.querySelector('[data-name]'));
+    get nameElements() {
+        return /** @type {NodeListOf<HTMLElement>} */ (this.querySelectorAll('[data-name]'));
     }
-
 
     get statusTextElement() {
         return /** @type {HTMLElement} */ (this.querySelector('[data-status-text]'));

--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.scss
@@ -12,6 +12,7 @@ ids-uploaded-file {
             padding: 5px;
             border-width: thin;
             margin: 3px;
+            align-items: center;
 
             .file-name {
                 display: block;

--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-files.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-files.js
@@ -126,7 +126,7 @@ export class UploadedFiles extends HTMLElement {
      * Emits an event to signify that all uploads have finished processing
      */
     #emitProcessedEvent() {
-        emitEvent(Events.FILE_UPLOAD_PROCESSED);
+        emitEvent(Events.FILE_UPLOADS_PROCESSED);
     }
 
 
@@ -142,7 +142,7 @@ export class UploadedFiles extends HTMLElement {
      * Monitors the processing status of each uploaded file
      */
     #monitorProcessingStatus() {
-        listenEvent(Events.FILE_UPLOADS_PROCESSED, (evt) => {
+        listenEvent(Events.FILE_UPLOAD_PROCESSED, (evt) => {
             const uploadedFile = /** @type {CustomEvent} */ (evt).detail;
             if (uploadedFile.parentNode !== this.container) return;
             if (this.allProcessed()) this.#emitProcessedEvent();

--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-files.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-files.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { emitEvent, Events, listenEvent } from "../events";
 import { UploadedFile } from "./uploaded-file";
 
 export class UploadedFiles extends HTMLElement {
@@ -62,11 +63,28 @@ export class UploadedFiles extends HTMLElement {
         this.files.splice(index, 1); // Remove file from array
         if (uploadedFile.parentNode === this.container) this.container.removeChild(uploadedFile);
         if (this.allProcessed()) this.#emitProcessedEvent();
+        this.setFocus(index);
         if (this.isEmpty()) {
             this.remove();
             this.#emitRemovedEvent();
         }
         return true;
+    }
+
+
+    /**
+     * Sets the focus state according to the file index passed
+     * @param {number} index - UploadedFile files index
+     */
+    setFocus(index) {
+        // Focus parent container if no files
+        if (this.isEmpty()) return this.parentElement?.focus();
+
+        // Focus file at current index
+        if (this.files[index]) return this.files[index].removeElement.focus();
+
+        // Focus file at previous index (if current index was last in the list and removed)
+        if (this.files[index-1]) return this.files[index-1].removeElement.focus();
     }
 
 
@@ -97,7 +115,7 @@ export class UploadedFiles extends HTMLElement {
 
 
     /**
-     * Checks if the files lsit is empty
+     * Checks if the files list is empty
      * @returns {boolean} Flag indicating if files array is empty
      */
     isEmpty() {
@@ -108,7 +126,7 @@ export class UploadedFiles extends HTMLElement {
      * Emits an event to signify that all uploads have finished processing
      */
     #emitProcessedEvent() {
-        document.body.dispatchEvent(new CustomEvent("file-uploads-processed"));
+        emitEvent(Events.FILE_UPLOAD_PROCESSED);
     }
 
 
@@ -116,7 +134,7 @@ export class UploadedFiles extends HTMLElement {
      * Emits an event to signify that the element has been removed
      */
     #emitRemovedEvent() {
-        document.body.dispatchEvent(new CustomEvent("file-uploads-removed"));
+        emitEvent(Events.FILE_UPLOADS_REMOVED);
     }
 
 
@@ -124,7 +142,7 @@ export class UploadedFiles extends HTMLElement {
      * Monitors the processing status of each uploaded file
      */
     #monitorProcessingStatus() {
-        document.body.addEventListener("file-upload-processed", (evt) => {
+        listenEvent(Events.FILE_UPLOADS_PROCESSED, (evt) => {
             const uploadedFile = /** @type {CustomEvent} */ (evt).detail;
             if (uploadedFile.parentNode !== this.container) return;
             if (this.allProcessed()) this.#emitProcessedEvent();

--- a/django_app/frontend/src/js/web-components/chats/message-input.js
+++ b/django_app/frontend/src/js/web-components/chats/message-input.js
@@ -160,6 +160,7 @@ export class MessageInput extends HTMLElement {
     if (hasUploadedFiles) this.textarea.appendChild(document.createElement("br"));
     this.textarea.blur();
     this.textarea.classList.remove(this.expandedClass);
+    this.textarea.focus();
   };
 
 

--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { UploadedFiles, UploadedFile } from "../../../interaction_design_system/ids/components";
+import { Events, listenEvent } from "../../../interaction_design_system/ids/events";
 import { pollFileStatus, refreshUI } from "../../services";
 import { getCsrfToken } from "../../utils";
 import { MessageInput } from "../chats/message-input";
@@ -190,9 +191,10 @@ class FileUpload extends HTMLElement {
             }
         });
 
-        document.body.addEventListener("file-uploads-processed", this.messageInput?.enableSubmit);
-        document.body.addEventListener("file-uploads-removed", () => {
+        listenEvent(Events.FILE_UPLOAD_PROCESSED, this.messageInput?.enableSubmit);
+        listenEvent(Events.FILE_UPLOADS_REMOVED, () => {
             if (!this.messageInput?.getValue()) this.messageInput.reset();
+            this.messageInput?.enableSubmit();
         });
     }
 

--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -191,7 +191,7 @@ class FileUpload extends HTMLElement {
             }
         });
 
-        listenEvent(Events.FILE_UPLOAD_PROCESSED, this.messageInput?.enableSubmit);
+        listenEvent(Events.FILE_UPLOADS_PROCESSED, this.messageInput?.enableSubmit);
         listenEvent(Events.FILE_UPLOADS_REMOVED, () => {
             if (!this.messageInput?.getValue()) this.messageInput.reset();
             this.messageInput?.enableSubmit();

--- a/django_app/redbox_app/templates/macros/attributes.html
+++ b/django_app/redbox_app/templates/macros/attributes.html
@@ -1,0 +1,7 @@
+{% macro renderAttributes(attrs) %}
+  {% if attrs %}
+    {% for key, value in attrs.items() %}
+      {{ key }}="{{ value }}"
+    {% endfor %}
+  {% endif %}
+{% endmacro %}

--- a/django_app/redbox_app/templates/macros/govuk-button.html
+++ b/django_app/redbox_app/templates/macros/govuk-button.html
@@ -1,11 +1,14 @@
-{% macro govukButton(text=None, classes=None, prevent_double_click=False, dont_submit=False, id=None) %}
+{% from "macros/attributes.html" import renderAttributes %}
+
+{% macro govukButton(text=None, classes=None, prevent_double_click=False, dont_submit=False, id=None, attributes=None) %}
 
 <button
   type="{{ 'button' if dont_submit else 'submit' }}"
   class="govuk-button {{ classes }}"
   data-module="govuk-button"
   {% if prevent_double_click %}data-prevent-double-click="true"{% endif %}
-  {% if id %}id="{{ id }}"{% endif %}>
+  {% if id %}id="{{ id }}"{% endif %}
+  {{ renderAttributes(attributes) }}>
     {{ text | safe }}
     {% if caller %}
       {{ caller() }}


### PR DESCRIPTION
## Context

PR to make changes for the Custom links section of the Assist Accessibility report


## What

- Changes the remove document element from an `a` to a `button` with a close icon to improve accessibility.
- Add a new hidden `span` inside the remove button to assist a screen reader

<img width="757" height="230" alt="image" src="https://github.com/user-attachments/assets/be39711b-535e-4380-b799-9557f2aa7bb3" />

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
