### PR TITLE
feature/ASSIST-1507-name-role-value

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/show-more.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/show-more.js
@@ -202,7 +202,7 @@ export class ShowMore extends HTMLElement {
 
     /**
      * Function to show all items in the container
-     * @param {boolean | null | undefined} expanded - aria-expanded value
+     * @param {boolean | null | undefined} expanded - data-expanded value
     */
     #showItems(items=this.items, expanded=true) {
         this.isExpanded = expanded;
@@ -232,24 +232,24 @@ export class ShowMore extends HTMLElement {
 
 
     /**
-     * Getter for isExpanded property for aria-expanded
+     * Getter for isExpanded property for data-expanded
     */
     get isExpanded() {
-        const value = this.getAttribute("aria-expanded");
+        const value = this.getAttribute("data-expanded");
         if (value == null) return null;
         return value === "true";
     }
 
 
     /**
-     * Setter for isExpanded property for aria-expanded
+     * Setter for isExpanded property for data-expanded
      * @param {boolean | null | undefined} value - Name of attribute
     */
     set isExpanded(value) {
         if (value === null || value === undefined) {
-            this.removeAttribute("aria-expanded");
+            this.removeAttribute("data-expanded");
         } else {
-            this.setAttribute("aria-expanded", value ? "true" : "false");
+            this.setAttribute("data-expanded", value ? "true" : "false");
         }
     }
 }

--- a/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.html
+++ b/django_app/frontend/src/interaction_design_system/ids/components/uploaded-file.html
@@ -3,7 +3,7 @@
 
 <template id="ids-uploaded-file-template">
     <div class="uploaded-file-wrapper" data-id="">
-        <div class="uploaded-file" contenteditable="false" aria-readonly="true" tabindex="-1">
+        <div class="uploaded-file" contenteditable="false" tabindex="-1">
             <div data-icon></div>
             <span class="file-name" title="" data-name></span>
             {% call govukButton(

--- a/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
+++ b/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
@@ -72,12 +72,17 @@ export class FeedbackButtons extends HTMLElement {
 
   #highlightButton(selectedButton, otherButton) {
     selectedButton.style.opacity = 1;
+    selectedButton.setAttribute("aria-pressed", "true");
     otherButton.style.opacity = 0.2;
+    otherButton.setAttribute("aria-pressed", "false");
   }
 
   #resetButtons(button1, button2) {
     button1.style.opacity = 1;
+    button1.setAttribute("aria-pressed", "false");
+
     button2.style.opacity = 1;
+    button2.setAttribute("aria-pressed", "false");
   }
 
   async #sendFeedback(retry = 0) {


### PR DESCRIPTION
## Context

PR to make changes for the Name, role and value section of the Assist Accessibility report


## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
- Add an `aria-pressed` attribute to the feedback thumbs up and down buttons to highlight to a screen reader these elements are clickable, and their current clicked state
- Remove the `aria-expanded` attribute from the show-more elements that are not eligible to use it 
- Remove the `aria-readonly` attribute from the file upload `div` element as it is not eligible to use it 
## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
