### PR TITLE
feature/create-govuk-link-specific-macro

### DIFF
--- a/django_app/redbox_app/templates/chat/chat_actions.html
+++ b/django_app/redbox_app/templates/chat/chat_actions.html
@@ -1,5 +1,5 @@
 {% from "macros/icon.html" import ids_icon %}
-{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-link.html" import govukLink %}
 
 <div class="ids-chat-title__actions">
     {% if not flag_is_active(request, flags.DISABLE_TOOLS) %}
@@ -20,7 +20,7 @@
                 <div class="ids-collapsible-menu__panel">
                     {% for tool_obj in tools %}
                         {% if tool_obj != tool %}
-                            {{ govukButton(
+                            {{ govukLink(
                                 text=tool_obj.name,
                                 classes="govuk-button--secondary ids-tools-button",
                                 href=tool_obj.chat_url
@@ -37,7 +37,7 @@
         <span class='cta-text'>New conversation</span>
     {% endset %}
 
-    {{ govukButton(
+    {{ govukLink(
         text=new_chat_text,
         href=urls.new_chat_url,
         classes="govuk-button--secondary govuk-!-margin-0 ids-icon-text-button"

--- a/django_app/redbox_app/templates/chat/chat_feed.html
+++ b/django_app/redbox_app/templates/chat/chat_feed.html
@@ -1,5 +1,4 @@
 {% from "macros/chat-macros.html" import message_box, route_display %}
-{% from "macros/govuk-button.html" import govukButton %}
 {% from "macros/govuk-warning.html" import govuk_warning %}
 {% from "macros/icon.html" import ids_icon %}
 {% from "macros/upload_form.html" import upload_form %}

--- a/django_app/redbox_app/templates/chat/chat_title.html
+++ b/django_app/redbox_app/templates/chat/chat_title.html
@@ -1,6 +1,5 @@
 {% from "ids/components/editable-text.html" import editable_text %}
 {% from "macros/icon.html" import ids_icon %}
-{% from "macros/govuk-button.html" import govukButton %}
 
 <div class="ids-chat-title ids-flex-row">
     {% if current_chat %}

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -3,7 +3,6 @@
 
 {% extends "base.html" %}
 
-{% from "macros/govuk-button.html" import govukButton %}
 {% from "macros/iai-doc-list.html" import iaiDocList %}
 {% from "macros/upload_form.html" import upload_form %}
 

--- a/django_app/redbox_app/templates/faq.html
+++ b/django_app/redbox_app/templates/faq.html
@@ -5,8 +5,6 @@
 
 {% extends "base.html" %}
 
-{% from "macros/govuk-button.html" import govukButton %}
-
 
 {% block content %}
 

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -3,7 +3,7 @@
 
 {% extends "base.html" %}
 
-{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-link.html" import govukLink %}
 
 
 {% block content %}
@@ -21,13 +21,13 @@
                     </p>
                     <div class="ids-banner__links">
                         {% if not request.user.is_authenticated %}
-                            {{ govukButton(
+                            {{ govukLink(
                                 text="Sign in",
                                 href=url('sign-in'),
                                 classes="govuk-button--secondary govuk-!-margin-bottom-3"
                             ) }}
                         {% else %}
-                            {{ govukButton(
+                            {{ govukLink(
                                 text = "Start a chat",
                                 href=url('chats'),
                                 classes="govuk-button--secondary govuk-!-margin-bottom-0"

--- a/django_app/redbox_app/templates/macros/govuk-button.html
+++ b/django_app/redbox_app/templates/macros/govuk-button.html
@@ -1,17 +1,15 @@
-{% macro govukButton(text=None, visually_hidden_text=None, href=None, classes=None, download=False, prevent_double_click=False, dont_submit=False, id=None) %}
+{% macro govukButton(text=None, classes=None, prevent_double_click=False, dont_submit=False, id=None) %}
 
-{% if href %}
-  <a href="{{ href }}" role="button" draggable="false" class="govuk-button ids-text-xs {{ classes }}" data-module="govuk-button"
-    {% if download %}download{% endif %} {% if id %}id="{{ id }}"{% endif %}>
-    {{ text | safe }}
-  </a>
-{% else %}
-  <button type="{{ 'button' if dont_submit else 'submit' }}" class="govuk-button {{ classes }}" data-module="govuk-button" {% if prevent_double_click %}data-prevent-double-click="true"{% endif %} {% if id %}id="{{ id }}"{% endif %}>
+<button
+  type="{{ 'button' if dont_submit else 'submit' }}"
+  class="govuk-button {{ classes }}"
+  data-module="govuk-button"
+  {% if prevent_double_click %}data-prevent-double-click="true"{% endif %}
+  {% if id %}id="{{ id }}"{% endif %}>
     {{ text | safe }}
     {% if caller %}
       {{ caller() }}
     {% endif %}
-  </button>
-{% endif %}
+</button>
 
 {% endmacro %}

--- a/django_app/redbox_app/templates/macros/govuk-link.html
+++ b/django_app/redbox_app/templates/macros/govuk-link.html
@@ -1,0 +1,14 @@
+{% macro govukLink(text=None, href=None, classes=None, download=False, id=None) %}
+
+<a
+  href="{{ href }}"
+  role="button"
+  draggable="false"
+  class="govuk-button ids-text-xs {{ classes }}"
+  data-module="govuk-button"
+  {% if download %}download{% endif %}
+  {% if id %}id="{{ id }}"{% endif %}>
+    {{ text | safe }}
+</a>
+
+{% endmacro %}

--- a/django_app/redbox_app/templates/sign-up-page-7.html
+++ b/django_app/redbox_app/templates/sign-up-page-7.html
@@ -2,7 +2,7 @@
 
 {% extends "base.html" %}
 
-{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-link.html" import govukLink %}
 
 
 {% block content %}
@@ -44,7 +44,7 @@
         </ul>
 
         <div class="govuk-button-group govuk-!-margin-top-6">
-          {{ govukButton(text="Sign in to your Redbox", href=url('sign-in')) }}
+          {{ govukLink(text="Sign in to your Redbox", href=url('sign-in')) }}
         </div>
 
       </div>

--- a/django_app/redbox_app/templates/tools/base-tool-info.html
+++ b/django_app/redbox_app/templates/tools/base-tool-info.html
@@ -3,7 +3,7 @@
 
 {% extends "base.html" %}
 
-{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-link.html" import govukLink %}
 
 
 {% block content %}
@@ -32,7 +32,7 @@
                 {% block tool_additional_content %}
                 {% endblock %}
 
-                {{ govukButton(
+                {{ govukLink(
                     text = "Use " ~ tool.name | lower,
                     href=tool.chat_url,
                     classes="ids-push-bottom ids-w-fit"

--- a/django_app/redbox_app/templates/tools/settings.html
+++ b/django_app/redbox_app/templates/tools/settings.html
@@ -5,6 +5,7 @@
 {% extends "base.html" %}
 
 {% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-link.html" import govukLink %}
 {% from "macros/icon.html" import ids_icon %}
 
 {% block content %}
@@ -89,11 +90,10 @@
             Users
         </h3>
 
-        {{ govukButton(
+        {{ govukLink(
             text="Add users",
             href=bulk_add_user_tool_url,
-            classes="govuk-button--secondary",
-            prevent_double_click=True
+            classes="govuk-button--secondary"
         ) }}
 
         <div class="ids-scrollable ids-max-height-content--two-thirds">
@@ -123,11 +123,10 @@
             Access Rules
         </h3>
 
-        {{ govukButton(
+        {{ govukLink(
             text="Add rule",
             href=add_tool_access_rule_url,
-            classes="govuk-button--secondary",
-            prevent_double_click=True
+            classes="govuk-button--secondary"
         ) }}
 
         <div class="ids-scrollable ids-max-height-content--two-thirds">

--- a/django_app/redbox_app/templates/tools/tool-card.html
+++ b/django_app/redbox_app/templates/tools/tool-card.html
@@ -1,5 +1,5 @@
 {% from "macros/icon.html" import ids_icon %}
-{% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-link.html" import govukLink %}
 
 {% if tool %}
     <div class="ids-card ids-card--tool govuk-!-padding-4 ids-width--full">
@@ -8,7 +8,7 @@
                 <div class="ids-item-actions">
                     <h3 class="govuk-heading-s govuk-!-margin-0">{{ tool.name }}</h3>
                     {% if request.user.can_manage_tool(tool) %}
-                        {{ govukButton(
+                        {{ govukLink(
                             text=ids_icon(icon_name="edit.html", icon_classes="link"),
                             href=tool.settings_url,
                             classes="govuk-button--secondary govuk-!-margin-0 ids-icon-button"

--- a/django_app/redbox_app/templates/tools/tools.html
+++ b/django_app/redbox_app/templates/tools/tools.html
@@ -3,8 +3,6 @@
 
 {% extends "base.html" %}
 
-{% from "macros/govuk-button.html" import govukButton %}
-
 
 {% block content %}
 <div class="govuk-width-container">


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Refactor the `govukButton` to make it easier to use in an upcoming PR

## What
- Refactor the `govukButton` macro that can render either a `<button>` or an `<a>` into 2 separate components. The `govukButton` now only renders a `<button>`, and a new `govukLink` macro will render an `<a>`
<!-- What is this PR doing? What is being accomplished by this change in the code? -->

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
