### PR TITLE
feature/ASSIST-1515-non-descriptive-image-controls

### DIFF
--- a/django_app/redbox_app/templates/chat/chat_title.html
+++ b/django_app/redbox_app/templates/chat/chat_title.html
@@ -12,7 +12,7 @@
                         <h2 class="ids-chat-title__heading govuk-heading-s title-text">{{ current_chat.name }}</h2>
                         <button id="chat-title-edit-button" class="edit-trigger ids-icon-button" type="button">
                             {{ ids_icon(icon_name="edit.html") }}
-                            <span class="govuk-visually-hidden">Chat Title</span>
+                            <span class="govuk-visually-hidden">Edit chat: {{ current_chat.name }}</span>
                         </button>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## Context

PR to make changes for the Non-descriptive image controls section of the Assist Accessibility report

## What

- Add more descriptive text for the edit chat title button, as the generic "Chat title" text currently used was making it difficult for screen readers to detect the button purpose 

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
