### PR TITLE
feat: mcp tool cache and new run_tools_parallel_extended

### DIFF
--- a/redbox/redbox/api/wrapper.py
+++ b/redbox/redbox/api/wrapper.py
@@ -30,6 +30,14 @@ class SensitiveValue:
         memo[id(self)] = new
         return new
 
+    def __hash__(self) -> int:
+        return hash(self.get())  # hashed, never logged
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SensitiveValue):
+            return NotImplemented
+        return self.get() == other.get()
+
 
 class NonPicklableCallable:
     """Wraps a callable to prevent deepcopy/pickle from walking into it."""

--- a/redbox/redbox/graph/nodes/cache/tools.py
+++ b/redbox/redbox/graph/nodes/cache/tools.py
@@ -1,7 +1,8 @@
-import logging
 import asyncio
+import logging
 import time
-from typing import Callable, Any
+from typing import Any, Awaitable, Callable
+
 from pydantic import BaseModel, Field
 
 from redbox.api.wrapper import SensitiveValue
@@ -24,7 +25,7 @@ _datahub_mcp_tool_cache: dict[SensitiveValue, CacheEntry] = {}
 _datahub_mcp_tool_cache_lock = asyncio.Lock()
 
 
-async def get_cached_datahub_mcp_tools(sso_token_getter: Callable[[], str]) -> list:
+async def get_cached_datahub_mcp_tools(sso_token_getter: Callable[[], Awaitable[str]]) -> list:
     raw_token: str = await sso_token_getter()
     token_key = SensitiveValue(value=raw_token)
 

--- a/redbox/redbox/graph/nodes/cache/tools.py
+++ b/redbox/redbox/graph/nodes/cache/tools.py
@@ -1,0 +1,36 @@
+import asyncio
+import time
+from typing import Callable, Any
+from pydantic import BaseModel, Field
+
+from redbox.api.wrapper import SensitiveValue
+from redbox.graph.nodes.tools import get_datahub_mcp_tools
+
+
+class CacheEntry(BaseModel):
+    value: Any
+    expires_at: float = Field(default_factory=lambda: time.monotonic() + 60)
+
+    def is_expired(self) -> bool:
+        return time.monotonic() >= self.expires_at
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+_datahub_mcp_tool_cache: dict[SensitiveValue, CacheEntry] = {}
+_datahub_mcp_tool_cache_lock = asyncio.Lock()
+
+
+async def get_cached_datahub_mcp_tools(sso_token_getter: Callable[[], str]) -> list:
+    raw_token: str = await sso_token_getter()
+    token_key = SensitiveValue(value=raw_token)
+
+    if (entry := _datahub_mcp_tool_cache.get(token_key)) and not entry.is_expired():
+        return entry.value
+
+    async with _datahub_mcp_tool_cache_lock:
+        if not (entry := _datahub_mcp_tool_cache.get(token_key)) or entry.is_expired():
+            _datahub_mcp_tool_cache[token_key] = CacheEntry(
+                value=await get_datahub_mcp_tools(sso_token_getter=sso_token_getter)
+            )
+    return _datahub_mcp_tool_cache[token_key].value

--- a/redbox/redbox/graph/nodes/cache/tools.py
+++ b/redbox/redbox/graph/nodes/cache/tools.py
@@ -9,7 +9,7 @@ from redbox.graph.nodes.tools import get_datahub_mcp_tools
 
 class CacheEntry(BaseModel):
     value: Any
-    expires_at: float = Field(default_factory=lambda: time.monotonic() + 60)
+    expires_at: float = Field(default_factory=lambda: time.monotonic() + 300)
 
     def is_expired(self) -> bool:
         return time.monotonic() >= self.expires_at

--- a/redbox/redbox/graph/nodes/cache/tools.py
+++ b/redbox/redbox/graph/nodes/cache/tools.py
@@ -1,3 +1,4 @@
+import logging
 import asyncio
 import time
 from typing import Callable, Any
