### PR TITLE
feature/ASSIST-1513-conversation-buttons

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/styles/chat-styles.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/styles/chat-styles.scss
@@ -51,12 +51,16 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   color: #6b7280;
   display: flex;
   flex-wrap: wrap;
+  border:none;
+  gap:15px;
+  padding: 0px;;
 }
 
 .feedback__heading {
   color: var(--color-text);
   margin: 0;
   margin-right: 1rem;
+  display: contents;
 }
 
 .thumb_feedback-btn {
@@ -64,7 +68,6 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   background: none;
   padding: 2px;
   cursor: pointer;
-  margin-right: 8px;
 }
 
 .feedback__text-area {
@@ -304,8 +307,13 @@ main:has(.iai-chat-bubble[data-role="ai"]) .exit-feedback {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 10px;
+  gap: 18px;
   font-size: 14px;
+}
+
+.feedback-button-container {
+  display: flex;
+  gap: 8px;
 }
 
 .ids-message-container,

--- a/django_app/frontend/src/interaction_design_system/ids/styles/chat-styles.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/styles/chat-styles.scss
@@ -51,8 +51,8 @@ chat-history[data-initialised] .rb-chat-history__actions-button {
   color: #6b7280;
   display: flex;
   flex-wrap: wrap;
-  border:none;
-  gap:15px;
+  border: none;
+  gap: 15px;
   padding: 0px;;
 }
 
@@ -307,9 +307,14 @@ main:has(.iai-chat-bubble[data-role="ai"]) .exit-feedback {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 18px;
+  gap: 10px;
   font-size: 14px;
 }
+
+.chat-actions-container__feedback{
+  gap: 18px;
+}
+
 
 .feedback-button-container {
   display: flex;

--- a/django_app/frontend/src/js/web-components/chats/chat-message.js
+++ b/django_app/frontend/src/js/web-components/chats/chat-message.js
@@ -39,7 +39,7 @@ export class ChatMessage extends HTMLElement {
                     </div>
                 </div>
             ${this.dataset.role == 'ai' ?
-        `<div class="chat-actions-container">
+        `<div class="chat-actions-container chat-actions-container__feedback">
             </div>`
         : ''}
 

--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -17,6 +17,7 @@ class CopyText extends HTMLElement {
           </defs>
           </svg>
           Copy
+          <span class="govuk-visually-hidden"> message content</span>
         </button>
     `;
 

--- a/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
+++ b/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
@@ -22,15 +22,17 @@ export class FeedbackButtons extends HTMLElement {
     this.dataset.id = messageId;
 
     this.innerHTML = `
-    <div class="feedback-container feedback-container--1" tabindex="-1">
-      <p class="feedback__heading">Is this response useful?</p>
+    <fieldset class="feedback-container feedback-container--1" tabindex="-1">
+      <legend class="feedback__heading">Is this response useful?</legend>
+      <div class="feedback-button-container">
       <button class="thumb_feedback-btn thumb_feedback-btn--up" type="button">
-        <img src="/static/icons/thumbs-up.svg" alt="Thumbs Up" aria-labelledby="feedback-heading" />
+        <img src="/static/icons/thumbs-up.svg" alt="Yes" />
       </button>
       <button class="thumb_feedback-btn thumb_feedback-btn--down" type="button">
-        <img src="/static/icons/thumbs-down.svg" alt="Thumbs down" aria-labelledby="feedback-heading"/>
+        <img src="/static/icons/thumbs-down.svg" alt="No" />
       </button>
-    </div>
+      </div>
+    </fieldset>
      `;
 
     // 1 Thumbs up, 2 Thumbs down

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -75,7 +75,7 @@
   {% endif %}
 
   {% if message.role == "ai" %}
-    <div class="chat-actions-container">
+    <div class="chat-actions-container chat-actions-container__feedback">
       <feedback-buttons data-id="{{ message.id }}"></feedback-buttons>
       <copy-text data-id="{{ message.id}}"></copy-text>
     </div>


### PR DESCRIPTION
## Context

PR to make changes for the Conversation buttons section of the Assist Accessibility report

## What

- Add a hidden span after the Copy button to give a screen reader more context what is being copied
- Update the thumbs up and down alt text to be yes and no to be more descriptive to screen readers
- Remove the aria-labelled attribute as it is pointing to a non-existant HTML element
- Change the button div to a fieldset with a legend to group the buttons in an easier to understand format for a screen reader

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
