### PR TITLE
feat: prepopulate chat message input from ?q= url param

### DIFF
--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -39,6 +39,9 @@ class ChatsView(View):
         if tool and (tool not in context["tools"]):
             return HttpResponse(status=HTTPStatus.UNAUTHORIZED)
 
+        if not chat_id:
+            context["prepopulated_query"] = request.GET.get("q", "")
+
         return chat_service.render_chats(request, context)
 
 

--- a/django_app/redbox_app/templates/chat/chat_interaction.html
+++ b/django_app/redbox_app/templates/chat/chat_interaction.html
@@ -7,7 +7,7 @@
             <ids-message-input>
                 <div class="govuk-textarea ids-message-input ids-border {% if not messages and not is_first_time_user %}ids-message-input__expanded {% endif %}ids-drop-zone"
                     id="message" name="message" contenteditable="true" role="textbox" aria-multiline="true"
-                    data-text="Type your message here..." aria-label="Text input field for typing and submitting your message"></div>
+                    data-text="Type your message here..." aria-label="Text input field for typing and submitting your message">{{ prepopulated_query or "" }}</div>
                 <div class="ids-message-input__actions">
                     <!-- Upload Button -->
                     <file-upload upload-url="{{ urls.upload_url }}">

--- a/django_app/tests/views/test_chat_views.py
+++ b/django_app/tests/views/test_chat_views.py
@@ -85,6 +85,71 @@ def test_nonexistent_chats(alice: User, client: Client):
 
 
 @pytest.mark.django_db
+def test_new_chat_prepopulates_query_from_url(alice: User, client: Client):
+    # Given
+    client.force_login(alice)
+
+    # When
+    response = client.get(reverse("chats"), data={"q": "Hello redbox"})
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    soup = BeautifulSoup(response.content, "html.parser")
+    message_input = soup.find(id="message")
+    assert message_input is not None
+    assert message_input.get_text() == "Hello redbox"
+
+
+@pytest.mark.django_db
+def test_new_chat_without_query_param_has_empty_input(alice: User, client: Client):
+    # Given
+    client.force_login(alice)
+
+    # When
+    response = client.get(reverse("chats"))
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    soup = BeautifulSoup(response.content, "html.parser")
+    message_input = soup.find(id="message")
+    assert message_input is not None
+    assert message_input.get_text() == ""
+
+
+@pytest.mark.django_db
+def test_prepopulated_query_is_escaped(alice: User, client: Client):
+    # Given
+    client.force_login(alice)
+    malicious = "<script>alert('xss')</script>"
+
+    # When
+    response = client.get(reverse("chats"), data={"q": malicious})
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    assert b"<script>alert('xss')</script>" not in response.content
+    soup = BeautifulSoup(response.content, "html.parser")
+    message_input = soup.find(id="message")
+    assert message_input.get_text() == malicious
+
+
+@pytest.mark.django_db
+def test_existing_chat_ignores_query_param(chat_with_message: Chat, client: Client):
+    # Given
+    client.force_login(chat_with_message.user)
+
+    # When
+    response = client.get(f"/chats/{chat_with_message.id}/", data={"q": "should be ignored"})
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    soup = BeautifulSoup(response.content, "html.parser")
+    message_input = soup.find(id="message")
+    assert message_input is not None
+    assert message_input.get_text() == ""
+
+
+@pytest.mark.django_db
 def test_post_chat_title(alice: User, chat: Chat, client: Client):
     # Given
     client.force_login(alice)


### PR DESCRIPTION
## Context

* data hub would like to link to dbt assist with a pre-filled prompt as a shortcut to allow users to access summaries of its companies/interactions
* thus enabling other services to do similar type of linking

## What

* adds support for pre-filling the chat message input via a `?q=` url query parameter on the chats page
* opens a new chat with `q`'s value already typed in the message input
* takes effect only on the new-chat route
* existing chats ignore the param so we don't clobber a user's in-progress draft
* output is auto-escaped so untrusted query params can't inject html

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No