@@ -5,6 +6,8 @@ from pydantic import BaseModel, Field
 
 from redbox.api.wrapper import SensitiveValue
 from redbox.graph.nodes.tools import get_datahub_mcp_tools
+
+log = logging.getLogger(__name__)
 
 
 class CacheEntry(BaseModel):
@@ -26,10 +29,14 @@ async def get_cached_datahub_mcp_tools(sso_token_getter: Callable[[], str]) -> l
     token_key = SensitiveValue(value=raw_token)
 
     if (entry := _datahub_mcp_tool_cache.get(token_key)) and not entry.is_expired():
+        log.warning("[get_cached_datahub_mcp_tools] Fetching Datahub_Agent MCP tools from cache...")
         return entry.value
 
     async with _datahub_mcp_tool_cache_lock:
         if not (entry := _datahub_mcp_tool_cache.get(token_key)) or entry.is_expired():
+            log.warning(
+                "[get_cached_datahub_mcp_tools] Fetching Datahub_Agent MCP tools from server and updating cache..."
+            )
             _datahub_mcp_tool_cache[token_key] = CacheEntry(
                 value=await get_datahub_mcp_tools(sso_token_getter=sso_token_getter)
             )

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -30,7 +30,6 @@ from redbox.chains.parser import ClaudeParser
 from redbox.chains.runnables import CannedChatLLM, build_llm_chain, chain_use_metadata, create_chain_agent
 from redbox.graph.nodes.sends import run_tools_parallel, run_tools_parallel_extended
 
