### PR TITLE
Search docs tool returned empty or whitespace-only response

### DIFF
--- a/redbox/redbox/app.py
+++ b/redbox/redbox/app.py
@@ -1,6 +1,6 @@
 from asyncio import CancelledError
 from logging import getLogger
-from typing import Dict, Literal, Callable
+from typing import Callable, Dict, Literal
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStoreRetriever
@@ -18,12 +18,12 @@ from redbox.graph.nodes.tools import (
     build_document_from_prompt_tool,
     build_govuk_search_tool,
     build_legislation_search_tool,
+    build_query_tabular_file_tool,
     build_retrieve_document_full_text,
     build_retrieve_knowledge_base,
     build_search_documents_tool,
     build_search_wikipedia_tool,
     build_web_search_tool,
-    build_query_tabular_file_tool,
 )
 from redbox.graph.root import build_new_route_graph, build_root_graph, get_summarise_graph
 from redbox.models.chain import RedboxState
@@ -246,10 +246,13 @@ class Redbox:
                 is_summary_multiagent_streamed=is_summary_multiagent_streamed,
                 is_evaluator_output_streamed=is_evaluator_output_streamed,
             )
-            try:
-                _ = final_state.messages[-1].content
-            except Exception as e:
-                logger.exception(f"app: LLM Error - Blank Response; {e}")
+            if final_state is None:
+                logger.error("app: LLM Error - Blank Response; graph produced no final state")
+            elif not final_state.messages:
+                logger.error("app: LLM Error - Blank Response; final state has no messages")
+            elif not (final_state.messages[-1].content or "").strip():
+                logger.error("app: LLM Error - Blank Response; final message content is empty")
+
         except CancelledError:
             logger.error("All retries exhausted for CancelledError in the astream_events function")
             raise

--- a/redbox/redbox/graph/agents/workers.py
+++ b/redbox/redbox/graph/agents/workers.py
@@ -64,9 +64,12 @@ class WorkerAgent(Agent):
 
     def _processing(self, result):
         result_content = ""
-        if isinstance(result, str):
+        if result is None or (isinstance(result, list) and not result):
+            self.logger.warning(f"[{self.config.name}] No tool results returned")
+        elif isinstance(result, str):
             self.logger.warning(f"[{self.config.name}] Using raw string result.")
             result_content = result
+
         elif isinstance(result, list) and isinstance(result[0], dict):
             self.logger.warning(f"[{self.config.name}] Using raw string in a list as result.")
             result_content = result[0].get("text", "")

--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -259,9 +259,16 @@ def build_search_documents_tool(
             time.time() - start_time,
         )
         log.warning("[_search_documents] Returning %s documents", len(sorted_documents))
+        formatted_docs = format_documents(sort_documents)
+        if not formatted_docs.strip():
+            log.warning(
+                "[_search_documents] Formatted result was empty despite %s hit(s); returning no_results_msg",
+                len(initial_documents),
+            )
+            return no_results_msg, []
 
         # Return as state update
-        return format_documents(sorted_documents), sorted_documents
+        return formatted_docs, sorted_documents
 
     @tool(response_format="content_and_artifact")
     def _search_documents(query: str, state: Annotated[RedboxState, InjectedState]) -> tuple[str, list[Document]]:

--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -259,7 +259,7 @@ def build_search_documents_tool(
             time.time() - start_time,
         )
         log.warning("[_search_documents] Returning %s documents", len(sorted_documents))
