### PR TITLE
fix: LLM Error - Blank Response error, in stream_plan

### DIFF
--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -881,7 +881,8 @@ def stream_plan():
         plan_parts.append(f"\n\n{suffix}")
         dispatch_custom_event(RedboxEventType.response_tokens, data=plan_parts[-1])
 
-        return {"messages": [AIMessage(content="".join(plan_parts))]}
+        state.messages = state.messages + [AIMessage(content="".join(plan_parts))]
+        return state
 
     return _stream_plan
 

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -44,9 +44,9 @@ from redbox.models.chain import (
 )
 from redbox.models.graph import ROUTE_NAME_TAG, RedboxActivityEvent, RedboxEventType
 from redbox.models.prompts import (
-    USER_FEEDBACK_EVAL_PROMPT,
-    DATAHUB_USER_FEEDBACK,
     DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS,
+    DATAHUB_USER_FEEDBACK,
+    USER_FEEDBACK_EVAL_PROMPT,
 )
 from redbox.models.settings import ChatLLMBackend
 from redbox.transform import combine_documents, flatten_document_state, join_result_with_token_limit
@@ -871,11 +871,17 @@ def stream_plan():
     @RunnableLambda
     def _stream_plan(state: RedboxState):
         prefix_texts, suffix_texts = get_plan_fix_prompts()
-        dispatch_custom_event(RedboxEventType.response_tokens, data=f"{random.choice(prefix_texts)}\n\n")
+        prefix = random.choice(prefix_texts)
+        suffix = random.choice(suffix_texts)
+        plan_parts = [f"{prefix}\n\n"]
+        dispatch_custom_event(RedboxEventType.response_tokens, data=plan_parts[-1])
         for i, t in enumerate(state.agent_plans.tasks):
-            dispatch_custom_event(RedboxEventType.response_tokens, data=f"{i + 1}. {t.task}\n\n")
-        dispatch_custom_event(RedboxEventType.response_tokens, data=f"\n\n{random.choice(suffix_texts)}")
-        return state
+            plan_parts.append(f"{i + 1}. {t.task}\n\n")
+            dispatch_custom_event(RedboxEventType.response_tokens, data=plan_parts[-1])
+        plan_parts.append(f"\n\n{suffix}")
+        dispatch_custom_event(RedboxEventType.response_tokens, data=plan_parts[-1])
+
+        return {"messages": [AIMessage(content="".join(plan_parts))]}
 
     return _stream_plan
 

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -1205,7 +1205,7 @@ def test_stream_plan_saves_to_messages(fake_state_with_plan):
     assert isinstance(result, RedboxState)
     assert len(result.messages) == pre_existing + 1
 
-    message = result["messages"][0]
+    message = result.messages[-1]
     assert isinstance(message, AIMessage)
 
     assert message.content.strip() != ""

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -1196,12 +1196,14 @@ def test_check_if_tasks_completed(task_idx, task_status, expected, fake_state_wi
 
 
 def test_stream_plan_saves_to_messages(fake_state_with_plan):
-    state = fake_state_with_plan
+    state = copy.deepcopy(fake_state_with_plan)
+    pre_existing = len(state.messages)
+
     result = stream_plan().invoke(state)
 
     # Assertions
-    assert "messages" in result
-    assert len(result["messages"]) == 1
+    assert isinstance(result, RedboxState)
+    assert len(result.messages) == pre_existing + 1
 
     message = result["messages"][0]
     assert isinstance(message, AIMessage)

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -1195,8 +1195,8 @@ def test_check_if_tasks_completed(task_idx, task_status, expected, fake_state_wi
     assert expected == actual
 
 
-def test_stream_plan_saves_to_messages(state_with_plan):
-    state = state_with_plan
+def test_stream_plan_saves_to_messages(fake_state_with_plan):
+    state = fake_state_with_plan
     result = stream_plan().invoke(state)
 
     # Assertions

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -1,6 +1,7 @@
+import copy
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-import copy
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolCall
@@ -8,14 +9,13 @@ from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import RunnableLambda
 from langgraph.graph import END, START, StateGraph
 from pytest_mock import MockerFixture
-from unittest.mock import AsyncMock, patch
 
 from redbox.chains.components import get_structured_response_with_citations_parser
 from redbox.chains.runnables import CannedChatLLM, build_chat_prompt_from_messages_runnable, build_llm_chain
 from redbox.graph.nodes.processes import (
     build_agent_with_loop,
-    build_datahub_agent_with_loop,
     build_chat_pattern,
+    build_datahub_agent_with_loop,
     build_merge_pattern,
     build_passthrough_pattern,
     build_retrieve_pattern,
@@ -25,6 +25,7 @@ from redbox.graph.nodes.processes import (
     check_if_tasks_completed,
     clear_documents_process,
     empty_process,
+    stream_plan,
 )
 from redbox.models.chain import (
     AISettings,
@@ -37,8 +38,8 @@ from redbox.models.chain import (
     TaskStatus,
     configure_agent_task_plan,
 )
-from redbox.models.prompts import DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS
 from redbox.models.chat import ChatRoute
+from redbox.models.prompts import DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS
 from redbox.test.data import (
     RedboxChatTestCase,
     RedboxTestData,
@@ -1192,3 +1193,19 @@ def test_check_if_tasks_completed(task_idx, task_status, expected, fake_state_wi
         fake_state.agent_plans.tasks[idx].status = task_status[i]
     actual = check_if_tasks_completed(fake_state)
     assert expected == actual
+
+
+def test_stream_plan_saves_to_messages(state_with_plan):
+    state = state_with_plan
+    result = stream_plan().invoke(state)
+
+    # Assertions
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+
+    message = result["messages"][0]
+    assert isinstance(message, AIMessage)
+
+    assert message.content.strip() != ""
+    for task in state.agent_plans.tasks:
+        assert task.task in message.content


### PR DESCRIPTION
## Context

Error appearing in the logs which shows "LLM Error - Blank Response" - but we found no error in DataDog Traces.
With an empty messages list, the final_state.messages in app.py catches the exception and logs a the error, despite the stream_plan working

## What

We believe that the root of the error is that stream_plan showed the plan to the user but never saved it to state_messages, so the final state had no message, and therefore gave the blank response error.

stream_plan now returns the plan as an message, so therefore the final state has a message, stopping the blank message going through, and therefore error log message.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
