### PR TITLE
feature/ASSIST-1511-dialog

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/side-panel.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/side-panel.js
@@ -30,6 +30,7 @@ export class SidePanel extends HTMLElement {
             evt.stopPropagation();
             this.togglePanel();
         });
+
     }
 
 
@@ -39,6 +40,9 @@ export class SidePanel extends HTMLElement {
         } else {
             document.addEventListener("click", this.handleOutsideClick);
         }
+
+        this.handleScreenOverlay();
+
     }
 
 
@@ -55,6 +59,18 @@ export class SidePanel extends HTMLElement {
         this.close();
     }
 
+
+    handleScreenOverlay() {
+        //background is blurred
+        if (!this.noOverlap && this.expanded) {
+            this.setAttribute("role", "dialog");
+            this.setAttribute("aria-modal", "true");
+        }
+        else {
+            this.removeAttribute("role");
+            this.removeAttribute("aria-modal");
+        }
+    }
 
     /**
      * Returns the sidepanel ID
@@ -109,6 +125,8 @@ export class SidePanel extends HTMLElement {
         document.cookie = `${this.storageKey}=false; path=/`;
 
         if (!this.noOverlap) document.addEventListener("click", this.handleOutsideClick);
+
+        this.handleScreenOverlay();
     }
 
 
@@ -126,6 +144,8 @@ export class SidePanel extends HTMLElement {
         document.cookie = `${this.storageKey}=true; path=/`;
 
         document.removeEventListener("click", this.handleOutsideClick);
+
+        this.handleScreenOverlay();
     }
 }
 customElements.define("ids-side-panel", SidePanel);

--- a/django_app/frontend/src/interaction_design_system/ids/layouts/page.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/layouts/page.scss
@@ -107,6 +107,7 @@
         &:has(.ids-side-panel-wrapper--expanded) .ids-page-content {
             pointer-events: all;
             touch-action: auto;
+            interactivity: auto;
         }
     }
 }

--- a/django_app/frontend/src/interaction_design_system/ids/layouts/page.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/layouts/page.scss
@@ -74,10 +74,16 @@
         .ids-page-content {
             pointer-events: none;
             touch-action: none;
+            interactivity: inert;
         }
     }
-    .ids-page-layout:has(.ids-side-panel-wrapper--collapsed)::after {
-        background: rgba(0, 0, 0, 0);
+    .ids-page-layout:has(.ids-side-panel-wrapper--collapsed) {
+        &::after{
+            background: rgba(0, 0, 0, 0);
+        }
+        .ids-page-content {
+            interactivity: auto;
+        }
     }
 }
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
PR to make changes for the expandable menu section of the Assist Accessibility report

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
On smaller screens, when the menu is expanded the elements behind the menu are still navigable using the tab button. This change adds some attributes to the menu to highlight to a screen reader the menu is acting as a modal, and sets the `inert` attribute on the div behind to block the elements being selected

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