-        formatted_docs = format_documents(sort_documents)
+        formatted_docs = format_documents(sorted_documents)
         if not formatted_docs.strip():
             log.warning(
                 "[_search_documents] Formatted result was empty despite %s hit(s); returning no_results_msg",

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -479,6 +479,73 @@ def test_search_knowledge_base_tool_empty_opensearch_response_returns_text(mocke
     mock_es_client.search.assert_called()
 
 
+def test_search_documents_tool_merge_produces_empty_returns_text(mocker: MockerFixture, env: Settings):
+    """
+    If  merge_documents returns empty or whitespace only, despite documents existing, the tool must return a non-empty string
+    """
+    mock_es_client = mocker.MagicMock(spec=OpenSearch)
+    mock_es_client.search.return_value = {
+        "hits": {"hits": [{"_id": "1", "_score": 1.0, "source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+    }
+    mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
+    embedding_model = FakeEmbeddings(size=1024)
+
+    search = build_search_documents_tool(
+        es_client=mock_es_client,
+        index_name="index",
+        embedding_model=embedding_model,
+        embedding_field_name=env.embedding_document_field_name,
+        chunk_resolution=ChunkResolution.normal,
+    )
+
+    tool_node = ToolNode(tools=[search])
+    result_state = tool_node.invoke(
+        _make_search_tool_state("example prompt", s3_keys=["s3_key"], permitted_s3_keys=["s3_key"])
+    )
+
+    message = result_state["messages"][0]
+
+    assert message.content
+    assert message.artifact == []
+
+
+def test_search_knowledge_base_tool_merge_produces_empty_returns_text(mocker: MockerFixture, env: Settings):
+    """
+    If  merge_documents returns empty or whitespace only, despite documents existing, the tool must return a non-empty string, for knowledge base
+    """
+    mock_es_client = mocker.MagicMock(spec=OpenSearch)
+    mock_es_client.search.return_value = {
+        "hits": {"hits": [{"_id": "1", "_score": 1.0, "source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+    }
+    mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
+    embedding_model = FakeEmbeddings(size=1024)
+
+    knowledge_base_search = build_search_documents_tool(
+        es_client=mock_es_client,
+        index_name="index",
+        embedding_model=embedding_model,
+        embedding_field_name=env.embedding_document_field_name,
+        chunk_resolution=ChunkResolution.normal,
+        repository="knowledge_base",
+    )
+
+    tool_node = ToolNode(tools=[knowledge_base_search])
+    result_state = tool_node.invoke(
+        _make_search_tool_state(
+            "example prompt",
+            s3_keys=["s3_key"],
+            permitted_s3_keys=["s3_key"],
+            knowledge_base_s3_keys=["s3_key"],
+            tool_name="_search_knowledge_base",
+        )
+    )
+
+    message = result_state["messages"][0]
+
+    assert message.content
+    assert message.artifact == []
+
+
 @pytest.mark.xfail(reason="calls api")
 def test_govuk_search_tool():
     tool = build_govuk_search_tool()

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -509,15 +509,38 @@ def test_search_documents_tool_merge_produces_empty_returns_text(mocker: MockerF
     assert message.artifact == []
 
 
-def test_search_knowledge_base_tool_merge_produces_empty_returns_text(mocker: MockerFixture, env: Settings):
+def test_search_knowledge_base_tool_merge_produces_empty_returns_text(
+    mocker: MockerFixture,
+    env: Settings,
+):
     """
-    If  merge_documents returns empty or whitespace only, despite documents existing, the tool must return a non-empty string, for knowledge base
+    If merge_documents returns empty or whitespace only, despite documents
+    existing, the tool must return a non-empty string, for knowledge base.
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     mock_es_client.search.return_value = {
-        "hits": {"hits": [{"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+        "hits": {
+            "hits": [
+                {
+                    "_index": "index",
+                    "_id": "1",
+                    "_score": 1.0,
+                    "_source": {
+                        "text": "hello world",
+                        "metadata": {
+                            "uri": "abc",
+                        },
+                    },
+                }
+            ]
+        }
     }
-    mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
+
+    mocker.patch(
+        "redbox.graph.nodes.tools.merge_documents",
+        return_value=[],
+    )
+
     embedding_model = FakeEmbeddings(size=1024)
 
     knowledge_base_search = build_search_documents_tool(
@@ -530,6 +553,7 @@ def test_search_knowledge_base_tool_merge_produces_empty_returns_text(mocker: Mo
     )
 
     tool_node = ToolNode(tools=[knowledge_base_search])
+
     result_state = tool_node.invoke(
         _make_search_tool_state(
             "example prompt",

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -485,7 +485,7 @@ def test_search_documents_tool_merge_produces_empty_returns_text(mocker: MockerF
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     mock_es_client.search.return_value = {
-        "hits": {"hits": [{"_id": "1", "_score": 1.0, "source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+        "hits": {"hits": [{"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
     }
     mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
     embedding_model = FakeEmbeddings(size=1024)
@@ -515,7 +515,7 @@ def test_search_knowledge_base_tool_merge_produces_empty_returns_text(mocker: Mo
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     mock_es_client.search.return_value = {
-        "hits": {"hits": [{"_id": "1", "_score": 1.0, "source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+        "hits": {"hits": [{"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
     }
     mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
     embedding_model = FakeEmbeddings(size=1024)

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -485,7 +485,11 @@ def test_search_documents_tool_merge_produces_empty_returns_text(mocker: MockerF
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     mock_es_client.search.return_value = {
-        "hits": {"hits": [{"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+        "hits": {
+            "hits": [
+                {"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "index": 0, "metadata": {"uri": "abc"}}}
+            ]
+        }
     }
     mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
     embedding_model = FakeEmbeddings(size=1024)
@@ -515,7 +519,11 @@ def test_search_knowledge_base_tool_merge_produces_empty_returns_text(mocker: Mo
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     mock_es_client.search.return_value = {
-        "hits": {"hits": [{"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
+        "hits": {
+            "hits": [
+                {"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "index": 0, "metadata": {"uri": "abc"}}}
+            ]
+        }
     }
     mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
     embedding_model = FakeEmbeddings(size=1024)

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -509,43 +509,20 @@ def test_search_documents_tool_merge_produces_empty_returns_text(mocker: MockerF
     assert message.artifact == []
 
 
-def test_search_knowledge_base_tool_merge_produces_empty_returns_text(
-    mocker: MockerFixture,
-    env: Settings,
-):
+def test_search_knowledge_base_tool_merge_produces_empty_returns_text(mocker: MockerFixture, env: Settings):
     """
-    If merge_documents returns empty or whitespace only, despite documents
-    existing, the tool must return a non-empty string, for knowledge base.
+    If  merge_documents returns empty or whitespace only, despite documents existing, the tool must return a non-empty string, for knowledge base
     """
     mock_es_client = mocker.MagicMock(spec=OpenSearch)
     mock_es_client.search.return_value = {
-        "hits": {
-            "hits": [
-                {
-                    "_index": "index",
-                    "_id": "1",
-                    "_score": 1.0,
-                    "_source": {
-                        "text": "hello world",
-                        "metadata": {
-                            "uri": "abc",
-                        },
-                    },
-                }
-            ]
-        }
+        "hits": {"hits": [{"_id": "1", "_score": 1.0, "_source": {"text": "hello world", "metadata": {"uri": "abc"}}}]}
     }
-
-    mocker.patch(
-        "redbox.graph.nodes.tools.merge_documents",
-        return_value=[],
-    )
-
+    mocker.patch("redbox.graph.nodes.tools.merge_documents", return_value=[])
     embedding_model = FakeEmbeddings(size=1024)
 
     knowledge_base_search = build_search_documents_tool(
         es_client=mock_es_client,
-        index_name="index",
+        index_name="_index",
         embedding_model=embedding_model,
         embedding_field_name=env.embedding_document_field_name,
         chunk_resolution=ChunkResolution.normal,
@@ -553,7 +530,6 @@ def test_search_knowledge_base_tool_merge_produces_empty_returns_text(
     )
 
     tool_node = ToolNode(tools=[knowledge_base_search])
-
     result_state = tool_node.invoke(
         _make_search_tool_state(
             "example prompt",


### PR DESCRIPTION
## Context

The search documents tool has suddenlt started failing due to the search documents tool returning an empty or whitespace only string.

failed: _search_documents - Tool '_search_documents' returned empty or whitespace-only response

## What

replicate error in unit tests

fix bug so that root cause is fixed

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
