### PR TITLE
feature/ASSIST-1510-expandable-menu

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/side-panel.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/side-panel.js
@@ -5,6 +5,7 @@ import { disableNoScroll, enableNoScroll } from "./no-scroll";
 
 export class SidePanel extends HTMLElement {
     storageKey = "ids-side-panel-collapsed";
+    expandedClass = "ids-side-panel-wrapper--expanded";
     collapsedClass = "ids-side-panel-wrapper--collapsed";
     noScrollSource = "side-panel";
     toggleSlot = "toggle-side-panel";
@@ -96,6 +97,7 @@ export class SidePanel extends HTMLElement {
 
     open() {
         this.classList.remove(this.collapsedClass);
+        this.classList.add(this.expandedClass);
 
         // Enable no-scroll
         this.sidepanelId = enableNoScroll(this.noScrollSource);
@@ -111,6 +113,7 @@ export class SidePanel extends HTMLElement {
 
 
     close() {
+        this.classList.remove(this.expandedClass);
         this.classList.add(this.collapsedClass);
 
         // Disable no-scroll

--- a/django_app/frontend/src/interaction_design_system/ids/components/side-panel.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/side-panel.js
@@ -100,9 +100,6 @@ export class SidePanel extends HTMLElement {
         // Enable no-scroll
         this.sidepanelId = enableNoScroll(this.noScrollSource);
 
-        // Update aria
-        this.setAttribute('aria-expanded', 'true');
-
         // Persist state
         localStorage.setItem(this.storageKey, "false");
 
@@ -118,9 +115,6 @@ export class SidePanel extends HTMLElement {
 
         // Disable no-scroll
         if (this.sidepanelId) disableNoScroll(this.sidepanelId);
-
-        // Update aria
-        this.setAttribute('aria-expanded', 'false');
 
         // Persist state
         localStorage.setItem(this.storageKey, "true");

--- a/django_app/frontend/src/interaction_design_system/ids/layouts/page.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/layouts/page.scss
@@ -60,7 +60,7 @@
         }
     }
 
-    .ids-page-layout:has(.ids-side-panel-wrapper[aria-expanded="true"]) {
+    .ids-page-layout:has(.ids-side-panel-wrapper--expanded) {
         &::after {
             content: "";
             position: fixed;
@@ -76,7 +76,7 @@
             touch-action: none;
         }
     }
-    .ids-page-layout:has(.ids-side-panel-wrapper[aria-expanded="false"])::after {
+    .ids-page-layout:has(.ids-side-panel-wrapper--collapsed)::after {
         background: rgba(0, 0, 0, 0);
     }
 }
@@ -98,7 +98,7 @@
             content: none !important;
         }
 
-        &:has(.ids-side-panel-wrapper[aria-expanded="true"]) .ids-page-content {
+        &:has(.ids-side-panel-wrapper--expanded) .ids-page-content {
             pointer-events: all;
             touch-action: auto;
         }

--- a/django_app/frontend/src/interaction_design_system/ids/layouts/side-panel.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/layouts/side-panel.scss
@@ -67,7 +67,7 @@
 
       position: fixed;
 
-      &[aria-expanded="true"] {
+      &.ids-side-panel-wrapper--expanded {
         box-shadow: var(--side-panel-box-shadow);
       }
 
@@ -123,7 +123,7 @@
       --side-panel-width: var(--side-panel-width--m);
       position: sticky;
 
-      &[aria-expanded="true"] {
+      &.ids-side-panel-wrapper--expanded {
         box-shadow: none;
       }
 

--- a/django_app/redbox_app/templates/side_panel/header.html
+++ b/django_app/redbox_app/templates/side_panel/header.html
@@ -16,8 +16,9 @@
                             type="button"
                             class="govuk-header__menu-button ids-header__menu-button ids-side-panel__toggle ids-icon-button"
                             aria-controls="navigation"
-                            aria-label="Show or hide menu">
-                        {{ ids_icon(icon_name="left-panel-close.svg", icon_classes="dark") }}
+                            aria-label="Close the menu">
+                              {{ ids_icon(icon_name="left-panel-close.svg", icon_classes="dark") }}
+                              <span class="govuk-visually-hidden">Close the menu</span>
                     </button>
                 </ids-side-panel-toggle>
 

--- a/django_app/redbox_app/templates/side_panel/side_panel.html
+++ b/django_app/redbox_app/templates/side_panel/side_panel.html
@@ -4,9 +4,13 @@
     <ids-side-panel class="ids-side-panel-wrapper {% if sidepanel_collapsed %}ids-side-panel-wrapper--collapsed{% endif %}">
         <div class="ids-side-panel ids-text-xs">
             <ids-side-panel-toggle>
-                <button slot="toggle-side-panel" class="ids-side-panel--collapsed__content ids-side-panel__toggle ids-icon-button" type="button">
-                    {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="dark") }}
-                    <span class="govuk-visually-hidden">Toggle sidepanel</span>
+                <button slot="toggle-side-panel"
+                        type="button"
+                        class="ids-side-panel--collapsed__content ids-side-panel__toggle ids-icon-button"
+                        aria-controls="navigation"
+                        aria-label="Open the menu">
+                          {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="dark") }}
+                          <span class="govuk-visually-hidden">Open the menu</span>
                 </button>
             </ids-side-panel-toggle>
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
PR to make changes for the expandable menu section of the Assist Accessibility report


## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
As the open and close side menu buttons are 2 separate buttons in the HTML, provide dedicated text instructions for open and close instead of the generic Toggle sidemenu text. This allows the removal of the custom `aria-expanded` attribute

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
