### PR TITLE
feature/ASSIST-1518-focus-visible

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/header.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/components/header.scss
@@ -9,5 +9,17 @@
         background-color: transparent;
         box-shadow: none;
     }
-    padding-top: 5px !important;
+    .button-content{
+      line-height: 0;
+    }
+    &:focus > .button-content {
+        outline: 3px solid var(--color-focus);
+        outline-offset: 0;
+        background-color: var(--color-focus);
+    }
+    &:hover > .button-content {
+        background-color: transparent;
+        box-shadow: none;
+        outline:none;
+    }
 }

--- a/django_app/frontend/src/interaction_design_system/ids/components/header.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/components/header.scss
@@ -8,6 +8,7 @@
     &:focus {
         background-color: transparent;
         box-shadow: none;
+        outline:none;
     }
     .button-content{
       line-height: 0;

--- a/django_app/frontend/src/interaction_design_system/ids/layouts/side-panel.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/layouts/side-panel.scss
@@ -30,6 +30,10 @@
     .ids-side-panel--collapsed__content {
       display: flex;
     }
+    .ids-side-panel__toggle {
+      padding:10px;
+    }
+
   }
 }
 
@@ -57,7 +61,7 @@
 .ids-side-panel__toggle {
   align-items: center;
   justify-content: center;
-  padding: 10px;
+  padding: 0px 10px;
 }
 
 @media (min-width: bp(xs)) {

--- a/django_app/redbox_app/templates/chat/cta.html
+++ b/django_app/redbox_app/templates/chat/cta.html
@@ -3,9 +3,11 @@
 <div id="chat-cta" class="ids-chat-cta {% if not tool and not current_chat %}ids-chat-cta--centered{% endif %}" hx-swap-oob="outerHTML">
     <div class="ids-chat-cta__toggle">
         <ids-side-panel-toggle>
-            <button slot="toggle-side-panel" class="ids-side-panel__toggle ids-icon-button govuk-!-padding-left-0" type="button">
-                {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="") }}
-                <span class="govuk-visually-hidden">Toggle sidepanel</span>
+            <button slot="toggle-side-panel" class="ids-side-panel__toggle ids-icon-button ids-header__menu-button govuk-!-padding-left-0" type="button">
+                <div class="button-content">
+                  {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="") }}
+                  <span class="govuk-visually-hidden">Open the menu</span>
+                </div>
             </button>
         </ids-side-panel-toggle>
     </div>

--- a/django_app/redbox_app/templates/side_panel/header.html
+++ b/django_app/redbox_app/templates/side_panel/header.html
@@ -17,8 +17,10 @@
                             class="govuk-header__menu-button ids-header__menu-button ids-side-panel__toggle ids-icon-button"
                             aria-controls="navigation"
                             aria-label="Close the menu">
+                            <div class="button-content">
                               {{ ids_icon(icon_name="left-panel-close.svg", icon_classes="dark") }}
                               <span class="govuk-visually-hidden">Close the menu</span>
+                            </div>
                     </button>
                 </ids-side-panel-toggle>
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
PR to make changes for the Focus visible section of the Assist Accessibility report

## What

- Fix the alignment of the toggle button, as it is 5px below the side panel menu
- Add a focus style to the toggle button that highlights in yellow when a keyboard is used to tab through the page elements. This focus style does not appear when the button is clicked

<img width="283" height="313" alt="image" src="https://github.com/user-attachments/assets/73489e10-5f89-4bf2-91db-7d8c229a5829" />

<img width="611" height="270" alt="image" src="https://github.com/user-attachments/assets/8e5efb01-0764-4ae9-8d1e-8bb423eae357" />


## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