-# from redbox.graph.nodes.tools import get_datahub_mcp_tools
 from redbox.graph.nodes.cache.tools import get_cached_datahub_mcp_tools
 from redbox.models import ChatRoute
 from redbox.models.chain import (

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -28,8 +28,10 @@ from redbox.chains.activity import log_activity
 from redbox.chains.components import get_chat_llm, get_structured_response_with_citations_parser, get_tokeniser
 from redbox.chains.parser import ClaudeParser
 from redbox.chains.runnables import CannedChatLLM, build_llm_chain, chain_use_metadata, create_chain_agent
-from redbox.graph.nodes.sends import run_tools_parallel
-from redbox.graph.nodes.tools import get_datahub_mcp_tools
+from redbox.graph.nodes.sends import run_tools_parallel, run_tools_parallel_extended
+
+# from redbox.graph.nodes.tools import get_datahub_mcp_tools
+from redbox.graph.nodes.cache.tools import get_cached_datahub_mcp_tools
 from redbox.models import ChatRoute
 from redbox.models.chain import (
     DocumentState,
@@ -611,7 +613,7 @@ def build_datahub_agent_with_loop(
     async def _build_datahub_agent_with_loop(state: RedboxState):
         tools = []
         if sso_token_getter := state.request.sso_token_getter:
-            tools = await get_datahub_mcp_tools(sso_token_getter=sso_token_getter)
+            tools = await get_cached_datahub_mcp_tools(sso_token_getter=sso_token_getter)
 
         if not tools:
             log.error(f"[{agent_name}] No tools available")
@@ -704,11 +706,16 @@ def build_datahub_agent_with_loop(
 
             log.warning(f"{log_stub} Worker agent output:\n{ai_msg}")
 
-            log.warning(f"{log_stub} Running tools via run_tools_parallel...")
-            result = run_tools_parallel(ai_msg, tools, state, is_loop=True)  # this agent runs with loop
+            log.warning(f"{log_stub} Running tools via run_tools_parallel_extended...")
+            tr_result = run_tools_parallel_extended(ai_msg, tools, state, is_loop=True)
+
+            result = [r.response for r in tr_result.results] if tr_result.results else None
 
             if not result:
-                result = "Tool error: no results received."
+                if len(tr_result.failures) > 0:
+                    result = "Tool error: unable to contact Datahub MCP server"
+                else:
+                    result = "Tool error: no results received."
 
             elif has_loop and len(ai_msg.tool_calls) > 0:  # if loop, we need to transform results
                 collated_result = ""

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -28,9 +28,8 @@ from redbox.chains.activity import log_activity
 from redbox.chains.components import get_chat_llm, get_structured_response_with_citations_parser, get_tokeniser
 from redbox.chains.parser import ClaudeParser
 from redbox.chains.runnables import CannedChatLLM, build_llm_chain, chain_use_metadata, create_chain_agent
-from redbox.graph.nodes.sends import run_tools_parallel, run_tools_parallel_extended
-
 from redbox.graph.nodes.cache.tools import get_cached_datahub_mcp_tools
+from redbox.graph.nodes.sends import run_tools_parallel, run_tools_parallel_extended
 from redbox.models import ChatRoute
 from redbox.models.chain import (
     DocumentState,
@@ -45,9 +44,9 @@ from redbox.models.chain import (
 )
 from redbox.models.graph import ROUTE_NAME_TAG, RedboxActivityEvent, RedboxEventType
 from redbox.models.prompts import (
-    USER_FEEDBACK_EVAL_PROMPT,
-    DATAHUB_USER_FEEDBACK,
     DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS,
+    DATAHUB_USER_FEEDBACK,
+    USER_FEEDBACK_EVAL_PROMPT,
 )
 from redbox.models.settings import ChatLLMBackend
 from redbox.transform import combine_documents, flatten_document_state, join_result_with_token_limit
@@ -706,9 +705,15 @@ def build_datahub_agent_with_loop(
             log.warning(f"{log_stub} Worker agent output:\n{ai_msg}")
 
             log.warning(f"{log_stub} Running tools via run_tools_parallel_extended...")
+
             tr_result = run_tools_parallel_extended(ai_msg, tools, state, is_loop=True)
 
-            result = [r.response for r in tr_result.results] if tr_result.results else None
+            if tr_result is None:
+                ai_msg.content
+            elif tr_result.results:
+                result = [r.response for r in tr_result.results]
+            else:
+                result = None
 
             if not result:
                 if len(tr_result.failures) > 0:

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -709,14 +709,14 @@ def build_datahub_agent_with_loop(
             tr_result = run_tools_parallel_extended(ai_msg, tools, state, is_loop=True)
 
             if tr_result is None:
-                ai_msg.content
+                result = ai_msg.content
             elif tr_result.results:
                 result = [r.response for r in tr_result.results]
             else:
                 result = None
 
             if not result:
-                if len(tr_result.failures) > 0:
+                if tr_result is not None and len(tr_result.failures) > 0:
                     result = "Tool error: unable to contact Datahub MCP server"
                 else:
                     result = "Tool error: no results received."

--- a/redbox/redbox/graph/nodes/sends.py
+++ b/redbox/redbox/graph/nodes/sends.py
@@ -4,11 +4,9 @@ from typing import Callable
 from langchain_core.messages import AIMessage
 from langgraph.constants import Send
 
-from redbox.models.chain import DocumentState, RedboxState, TaskStatus
-
-
-from redbox.graph.nodes.runner.runner import ToolRunner
 from redbox.graph.nodes.runner.models import Result
+from redbox.graph.nodes.runner.runner import ToolRunner
+from redbox.models.chain import DocumentState, RedboxState, TaskStatus
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +75,7 @@ def run_tools_parallel_extended(
 
     if not ai_msg.tool_calls:
         log.warning("No tool calls detected. Returning agent content.")
-        return ai_msg.content
+        return None
 
     try:
         max_workers = min(10, len(ai_msg.tool_calls))
@@ -110,6 +108,9 @@ def run_tools_parallel(
     parallel_timeout=60,
     is_loop=False,
 ) -> list[AIMessage] | None:
+    if not ai_msg.tool_calls:
+        log.warning("No tool calls detected. Returning agent content.")
+        return ai_msg.content
 
     result = run_tools_parallel_extended(
         ai_msg=ai_msg,

--- a/redbox/redbox/graph/nodes/sends.py
+++ b/redbox/redbox/graph/nodes/sends.py
@@ -8,6 +8,7 @@ from redbox.models.chain import DocumentState, RedboxState, TaskStatus
 
 
 from redbox.graph.nodes.runner.runner import ToolRunner
+from redbox.graph.nodes.runner.models import Result
 
 log = logging.getLogger(__name__)
 
@@ -66,13 +67,13 @@ def build_tool_send(target: str) -> Callable[[RedboxState], list[Send]]:
     return _tool_send
 
 
-def run_tools_parallel(
+def run_tools_parallel_extended(
     ai_msg,
     tools,
     state,
     parallel_timeout=60,
     is_loop=False,
-) -> list[AIMessage] | None:
+) -> Result | None:
 
     if not ai_msg.tool_calls:
         log.warning("No tool calls detected. Returning agent content.")
@@ -90,9 +91,7 @@ def run_tools_parallel(
 
         try:
             result = runner.run(tool_calls=ai_msg.tool_calls)
-            if result.results:
-                return [r.response for r in result.results]
-            return None
+            return result
         finally:
             runner.executor.shutdown(wait=True)
 
@@ -102,6 +101,28 @@ def run_tools_parallel(
             exc_info=True,
         )
         return None
+
+
+def run_tools_parallel(
+    ai_msg,
+    tools,
+    state,
+    parallel_timeout=60,
+    is_loop=False,
+) -> list[AIMessage] | None:
+
+    result = run_tools_parallel_extended(
+        ai_msg=ai_msg,
+        tools=tools,
+        state=state,
+        parallel_timeout=parallel_timeout,
+        is_loop=is_loop,
+    )
+
+    if result is None:
+        return None
+
+    return [r.response for r in result.results] if result.results else None
 
 
 def no_dependencies(dependencies: list[str], plan) -> bool:

--- a/redbox/tests/graph/nodes/cache/test_tools.py
+++ b/redbox/tests/graph/nodes/cache/test_tools.py
@@ -1,8 +1,7 @@
 import asyncio
 import time
-from typing import Any
+from typing import Any, Awaitable, Callable
 from unittest.mock import AsyncMock, patch
-from typing import Callable, Awaitable
 
 import pytest
 

--- a/redbox/tests/graph/nodes/cache/test_tools.py
+++ b/redbox/tests/graph/nodes/cache/test_tools.py
@@ -1,0 +1,151 @@
+import asyncio
+import time
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from typing import Callable, Awaitable
+
+import pytest
+
+from redbox.graph.nodes.cache.tools import CacheEntry, SensitiveValue, get_cached_datahub_mcp_tools
+
+
+class TestCacheEntry:
+    @pytest.mark.parametrize(
+        "offset,expected",
+        [
+            (-1, True),  # expired 1s ago
+            (0, True),  # exactly at expiry
+            (1, False),  # 1s in the future
+            (300, False),  # full TTL remaining
+        ],
+    )
+    def test_is_expired(self, offset: float, expected: bool):
+        entry = CacheEntry(value="x", expires_at=time.monotonic() + offset)
+        assert entry.is_expired() is expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            [],
+            [{"name": "tool_a"}],
+            [{"name": "tool_a"}, {"name": "tool_b"}],
+        ],
+    )
+    def test_stores_any_value(self, value: Any):
+        entry = CacheEntry(value=value)
+        assert entry.value == value
+
+    def test_default_expires_at_is_five_minutes(self):
+        before = time.monotonic()
+        entry = CacheEntry(value=[])
+        after = time.monotonic()
+        assert before + 299 < entry.expires_at <= after + 301
+
+
+class TestSensitiveValue:
+    @pytest.mark.parametrize("token", ["token_a", "token_b", "token_a"])
+    def test_repr_is_redacted(self, token: str):
+        assert token not in repr(SensitiveValue(token))
+
+    @pytest.mark.parametrize(
+        "token_a,token_b,equal",
+        [
+            ("abc", "abc", True),
+            ("abc", "xyz", False),
+        ],
+    )
+    def test_equality(self, token_a: str, token_b: str, equal: bool):
+        assert (SensitiveValue(token_a) == SensitiveValue(token_b)) is equal
+
+    @pytest.mark.parametrize(
+        "token_a,token_b,same_bucket",
+        [
+            ("abc", "abc", True),
+            ("abc", "xyz", False),
+        ],
+    )
+    def test_hash(self, token_a: str, token_b: str, same_bucket: bool):
+        assert (hash(SensitiveValue(token_a)) == hash(SensitiveValue(token_b))) is same_bucket
+
+    def test_usable_as_dict_key(self):
+        key1 = SensitiveValue("token1")
+        key2 = SensitiveValue("token2")
+        d = {key1: "value1", key2: "value2"}
+        assert d[SensitiveValue("token1")] == "value1"
+        assert d[SensitiveValue("token2")] == "value2"
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Reset module-level cache between tests."""
+    from redbox.graph.nodes.cache.tools import _datahub_mcp_tool_cache
+
+    _datahub_mcp_tool_cache.clear()
+    yield
+    _datahub_mcp_tool_cache.clear()
+
+
+def make_token_getter(token: str) -> Callable[[], Awaitable[str]]:
+    async def _get_token() -> str:
+        return token
+
+    return _get_token
+
+
+@pytest.mark.asyncio
+class TestGetCachedTools:
+    @pytest.mark.parametrize(
+        "tools",
+        [
+            [],
+            [{"name": "tool_a"}],
+            [{"name": "tool_a"}, {"name": "tool_b"}],
+        ],
+    )
+    async def test_returns_tools_on_cold_cache(self, tools: list):
+        getter = make_token_getter("token_x")
+        with patch("redbox.graph.nodes.cache.tools.get_datahub_mcp_tools", AsyncMock(return_value=tools)):
+            result = await get_cached_datahub_mcp_tools(getter)
+        assert result == tools
+
+    async def test_cache_hit_skips_fetch(self):
+        getter = make_token_getter("token_x")
+        mock = AsyncMock(return_value=[{"name": "tool_a"}])
+        with patch("redbox.graph.nodes.cache.tools.get_datahub_mcp_tools", mock):
+            await get_cached_datahub_mcp_tools(getter)
+            await get_cached_datahub_mcp_tools(getter)
+        mock.assert_awaited_once()
+
+    async def test_cache_miss_on_expiry(self):
+        getter = make_token_getter("token_x")
+        mock = AsyncMock(return_value=[{"name": "tool_a"}])
+        with patch("redbox.graph.nodes.cache.tools.get_datahub_mcp_tools", mock):
+            await get_cached_datahub_mcp_tools(getter)
+            # Force expiry
+            from redbox.graph.nodes.cache.tools import _datahub_mcp_tool_cache
+
+            for entry in _datahub_mcp_tool_cache.values():
+                entry.expires_at = time.monotonic() - 1
+            await get_cached_datahub_mcp_tools(getter)
+        assert mock.await_count == 2
+
+    @pytest.mark.parametrize(
+        "token_a,token_b,expected_calls",
+        [
+            ("token_x", "token_x", 1),  # same token -> shared cache
+            ("token_x", "token_y", 2),  # different tokens -> separate fetches
+        ],
+    )
+    async def test_cache_isolation_by_token(self, token_a: str, token_b: str, expected_calls: int):
+        mock = AsyncMock(return_value=[])
+        with patch("redbox.graph.nodes.cache.tools.get_datahub_mcp_tools", mock):
+            await get_cached_datahub_mcp_tools(make_token_getter(token_a))
+            await get_cached_datahub_mcp_tools(make_token_getter(token_b))
+        assert mock.await_count == expected_calls
+
+    async def test_concurrent_requests_fetch_once(self):
+        getter = make_token_getter("token_x")
+        mock = AsyncMock(return_value=[{"name": "tool_a"}])
+        with patch("redbox.graph.nodes.cache.tools.get_datahub_mcp_tools", mock):
+            await asyncio.gather(*[get_cached_datahub_mcp_tools(getter) for _ in range(10)])
+        mock.assert_awaited_once()

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -870,13 +870,24 @@ class TestBuildDatahubAgentLoop:
         mock_llm = mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
         mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
-        mock_tool_calls.return_value = Result(
-            results=[
-                ToolCallResult.Success(tool_name="test_tool", response=msg)
-                for msg in (tool_call_results if isinstance(tool_call_results, list) else [])
-                if isinstance(msg, AIMessage)
-            ]
-        )
+        if tool_call_results is None:
+            mock_tool_calls.return_value = Result()
+        elif isinstance(tool_call_results, list):
+            mock_tool_calls.return_value = Result(
+                results=[
+                    ToolCallResult.Success(
+                        tool_name="test_tool",
+                        response=msg if isinstance(msg, AIMessage) else AIMessage(content=msg.get("text", "")),
+                    )
+                    for msg in tool_call_results
+                ]
+            )
+        else:
+            mock_tool_calls.return_value = Result(
+                results=[
+                    ToolCallResult.Success(tool_name="test_tool", response=AIMessage(content=str(tool_call_results)))
+                ]
+            )
 
         mock_preprocess = None
         if pre_process is not None:

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -661,7 +661,6 @@ class TestBuildAgentLoop:
         mock_llm = mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
         mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
-        mock_tool_calls.return_value = tool_call_results
 
         mock_preprocess = None
         if pre_process is not None:

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -1,6 +1,7 @@
+import copy
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-import copy
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolCall
@@ -8,14 +9,13 @@ from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import RunnableLambda
 from langgraph.graph import END, START, StateGraph
 from pytest_mock import MockerFixture
-from unittest.mock import AsyncMock, patch
 
 from redbox.chains.components import get_structured_response_with_citations_parser
 from redbox.chains.runnables import CannedChatLLM, build_chat_prompt_from_messages_runnable, build_llm_chain
 from redbox.graph.nodes.processes import (
     build_agent_with_loop,
-    build_datahub_agent_with_loop,
     build_chat_pattern,
+    build_datahub_agent_with_loop,
     build_merge_pattern,
     build_passthrough_pattern,
     build_retrieve_pattern,
@@ -26,6 +26,7 @@ from redbox.graph.nodes.processes import (
     clear_documents_process,
     empty_process,
 )
+from redbox.graph.nodes.runner.models import Result, ToolCallResult
 from redbox.models.chain import (
     AISettings,
     Citation,
@@ -37,8 +38,8 @@ from redbox.models.chain import (
     TaskStatus,
     configure_agent_task_plan,
 )
-from redbox.models.prompts import DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS
 from redbox.models.chat import ChatRoute
+from redbox.models.prompts import DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS
 from redbox.test.data import (
     RedboxChatTestCase,
     RedboxTestData,
@@ -659,7 +660,7 @@ class TestBuildAgentLoop:
         llm = GenericFakeChatModel(messages=iter([res]))
         mock_llm = mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
         mock_tool_calls.return_value = tool_call_results
 
         mock_preprocess = None
@@ -739,8 +740,10 @@ class TestBuildAgentLoop:
         llm = GenericFakeChatModel(messages=iter([llm_message]))
         mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
-        mock_tool_calls.return_value = [llm_message]
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
+        mock_tool_calls.return_value = Result(
+            results=[ToolCallResult.Success(tool_name="test_tool", response=llm_message)]
+        )
 
         agent = "Internal_Retrieval_Agent"
         agent_task, multi_agent_plan = configure_agent_task_plan({agent: agent})
@@ -793,7 +796,7 @@ class TestBuildAgentLoop:
 
 @pytest.fixture
 def mock_datahub_tools(mocker: MockerFixture):
-    with patch("redbox.graph.nodes.processes.get_datahub_mcp_tools", new_callable=AsyncMock) as mock:
+    with patch("redbox.graph.nodes.processes.get_cached_datahub_mcp_tools", new_callable=AsyncMock) as mock:
         fake_tool = mocker.Mock()
         fake_tool.name = "fake_tool"
         mock.return_value = [fake_tool]
@@ -1102,8 +1105,10 @@ class TestBuildDatahubAgentLoop:
         llm = GenericFakeChatModel(messages=iter([res] * 10))
         mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
-        mock_tool_calls.return_value = tool_results
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
+        mock_tool_calls.return_value = Result(
+            results=[ToolCallResult.Success(tool_name="test_tool", response=msg) for msg in tool_results]
+        )
 
         agent_name = "Internal_Retrieval_Agent"
         agent_task, multi_agent_plan = configure_agent_task_plan({agent_name: agent_name})

--- a/redbox/tests/graph/test_patterns.py
+++ b/redbox/tests/graph/test_patterns.py
@@ -660,7 +660,8 @@ class TestBuildAgentLoop:
         llm = GenericFakeChatModel(messages=iter([res]))
         mock_llm = mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
+        mock_tool_calls.return_value = tool_call_results
 
         mock_preprocess = None
         if pre_process is not None:
@@ -739,10 +740,8 @@ class TestBuildAgentLoop:
         llm = GenericFakeChatModel(messages=iter([llm_message]))
         mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
-        mock_tool_calls.return_value = Result(
-            results=[ToolCallResult.Success(tool_name="test_tool", response=llm_message)]
-        )
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
+        mock_tool_calls.return_value = [llm_message]
 
         agent = "Internal_Retrieval_Agent"
         agent_task, multi_agent_plan = configure_agent_task_plan({agent: agent})
@@ -870,8 +869,14 @@ class TestBuildDatahubAgentLoop:
         llm = GenericFakeChatModel(messages=iter([res]))
         mock_llm = mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
-        mock_tool_calls.return_value = tool_call_results
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
+        mock_tool_calls.return_value = Result(
+            results=[
+                ToolCallResult.Success(tool_name="test_tool", response=msg)
+                for msg in (tool_call_results if isinstance(tool_call_results, list) else [])
+                if isinstance(msg, AIMessage)
+            ]
+        )
 
         mock_preprocess = None
         if pre_process is not None:
@@ -968,8 +973,10 @@ class TestBuildDatahubAgentLoop:
         llm = GenericFakeChatModel(messages=iter([llm_message]))
         mocker.patch("redbox.chains.runnables.get_chat_llm", return_value=llm)
 
-        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel")
-        mock_tool_calls.return_value = [llm_message]
+        mock_tool_calls = mocker.patch("redbox.graph.nodes.processes.run_tools_parallel_extended")
+        mock_tool_calls.return_value = Result(
+            results=[ToolCallResult.Success(tool_name="test_tool", response=llm_message)]
+        )
 
         agent = "Internal_Retrieval_Agent"
         agent_task, multi_agent_plan = configure_agent_task_plan({agent: agent})


### PR DESCRIPTION
## Context
Sets up MCP tool caching so we don't need to list tools for every request. This tool cache uses wrapped token as the cache key so that tool cache embed any token-based access control on MCP server.

Given adding caching means there is a case where we call the MCP server when it is down, have added `run_tools_parallel_extended` so that the datahub agent is aware of tool errors and returns appropriate error to user.

## What
- Adds token-based datahub MCP tool cache, cache lasts 5 minutes
- Adds `run_tools_parallel_extended` for agents to be slowly migrated to, to leverage better error handling

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

1. Starting with MCP server on, make request to Datahub_Agent
2. Turn off MCP server
3. Run new request to Datahub_Agent
4. Check it returns response saying unable to contact MCP server

You need breakpoints to actually check whether cache is being used or not, or watch logs

## Relevant links
