### PR TITLE
feat: add admin opensearch file management

### DIFF
--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -46,7 +46,7 @@ def backfill_original_file_names(self, request, queryset):
 # Opensearch Files
 
 
-@admin.action(description="OpenSearch: check which chunk resolutions exist")
+@admin.action(description="File Ingestion Health Check")
 def check_chunk_resolutions(_, request, queryset):
     results = []
 

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -95,7 +95,7 @@ def enqueue_reingest(self, request, file: File) -> None:
             file=file,
             resolutions=resolutions,
         )
-        if not result.chunk_resolution_status:
+        if not result.chunk_resolution_ok:
             problematic = [r.name for r in result.resolutions if r.is_low]
             self.message_user(request, f"Reingesting '{file.unique_name}' to resolutions: {', '.join(problematic)}")
 

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -86,13 +86,14 @@ def check_chunk_resolutions(_, request, queryset):
 def enqueue_reingest(self, request, file: File) -> None:
     logger.info("Queueing file for reingestion: %s", file)
 
-    if True:  # file.status == "complete":
+    if file.status == "complete":
+        resolutions = _get_resolutions_for_file(
+            file_uri=file.unique_name,
+            index_name=env.elastic_alias,
+        )
         result = FileChunkResolutionResult.from_complete_file(
-            file,
-            _get_resolutions_for_file(
-                file_uri=file.unique_name,
-                index_name=env.elastic_alias,
-            ),
+            file=file,
+            resolutions=resolutions,
         )
         if not result.healthy:
             problematic = [r.name for r in result.resolutions if r.is_low]

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -78,7 +78,7 @@ def enqueue_reingest(self, request, file: File) -> None:
 
             if not result.chunk_resolution_ok:
                 self.message_user(request, f"Reingesting chunks '{file.unique_name}'...")
-                async_task(ingest, file.unique_name, env.elastic_alias)
+                async_task(ingest, file.id, env.elastic_alias)
                 logger.info("Successfully queued file ingest %s.", file)
 
             if not result.chunk_duplicates_ok:

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -9,7 +9,7 @@ from django_q.tasks import async_task
 from redbox.admin.models import FileChunkResolutionResult
 from redbox.models.settings import get_settings
 from redbox_app.redbox_core.models import File
-from redbox_app.worker import ingest
+from redbox_app.worker import deduplicate_chunks, ingest
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -73,11 +73,18 @@ def enqueue_reingest(self, request, file: File) -> None:
             file=file,
             index_name=env.elastic_alias,
         )
-        if not result.chunk_resolution_ok:
-            self.message_user(request, f"Reingesting '{file.unique_name}'...")
+        if result.file_ingestion_ok and not result.overall_ok:
+            self.message_user(request, f"Starting reingest '{file.unique_name}'...")
 
-            async_task(ingest, file.id, env.elastic_alias)
-            logger.info("Successfully queued file %s.", file)
+            if not result.chunk_resolution_ok:
+                self.message_user(request, f"Reingesting chunks '{file.unique_name}'...")
+                async_task(ingest, file.unique_name, env.elastic_alias)
+                logger.info("Successfully queued file ingest %s.", file)
+
+            if not result.chunk_duplicates_ok:
+                self.message_user(request, f"Deduplicating chunks '{file.unique_name}'...")
+                async_task(deduplicate_chunks, file.unique_name, env.elastic_alias)
+                logger.info("Successfully queued chunk deduplication %s.", file)
 
         else:
             logger.info("Failed to queue file %s - already healthy.", file)

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -6,7 +6,6 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django_q.tasks import async_task
 
-from redbox.admin.ingest import _get_duplicate_chunks, _get_resolutions_for_file
 from redbox.admin.models import FileChunkResolutionResult
 from redbox.models.settings import get_settings
 from redbox_app.redbox_core.models import File
@@ -54,12 +53,7 @@ def check_chunk_resolutions(_, request, queryset):
     for file in queryset:
         try:
             if file.status == "complete":
-                resolutions = _get_resolutions_for_file(
-                    file_uri=file.unique_name,
-                    index_name=env.elastic_alias,
-                )
-                duplicates = _get_duplicate_chunks(file_uri=file.unique_name, index_name=env.elastic_alias)
-                result = FileChunkResolutionResult.from_complete_file(file, resolutions, duplicates)
+                result = FileChunkResolutionResult.from_complete_file(file, env.elastic_alias)
             else:
                 result = FileChunkResolutionResult.from_incomplete_file(file)
         except Exception as exc:  # noqa: BLE001
@@ -71,36 +65,16 @@ def check_chunk_resolutions(_, request, queryset):
     return HttpResponseRedirect(reverse("admin:files_chunk_resolution_report"))
 
 
-# def opensearch_ingest(file: File):
-#     if file.status == "complete":
-#         resolutions = _get_resolutions_for_file(
-#             file_uri=file.unique_name,
-#             index_name=env.elastic_alias,
-#         )
-#         result = FileChunkResolutionResult.from_complete_file(file, resolutions)
-#         if not result.healthy:
-#             problematic = [r.name for r in resolutions if r.is_low]
-#             return problematic
-#     return []
-
-
 def enqueue_reingest(self, request, file: File) -> None:
     logger.info("Queueing file for reingestion: %s", file)
 
     if file.status == "complete":
-        resolutions = _get_resolutions_for_file(
-            file_uri=file.unique_name,
-            index_name=env.elastic_alias,
-        )
-        duplicates = _get_duplicate_chunks(file_uri=file.unique_name, index_name=env.elastic_alias)
         result = FileChunkResolutionResult.from_complete_file(
             file=file,
-            resolutions=resolutions,
-            duplicates=duplicates,
+            index_name=env.elastic_alias,
         )
         if not result.chunk_resolution_ok:
-            problematic = [r.name for r in result.resolutions if r.is_low]
-            self.message_user(request, f"Reingesting '{file.unique_name}' to resolutions: {', '.join(problematic)}")
+            self.message_user(request, f"Reingesting '{file.unique_name}'...")
 
             async_task(ingest, file.id, env.elastic_alias)
             logger.info("Successfully queued file %s.", file)

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -6,6 +6,8 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django_q.tasks import async_task
 
+from redbox.admin.ingest import _get_resolutions_for_file
+from redbox.admin.models import FileChunkResolutionResult
 from redbox.models.settings import get_settings
 from redbox_app.redbox_core.models import File
 from redbox_app.worker import ingest
@@ -45,44 +47,6 @@ def backfill_original_file_names(self, request, queryset):
 # Opensearch Files
 
 
-def _es_client():
-    return env.elasticsearch_client()
-
-
-def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
-    """Return chunk_resolution -> count for *file_uri* across the main alias index."""
-    es = _es_client()
-    resp = es.search(
-        index=index_name,
-        body={
-            "size": 0,
-            "query": {"term": {"metadata.uri.keyword": file_uri}},
-            "aggs": {"resolutions": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
-        },
-    )
-    return {bucket["key"]: bucket["doc_count"] for bucket in resp["aggregations"]["resolutions"]["buckets"]}
-
-
-def _file_has_largest_chunks(file_uri: str, index_name: str) -> bool:
-    """Return True if any 'largest' chunks already exist for *file_id*."""
-    es = _es_client()
-    resp = es.search(
-        index=index_name,
-        body={
-            "size": 1,
-            "query": {
-                "bool": {
-                    "must": [
-                        {"term": {"metadata.uri": file_uri}},
-                        {"term": {"metadata.chunk_resolution": "largest"}},
-                    ]
-                }
-            },
-        },
-    )
-    return resp["hits"]["total"]["value"] > 0
-
-
 @admin.action(description="OpenSearch: check which chunk resolutions exist")
 def check_chunk_resolutions(_, request, queryset):
     results = []
@@ -94,70 +58,57 @@ def check_chunk_resolutions(_, request, queryset):
                     file_uri=file.unique_name,
                     index_name=env.elastic_alias,
                 )
-
-                counts = list(resolutions.values())
-                healthy = len(counts) > 0 and len(set(counts)) == 1
-                max_count = max(counts) if counts else 0
-
-                formatted_resolutions = [
-                    {
-                        "name": resolution,
-                        "count": count,
-                        "is_low": count < max_count,
-                        "missing": max_count - count,
-                    }
-                    for resolution, count in sorted(resolutions.items())
-                ]
-
-                results.append(
-                    {
-                        "created_at_ts": int(file.created_at.timestamp()),
-                        "created_at": file.created_at.strftime("%d %b %Y %H:%M"),
-                        "file_id": str(file.pk),
-                        "file_name": file.file_name,
-                        "user": file.user.email,
-                        "status": file.status,
-                        "healthy": healthy,
-                        "overall_ok": healthy and file.status == "complete",
-                        "stored_name": file.unique_name,
-                        "resolutions": formatted_resolutions,
-                        "error": None,
-                    }
-                )
+                result = FileChunkResolutionResult.from_complete_file(file, resolutions)
             else:
-                results.append(
-                    {
-                        "created_at_ts": int(file.created_at.timestamp()),
-                        "created_at": file.created_at.strftime("%d %b %Y %H:%M"),
-                        "file_id": str(file.pk),
-                        "file_name": file.file_name,
-                        "user": file.user.email,
-                        "status": file.status,
-                        "healthy": False,
-                        "overall_ok": False,
-                        "stored_name": None,
-                        "resolutions": None,
-                        "error": None,
-                    }
-                )
-
+                result = FileChunkResolutionResult.from_incomplete_file(file)
         except Exception as exc:  # noqa: BLE001
-            results.append(
-                {
-                    "created_at_ts": int(file.created_at.timestamp()),
-                    "created_at": file.created_at.strftime("%d %b %Y %H:%M"),
-                    "file_id": str(file.pk),
-                    "file_name": file.file_name,
-                    "user": file.user.email,
-                    "status": file.status,
-                    "healthy": False,
-                    "overall_ok": False,
-                    "stored_name": file.unique_name,
-                    "resolutions": None,
-                    "error": str(exc),
-                }
-            )
+            result = FileChunkResolutionResult.from_error(file, exc)
+
+        results.append(result.to_dict())
 
     request.session["chunk_resolution_results"] = results
-
     return HttpResponseRedirect(reverse("admin:files_chunk_resolution_report"))
+
+
+# def opensearch_ingest(file: File):
+#     if file.status == "complete":
+#         resolutions = _get_resolutions_for_file(
+#             file_uri=file.unique_name,
+#             index_name=env.elastic_alias,
+#         )
+#         result = FileChunkResolutionResult.from_complete_file(file, resolutions)
+#         if not result.healthy:
+#             problematic = [r.name for r in resolutions if r.is_low]
+#             return problematic
+#     return []
+
+
+def enqueue_reingest(self, request, file: File) -> None:
+    logger.info("Queueing file for reingestion: %s", file)
+
+    if True:  # file.status == "complete":
+        result = FileChunkResolutionResult.from_complete_file(
+            file,
+            _get_resolutions_for_file(
+                file_uri=file.unique_name,
+                index_name=env.elastic_alias,
+            ),
+        )
+        if not result.healthy:
+            problematic = [r.name for r in result.resolutions if r.is_low]
+            self.message_user(request, f"Reingesting '{file.unique_name}' to resolutions: {', '.join(problematic)}")
+
+            async_task(ingest, file.id, env.elastic_alias)
+            logger.info("Successfully queued file %s.", file)
+
+        else:
+            logger.info("Failed to queue file %s - already healthy.", file)
+
+    else:
+        logger.info("Failed to queue file %s - invalid status.", file)
+
+
+@admin.action(description="Re-ingest selected files")
+def reingest(self, request, queryset):
+    for file in queryset:
+        enqueue_reingest(self=self, request=request, file=file)

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -2,13 +2,18 @@ import logging
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django_q.tasks import async_task
 
+from redbox.models.settings import get_settings
 from redbox_app.redbox_core.models import File
 from redbox_app.worker import ingest
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
+
+env = get_settings()
 
 
 def reupload(_self, _request, queryset):
@@ -35,3 +40,83 @@ def backfill_original_file_names(self, request, queryset):
         request,
         f"Updated {updated} files.",
     )
+
+
+# Opensearch Files
+
+
+def _es_client():
+    return env.elasticsearch_client()
+
+
+def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
+    """Return chunk_resolution -> count for *file_uri* across the main alias index."""
+    es = _es_client()
+    resp = es.search(
+        index=index_name,
+        body={
+            "size": 0,
+            "query": {"term": {"metadata.uri.keyword": file_uri}},
+            "aggs": {"resolutions": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
+        },
+    )
+    return {bucket["key"]: bucket["doc_count"] for bucket in resp["aggregations"]["resolutions"]["buckets"]}
+
+
+def _file_has_largest_chunks(file_uri: str, index_name: str) -> bool:
+    """Return True if any 'largest' chunks already exist for *file_id*."""
+    es = _es_client()
+    resp = es.search(
+        index=index_name,
+        body={
+            "size": 1,
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"metadata.uri": file_uri}},
+                        {"term": {"metadata.chunk_resolution": "largest"}},
+                    ]
+                }
+            },
+        },
+    )
+    return resp["hits"]["total"]["value"] > 0
+
+
+@admin.action(description="OpenSearch: check which chunk resolutions exist")
+def check_chunk_resolutions(_, request, queryset):
+    results = []
+
+    for file in queryset:
+        try:
+            resolutions = _get_resolutions_for_file(
+                file_uri=file.unique_name,
+                index_name=env.elastic_alias,
+            )
+
+            results.append(
+                {
+                    "file_id": str(file.pk),
+                    "file_name": file.file_name,
+                    "user": file.user.email,
+                    "stored_name": file.unique_name,
+                    "resolutions": resolutions,
+                    "error": None,
+                }
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            results.append(
+                {
+                    "file_id": str(file.pk),
+                    "file_name": file.file_name,
+                    "user": file.user.email,
+                    "stored_name": file.unique_name,
+                    "resolutions": None,
+                    "error": str(exc),
+                }
+            )
+
+    request.session["chunk_resolution_results"] = results
+
+    return HttpResponseRedirect(reverse("admin:files_chunk_resolution_report"))

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django_q.tasks import async_task
 
-from redbox.admin.ingest import _get_resolutions_for_file
+from redbox.admin.ingest import _get_duplicate_chunks, _get_resolutions_for_file
 from redbox.admin.models import FileChunkResolutionResult
 from redbox.models.settings import get_settings
 from redbox_app.redbox_core.models import File
@@ -58,7 +58,8 @@ def check_chunk_resolutions(_, request, queryset):
                     file_uri=file.unique_name,
                     index_name=env.elastic_alias,
                 )
-                result = FileChunkResolutionResult.from_complete_file(file, resolutions)
+                duplicates = _get_duplicate_chunks(file_uri=file.unique_name, index_name=env.elastic_alias)
+                result = FileChunkResolutionResult.from_complete_file(file, resolutions, duplicates)
             else:
                 result = FileChunkResolutionResult.from_incomplete_file(file)
         except Exception as exc:  # noqa: BLE001
@@ -91,9 +92,11 @@ def enqueue_reingest(self, request, file: File) -> None:
             file_uri=file.unique_name,
             index_name=env.elastic_alias,
         )
+        duplicates = _get_duplicate_chunks(file_uri=file.unique_name, index_name=env.elastic_alias)
         result = FileChunkResolutionResult.from_complete_file(
             file=file,
             resolutions=resolutions,
+            duplicates=duplicates,
         )
         if not result.chunk_resolution_ok:
             problematic = [r.name for r in result.resolutions if r.is_low]

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -97,6 +97,17 @@ def check_chunk_resolutions(_, request, queryset):
 
                 counts = list(resolutions.values())
                 healthy = len(counts) > 0 and len(set(counts)) == 1
+                max_count = max(counts) if counts else 0
+
+                formatted_resolutions = [
+                    {
+                        "name": resolution,
+                        "count": count,
+                        "is_low": count < max_count,
+                        "missing": max_count - count,
+                    }
+                    for resolution, count in sorted(resolutions.items())
+                ]
 
                 results.append(
                     {
@@ -105,9 +116,11 @@ def check_chunk_resolutions(_, request, queryset):
                         "file_id": str(file.pk),
                         "file_name": file.file_name,
                         "user": file.user.email,
+                        "status": file.status,
                         "healthy": healthy,
+                        "overall_ok": healthy and file.status == "complete",
                         "stored_name": file.unique_name,
-                        "resolutions": resolutions,
+                        "resolutions": formatted_resolutions,
                         "error": None,
                     }
                 )
@@ -119,10 +132,12 @@ def check_chunk_resolutions(_, request, queryset):
                         "file_id": str(file.pk),
                         "file_name": file.file_name,
                         "user": file.user.email,
+                        "status": file.status,
                         "healthy": False,
+                        "overall_ok": False,
                         "stored_name": None,
                         "resolutions": None,
-                        "error": f'Unable to evaluate has an invalid file status "{file.status}"',
+                        "error": None,
                     }
                 )
 
@@ -134,7 +149,9 @@ def check_chunk_resolutions(_, request, queryset):
                     "file_id": str(file.pk),
                     "file_name": file.file_name,
                     "user": file.user.email,
+                    "status": file.status,
                     "healthy": False,
+                    "overall_ok": False,
                     "stored_name": file.unique_name,
                     "resolutions": None,
                     "error": str(exc),

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -89,28 +89,52 @@ def check_chunk_resolutions(_, request, queryset):
 
     for file in queryset:
         try:
-            resolutions = _get_resolutions_for_file(
-                file_uri=file.unique_name,
-                index_name=env.elastic_alias,
-            )
+            if file.status == "complete":
+                resolutions = _get_resolutions_for_file(
+                    file_uri=file.unique_name,
+                    index_name=env.elastic_alias,
+                )
 
-            results.append(
-                {
-                    "file_id": str(file.pk),
-                    "file_name": file.file_name,
-                    "user": file.user.email,
-                    "stored_name": file.unique_name,
-                    "resolutions": resolutions,
-                    "error": None,
-                }
-            )
+                counts = list(resolutions.values())
+                healthy = len(counts) > 0 and len(set(counts)) == 1
+
+                results.append(
+                    {
+                        "created_at_ts": int(file.created_at.timestamp()),
+                        "created_at": file.created_at.strftime("%d %b %Y %H:%M"),
+                        "file_id": str(file.pk),
+                        "file_name": file.file_name,
+                        "user": file.user.email,
+                        "healthy": healthy,
+                        "stored_name": file.unique_name,
+                        "resolutions": resolutions,
+                        "error": None,
+                    }
+                )
+            else:
+                results.append(
+                    {
+                        "created_at_ts": int(file.created_at.timestamp()),
+                        "created_at": file.created_at.strftime("%d %b %Y %H:%M"),
+                        "file_id": str(file.pk),
+                        "file_name": file.file_name,
+                        "user": file.user.email,
+                        "healthy": False,
+                        "stored_name": None,
+                        "resolutions": None,
+                        "error": f'Unable to evaluate has an invalid file status "{file.status}"',
+                    }
+                )
 
         except Exception as exc:  # noqa: BLE001
             results.append(
                 {
+                    "created_at_ts": int(file.created_at.timestamp()),
+                    "created_at": file.created_at.strftime("%d %b %Y %H:%M"),
                     "file_id": str(file.pk),
                     "file_name": file.file_name,
                     "user": file.user.email,
+                    "healthy": False,
                     "stored_name": file.unique_name,
                     "resolutions": None,
                     "error": str(exc),

--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -95,7 +95,7 @@ def enqueue_reingest(self, request, file: File) -> None:
             file=file,
             resolutions=resolutions,
         )
-        if not result.healthy:
+        if not result.chunk_resolution_status:
             problematic = [r.name for r in result.resolutions if r.is_low]
             self.message_user(request, f"Reingesting '{file.unique_name}' to resolutions: {', '.join(problematic)}")
 

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -306,7 +306,7 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
             request,
             "admin/files/chunk_resolution_report.html",
             {
-                "title": "Chunk Resolution Report",
+                "title": "File Ingestion Health Check",
                 "results": results,
             },
             using="django",

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -7,9 +7,11 @@ from django.contrib.auth import get_user_model
 from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.template.response import TemplateResponse
+from django.urls import path
 from import_export.admin import ExportMixin, ImportExportMixin
 
-from redbox_app.redbox_core.actions import backfill_original_file_names, reupload
+from redbox_app.redbox_core.actions import backfill_original_file_names, check_chunk_resolutions, reupload
 
 from . import models
 from .serializers import UserSerializer
@@ -270,8 +272,34 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
     list_display = ["file_name", "user", "status", "created_at", "last_referenced"]
     list_filter = ["user", "status"]
     date_hierarchy = "created_at"
-    actions = [reupload, backfill_original_file_names]
+    actions = [reupload, backfill_original_file_names, check_chunk_resolutions]
     search_fields = ["user__email", "original_file_name"]
+
+    def get_urls(self):
+        urls = super().get_urls()
+
+        custom_urls = [
+            path(
+                "chunk-resolution-report/",
+                self.admin_site.admin_view(self.chunk_resolution_report_view),
+                name="files_chunk_resolution_report",
+            ),
+        ]
+
+        return custom_urls + urls
+
+    def chunk_resolution_report_view(self, request):
+        results = request.session.pop("chunk_resolution_results", [])
+
+        return TemplateResponse(
+            request,
+            "admin/files/chunk_resolution_report.html",
+            {
+                "title": "Chunk Resolution Report",
+                "results": results,
+            },
+            using="django",
+        )
 
 
 class FileToolAdmin(ExportMixin, admin.ModelAdmin):

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -323,11 +323,15 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
         for file in files:
             enqueue_reingest(self, request, file)
 
-        self.message_user(
-            request,
-            f"Queued {files.count()} file(s) for reingestion.",
-        )
+        results = request.session.get("chunk_resolution_results", [])
+        queued_ids = {str(f.pk) for f in files}
+        for result in results:
+            if result["file_id"] in queued_ids:
+                result["reingestion_queued"] = True
+        request.session["chunk_resolution_results"] = results
+        request.session.modified = True
 
+        self.message_user(request, f"Queued {files.count()} file(s) for reingestion.")
         return HttpResponseRedirect(reverse("admin:files_chunk_resolution_report"))
 
 

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -5,13 +5,19 @@ import logging
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.db.models import QuerySet
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import render
 from django.template.response import TemplateResponse
-from django.urls import path
+from django.urls import path, reverse
 from import_export.admin import ExportMixin, ImportExportMixin
 
-from redbox_app.redbox_core.actions import backfill_original_file_names, check_chunk_resolutions, reupload
+from redbox_app.redbox_core.actions import (
+    backfill_original_file_names,
+    check_chunk_resolutions,
+    # reingest,
+    enqueue_reingest,
+    reupload,
+)
 
 from . import models
 from .serializers import UserSerializer
@@ -284,12 +290,17 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
                 self.admin_site.admin_view(self.chunk_resolution_report_view),
                 name="files_chunk_resolution_report",
             ),
+            path(
+                "reingest-selected/",
+                self.admin_site.admin_view(self.reingest_selected_view),
+                name="files_reingest_selected",
+            ),
         ]
 
         return custom_urls + urls
 
     def chunk_resolution_report_view(self, request):
-        results = request.session.pop("chunk_resolution_results", [])
+        results = request.session.get("chunk_resolution_results", [])
 
         return TemplateResponse(
             request,
@@ -300,6 +311,24 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
             },
             using="django",
         )
+
+    def reingest_selected_view(self, request):
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
+
+        file_ids = request.POST.getlist("file_ids")
+
+        files = models.File.objects.filter(pk__in=file_ids)
+
+        for file in files:
+            enqueue_reingest(self, request, file)
+
+        self.message_user(
+            request,
+            f"Queued {files.count()} file(s) for reingestion.",
+        )
+
+        return HttpResponseRedirect(reverse("admin:files_chunk_resolution_report"))
 
 
 class FileToolAdmin(ExportMixin, admin.ModelAdmin):

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -318,25 +318,28 @@ function sortTable(columnIndex, header) {
         sortAscending ? "↑" : "↓";
 }
 
-sortTable(9, this)
-
 // Default sort by Created descending (newest first)
 window.addEventListener("load", () => {
     const createdHeader =
         document.querySelectorAll("th.sortable")[0];
 
-    sortTable(0, createdHeader);
-    sortTable(0, createdHeader);
-});
+    sortTable(1, createdHeader);
+    sortTable(1, createdHeader);
 
-const selectAll = document.getElementById("select-all");
+    const selectAll = document.getElementById("select-all");
 
-selectAll.addEventListener("change", () => {
-    document
-        .querySelectorAll('input[name="file_ids"]')
-        .forEach(cb => {
-            cb.checked = selectAll.checked;
-        });
+    if (!selectAll) {
+        console.error("select-all checkbox not found");
+        return;
+    }
+
+    selectAll.addEventListener("change", () => {
+        document
+            .querySelectorAll('input[name="file_ids"]')
+            .forEach(cb => {
+                cb.checked = selectAll.checked;
+            });
+    });
 });
 </script>
 

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -117,11 +117,11 @@ th.sortable {
         <tbody>
         {% for result in results %}
             {% if not result.file_ingestion_ok %}
-            <tr style="background-color: #ffeded;">
+            <tr style="background-color: #fff7f7;">
             {% elif result.overall_ok %}
-            <tr style="background-color: rgb(235, 255, 235);">
+            <tr style="background-color: rgb(248, 255, 248);">
             {% else %}
-            <tr>
+            <tr style="background-color: rgb(255, 239, 206);">
             {% endif %}
                 <td>
                     {% if not result.overall_ok and result.file_ingestion_ok %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -167,7 +167,7 @@ th.sortable {
                     {% if result.resolutions %}
                         <div class="resolution-list">
                             {% for resolution in result.resolutions %}
-                                <span class="resolution-badge {% if resolution.is_low %}resolution-badge-low{% endif %}">
+                                <span class="resolution-badge {% if not result.chunk_resolution_ok %}resolution-badge-low{% endif %}">
                                     <span class="resolution-name">
                                         {{ resolution.name }}
                                     </span>
@@ -175,12 +175,6 @@ th.sortable {
                                     <span>
                                         {{ resolution.count }}
                                     </span>
-
-                                    {% if resolution.is_low %}
-                                        <span class="resolution-missing">
-                                            (-{{ resolution.missing }})
-                                        </span>
-                                    {% endif %}
                                 </span>
                             {% endfor %}
                         </div>

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -1,0 +1,64 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+
+<table>
+    <thead>
+        <tr>
+            <th>File ID</th>
+            <th>File Name</th>
+            <th>User</th>
+            <th>Stored Name</th>
+            <th>Resolutions</th>
+            <th>Error</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for result in results %}
+        <tr>
+            <td>
+                <code>{{ result.file_id }}</code>
+            </td>
+
+            <td>
+                {{ result.file_name }}
+            </td>
+
+            <td>
+                {{ result.user }}
+            </td>
+
+            <td>
+                {{ result.stored_name }}
+            </td>
+
+            <td>
+                {% if result.resolutions %}
+                    <ul>
+                    {% for resolution, count in result.resolutions.items %}
+                        <li>{{ resolution }}: {{ count }}</li>
+                    {% endfor %}
+                    </ul>
+                {% elif not result.error %}
+                    No chunks found
+                {% endif %}
+            </td>
+
+            <td>
+                {% if result.error %}
+                    <span style="color:red">
+                        {{ result.error }}
+                    </span>
+                {% else %}
+                    —
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<p>
+    <a href="javascript:history.back()">← Back</a>
+</p>
+{% endblock %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -198,12 +198,12 @@ th.sortable {
                         —
                     {% elif result.duplicates %}
                         <div>
-                            {% for resolution, summary in result.duplicates.items %}
+                            {% for duplicate in result.duplicates %}
                                 <div style="color:red" {% if summary.avg_duplicates_per_page > 2 %}duplicate-high{% else %}duplicate-low{% endif %}">
-                                    <code>{{ resolution }}</code>
-                                    <span title="avg duplicates per page">~{{ summary.avg_duplicates_per_page }} duplicates</span>
-                                    <span title="affected pages">across {{ summary.affected_pages }} pages</span>
-                                    <span title="total duplicate chunks">({{ summary.total_duplicate_chunks }})</span>
+                                    <code>{{ duplicate.name }}</code>
+                                    <span title="avg duplicates per page">~{{ duplicate.avg_duplicates_per_page }} duplicates</span>
+                                    <span title="affected pages">across {{ duplicate.affected_pages }} pages</span>
+                                    <span title="total duplicate chunks">({{ duplicate.total_duplicate_chunks }})</span>
                                 </div>
                             {% endfor %}
                         </div>

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -2,22 +2,100 @@
 
 {% block content %}
 
+<style>
+th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.sort-indicator {
+    display: inline-block;
+    width: 1em;
+    margin-left: 0.25rem;
+    color: #666;
+}
+
+.file-cell {
+    line-height: 1.4;
+}
+
+.file-user {
+    font-weight: bold;
+}
+
+.file-stored-name {
+    color: #666;
+    font-size: 0.9em;
+    font-family: monospace;
+}
+.resolution-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.resolution-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 999px;
+    border: 1px solid #d0d7de;
+    background: #f6f8fa;
+    color: #24292f;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+
+.resolution-badge-low {
+    background: #fff1f2;
+    border-color: #d1242f;
+    color: #8a1c23;
+    font-weight: 600;
+}
+
+.resolution-name {
+    font-weight: 600;
+}
+
+.resolution-missing {
+    opacity: 0.8;
+}
+</style>
+
 <table>
     <thead>
         <tr>
-            <th style="cursor:pointer" onclick="sortTable(0)">
-                Created ↕
+            <th class="sortable" onclick="sortTable(0, this)">
+                Created <span class="sort-indicator"></span>
             </th>
-            <th>User</th>
-            <th>File Name</th>
-            <th>Stored Name</th>
-            <th>Resolutions</th>
-            <th style="cursor:pointer" onclick="sortTable(5)">
-                Health ↕
+
+            <th>
+                File
             </th>
-            <th>Error</th>
+
+            <th>
+                Chunk Resolutions
+            </th>
+
+            <th class="sortable" onclick="sortTable(4, this)">
+                Ingestion <span class="sort-indicator"></span>
+            </th>
+
+            <th class="sortable" onclick="sortTable(5, this)">
+                Chunks <span class="sort-indicator"></span>
+            </th>
+
+            <th>
+                Error
+            </th>
+
+            <th class="sortable" onclick="sortTable(6, this)">
+                Overall <span class="sort-indicator"></span>
+            </th>
         </tr>
     </thead>
+
     <tbody>
     {% for result in results %}
         <tr>
@@ -25,35 +103,65 @@
                 {{ result.created_at }}
             </td>
 
-            <td>
-                {{ result.user }}
+            <td class="file-cell">
+                <div class="file-user">
+                    {{ result.user }}
+                </div>
+
+                <div>
+                    <a href="/admin/redbox_core/file/{{ result.file_id }}/change/">
+                        {{ result.file_name }}
+                    </a>
+                </div>
+
+                <div class="file-stored-name">
+                    {% if result.stored_name %}
+                        {{ result.stored_name }}
+                    {% else %}
+                        —
+                    {% endif %}
+                </div>
             </td>
 
             <td>
-                <a href="/admin/redbox_core/file/{{ result.file_id }}/change/">
-                    {{ result.file_name }}
-                </a>
-            </td>
+                {% if result.resolutions %}
+                    <div class="resolution-list">
+                        {% for resolution in result.resolutions %}
+                            <span class="resolution-badge {% if resolution.is_low %}resolution-badge-low{% endif %}">
+                                <span class="resolution-name">
+                                    {{ resolution.name }}
+                                </span>
 
-            <td>
-                {% if result.stored_name %}
-                    {{ result.stored_name }}
+                                <span>
+                                    {{ resolution.count }}
+                                </span>
+
+                                {% if resolution.is_low %}
+                                    <span class="resolution-missing">
+                                        (-{{ resolution.missing }})
+                                    </span>
+                                {% endif %}
+                            </span>
+                        {% endfor %}
+                    </div>
+                {% elif not result.error %}
+                    <span style="color:#666">
+                        No chunks found
+                    </span>
                 {% else %}
                     —
                 {% endif %}
             </td>
 
-            <td>
-                {% if result.resolutions %}
-                    <ul>
-                    {% for resolution, count in result.resolutions.items %}
-                        <li>{{ resolution }}: {{ count }}</li>
-                    {% endfor %}
-                    </ul>
-                {% elif not result.error %}
-                    No chunks found
+            <td data-sort="{% if result.status == 'complete' %}1{% else %}0{% endif %}">
+                {% if result.status == "complete" %}
+                    <span style="color: green; font-weight: bold;">
+                        {{ result.status }}
+                    </span>
                 {% else %}
-                    -
+                    <span style="color: red; font-weight: bold;">
+                        {{ result.status }}
+                    </span>
                 {% endif %}
             </td>
 
@@ -74,6 +182,14 @@
                     —
                 {% endif %}
             </td>
+
+            <td data-sort="{% if result.overall_ok %}1{% else %}0{% endif %}">
+                {% if result.overall_ok %}
+                    <span style="color: green; font-weight: bold;">✓</span>
+                {% else %}
+                    <span style="color: red; font-weight: bold;">✗</span>
+                {% endif %}
+            </td>
         </tr>
     {% endfor %}
     </tbody>
@@ -84,15 +200,20 @@
 </p>
 
 <script>
-let sortDirection = {};
+let currentSortColumn = null;
+let sortAscending = true;
 
-function sortTable(columnIndex) {
+function sortTable(columnIndex, header) {
     const table = document.querySelector("table");
     const tbody = table.querySelector("tbody");
-
     const rows = Array.from(tbody.querySelectorAll("tr"));
 
-    sortDirection[columnIndex] = !sortDirection[columnIndex];
+    if (currentSortColumn === columnIndex) {
+        sortAscending = !sortAscending;
+    } else {
+        currentSortColumn = columnIndex;
+        sortAscending = true;
+    }
 
     rows.sort((a, b) => {
         const aCell = a.children[columnIndex];
@@ -112,11 +233,27 @@ function sortTable(columnIndex) {
             result = aVal.localeCompare(bVal);
         }
 
-        return sortDirection[columnIndex] ? result : -result;
+        return sortAscending ? result : -result;
     });
 
     rows.forEach(row => tbody.appendChild(row));
+
+    document.querySelectorAll(".sort-indicator").forEach(el => {
+        el.textContent = "";
+    });
+
+    header.querySelector(".sort-indicator").textContent =
+        sortAscending ? "↑" : "↓";
 }
+
+// Default sort by Created descending (newest first)
+window.addEventListener("load", () => {
+    const createdHeader =
+        document.querySelectorAll("th.sortable")[0];
+
+    sortTable(0, createdHeader);
+    sortTable(0, createdHeader);
+});
 </script>
 
 {% endblock %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -318,6 +318,8 @@ function sortTable(columnIndex, header) {
         sortAscending ? "↑" : "↓";
 }
 
+sortTable(9, this)
+
 // Default sort by Created descending (newest first)
 window.addEventListener("load", () => {
     const createdHeader =

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -90,6 +90,10 @@ th.sortable {
                 </th>
 
                 <th>
+                    Chunk Duplicates
+                </th>
+
+                <th>
                     Error
                 </th>
 
@@ -187,6 +191,21 @@ th.sortable {
                         —
                     {% endif %}
                 </td>
+
+                <td>
+                    {% if result.duplicates %}
+                        <div class="resolution-list">
+                            {{ result.duplicates }}
+                        </div>
+                    {% elif not result.error %}
+                        <span style="color:#666">
+                            No chunks found
+                        </span>
+                    {% else %}
+                        —
+                    {% endif %}
+                </td>
+
 
                 <td>
                     {% if result.error %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -126,7 +126,7 @@ th.sortable {
             <tr style="background-color: rgb(255, 239, 206);">
             {% endif %}
                 <td>
-                    {% if not result.overall_ok and result.file_ingestion_ok %}
+                    {% if not result.overall_ok and result.file_ingestion_ok and not result.reingestion_queued %}
                         <input
                             type="checkbox"
                             name="file_ids"
@@ -249,12 +249,10 @@ th.sortable {
                 </td>
 
                 <td data-sort="{% if not result.overall_ok and result.file_ingestion_ok %}0{% elif not result.file_ingestion_ok %}-1{% else %}1{% endif %}">
-                    {% if not result.overall_ok and result.file_ingestion_ok %}
-                        <button
-                            type="submit"
-                            name="file_ids"
-                            value="{{ result.file_id }}"
-                        >
+                    {% if result.reingestion_queued %}
+                        <span style="color: #7a5800">⏳ Queued</span>
+                    {% elif not result.overall_ok and result.file_ingestion_ok %}
+                        <button type="submit" name="file_ids" value="{{ result.file_id }}">
                             Reingest
                         </button>
                     {% elif not result.file_ingestion_ok %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -74,16 +74,16 @@ th.sortable {
                 File
             </th>
 
-            <th>
-                Chunk Resolutions
-            </th>
-
             <th class="sortable" onclick="sortTable(4, this)">
                 Ingestion <span class="sort-indicator"></span>
             </th>
 
+            <th>
+                Chunk Resolutions
+            </th>
+
             <th class="sortable" onclick="sortTable(5, this)">
-                Chunks <span class="sort-indicator"></span>
+                Chunk Status <span class="sort-indicator"></span>
             </th>
 
             <th>
@@ -123,6 +123,18 @@ th.sortable {
                 </div>
             </td>
 
+            <td data-sort="{% if result.status == 'complete' %}1{% else %}0{% endif %}">
+                {% if result.status == "complete" %}
+                    <span style="color: green; font-weight: bold;">
+                        {{ result.status }}
+                    </span>
+                {% else %}
+                    <span style="color: red; font-weight: bold;">
+                        {{ result.status }}
+                    </span>
+                {% endif %}
+            </td>
+
             <td>
                 {% if result.resolutions %}
                     <div class="resolution-list">
@@ -150,18 +162,6 @@ th.sortable {
                     </span>
                 {% else %}
                     —
-                {% endif %}
-            </td>
-
-            <td data-sort="{% if result.status == 'complete' %}1{% else %}0{% endif %}">
-                {% if result.status == "complete" %}
-                    <span style="color: green; font-weight: bold;">
-                        {{ result.status }}
-                    </span>
-                {% else %}
-                    <span style="color: red; font-weight: bold;">
-                        {{ result.status }}
-                    </span>
                 {% endif %}
             </td>
 

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -85,24 +85,24 @@ th.sortable {
                     File
                 </th>
 
-                <th class="sortable" onclick="sortTable(3, this)">
-                    Ingestion <span class="sort-indicator"></span>
-                </th>
-
                 <th>
                     Chunk Resolutions
-                </th>
-
-                <th class="sortable" onclick="sortTable(5, this)">
-                    Chunk Status <span class="sort-indicator"></span>
                 </th>
 
                 <th>
                     Error
                 </th>
 
+                <th class="sortable" onclick="sortTable(5, this)">
+                    File OK <span class="sort-indicator"></span>
+                </th>
+
+                <th class="sortable" onclick="sortTable(6, this)">
+                    Chunk OK <span class="sort-indicator"></span>
+                </th>
+
                 <th class="sortable" onclick="sortTable(7, this)">
-                    Overall <span class="sort-indicator"></span>
+                    Overall OK<span class="sort-indicator"></span>
                 </th>
 
                 <th>Actions</th>
@@ -113,7 +113,7 @@ th.sortable {
         {% for result in results %}
             <tr>
                 <td>
-                    {% if not result.overall_ok %}
+                    {% if not result.overall_ok and result.file_ingestion_ok %}
                         <input
                             type="checkbox"
                             name="file_ids"
@@ -144,18 +144,18 @@ th.sortable {
                             —
                         {% endif %}
                     </div>
-                </td>
 
-                <td data-sort="{% if result.status == 'complete' %}1{% else %}0{% endif %}">
-                    {% if result.status == "complete" %}
-                        <span style="color: green; font-weight: bold;">
-                            {{ result.status }}
-                        </span>
-                    {% else %}
-                        <span style="color: red; font-weight: bold;">
-                            {{ result.status }}
-                        </span>
-                    {% endif %}
+                    <div>
+                        {% if result.file_ingestion_status == "complete" %}
+                            <span style="color: green; font-weight: bold;">
+                                {{ result.file_ingestion_status }}
+                            </span>
+                        {% else %}
+                            <span style="color: red; font-weight: bold;">
+                                {{ result.file_ingestion_status }}
+                            </span>
+                        {% endif %}
+                    </div>
                 </td>
 
                 <td>
@@ -188,14 +188,6 @@ th.sortable {
                     {% endif %}
                 </td>
 
-                <td data-sort="{% if result.healthy %}1{% else %}0{% endif %}">
-                    {% if result.healthy %}
-                        <span style="color: green; font-weight: bold;">✓</span>
-                    {% else %}
-                        <span style="color: red; font-weight: bold;">✗</span>
-                    {% endif %}
-                </td>
-
                 <td>
                     {% if result.error %}
                         <span style="color:red">
@@ -203,6 +195,22 @@ th.sortable {
                         </span>
                     {% else %}
                         —
+                    {% endif %}
+                </td>
+
+                <td data-sort="{% if result.file_ingestion_ok %}1{% else %}0{% endif %}">
+                    {% if result.file_ingestion_ok %}
+                        <span style="color: green; font-weight: bold;">✓</span>
+                    {% else %}
+                        <span style="color: red; font-weight: bold;">✗</span>
+                    {% endif %}
+                </td>
+
+                <td data-sort="{% if result.chunk_resolution_ok %}1{% else %}0{% endif %}">
+                    {% if result.chunk_resolution_ok %}
+                        <span style="color: green; font-weight: bold;">✓</span>
+                    {% else %}
+                        <span style="color: red; font-weight: bold;">✗</span>
                     {% endif %}
                 </td>
 
@@ -215,7 +223,7 @@ th.sortable {
                 </td>
 
                 <td>
-                    {% if not result.overall_ok %}
+                    {% if not result.overall_ok and result.file_ingestion_ok %}
                         <button
                             type="submit"
                             name="file_ids"
@@ -223,6 +231,8 @@ th.sortable {
                         >
                             Reingest
                         </button>
+                    {% elif not result.file_ingestion_ok %}
+                        ✗
                     {% else %}
                         ✓
                     {% endif %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -116,7 +116,13 @@ th.sortable {
 
         <tbody>
         {% for result in results %}
+            {% if not result.file_ingestion_ok %}
+            <tr style="background-color: #ffeded;">
+            {% elif result.overall_ok %}
+            <tr style="background-color: rgb(235, 255, 235);">
+            {% else %}
             <tr>
+            {% endif %}
                 <td>
                     {% if not result.overall_ok and result.file_ingestion_ok %}
                         <input

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -61,6 +61,7 @@ th.sortable {
 .resolution-missing {
     opacity: 0.8;
 }
+
 </style>
 
 <form method="post" action="{% url 'admin:files_reingest_selected' %}">
@@ -193,19 +194,23 @@ th.sortable {
                 </td>
 
                 <td>
-                    {% if result.duplicates %}
-                        <div class="resolution-list">
-                            {{ result.duplicates }}
-                        </div>
-                    {% elif not result.error %}
-                        <span style="color:#666">
-                            No chunks found
-                        </span>
-                    {% else %}
+                    {% if result.error %}
                         —
+                    {% elif result.duplicates %}
+                        <div>
+                            {% for resolution, summary in result.duplicates.items %}
+                                <div style="color:red" {% if summary.avg_duplicates_per_page > 2 %}duplicate-high{% else %}duplicate-low{% endif %}">
+                                    <code>{{ resolution }}</code>
+                                    <span title="avg duplicates per page">~{{ summary.avg_duplicates_per_page }} duplicates</span>
+                                    <span title="affected pages">across {{ summary.affected_pages }} pages</span>
+                                    <span title="total duplicate chunks">({{ summary.total_duplicate_chunks }})</span>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <span class="no-data">No duplicates</span>
                     {% endif %}
                 </td>
-
 
                 <td>
                     {% if result.error %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -5,23 +5,24 @@
 <table>
     <thead>
         <tr>
-            <th>File ID</th>
-            <th>File Name</th>
+            <th style="cursor:pointer" onclick="sortTable(0)">
+                Created ↕
+            </th>
             <th>User</th>
+            <th>File Name</th>
             <th>Stored Name</th>
             <th>Resolutions</th>
+            <th style="cursor:pointer" onclick="sortTable(5)">
+                Health ↕
+            </th>
             <th>Error</th>
         </tr>
     </thead>
     <tbody>
     {% for result in results %}
         <tr>
-            <td>
-                <code>{{ result.file_id }}</code>
-            </td>
-
-            <td>
-                {{ result.file_name }}
+            <td data-sort="{{ result.created_at_ts }}">
+                {{ result.created_at }}
             </td>
 
             <td>
@@ -29,7 +30,17 @@
             </td>
 
             <td>
-                {{ result.stored_name }}
+                <a href="/admin/redbox_core/file/{{ result.file_id }}/change/">
+                    {{ result.file_name }}
+                </a>
+            </td>
+
+            <td>
+                {% if result.stored_name %}
+                    {{ result.stored_name }}
+                {% else %}
+                    —
+                {% endif %}
             </td>
 
             <td>
@@ -41,6 +52,16 @@
                     </ul>
                 {% elif not result.error %}
                     No chunks found
+                {% else %}
+                    -
+                {% endif %}
+            </td>
+
+            <td data-sort="{% if result.healthy %}1{% else %}0{% endif %}">
+                {% if result.healthy %}
+                    <span style="color: green; font-weight: bold;">✓</span>
+                {% else %}
+                    <span style="color: red; font-weight: bold;">✗</span>
                 {% endif %}
             </td>
 
@@ -61,4 +82,41 @@
 <p>
     <a href="javascript:history.back()">← Back</a>
 </p>
+
+<script>
+let sortDirection = {};
+
+function sortTable(columnIndex) {
+    const table = document.querySelector("table");
+    const tbody = table.querySelector("tbody");
+
+    const rows = Array.from(tbody.querySelectorAll("tr"));
+
+    sortDirection[columnIndex] = !sortDirection[columnIndex];
+
+    rows.sort((a, b) => {
+        const aCell = a.children[columnIndex];
+        const bCell = b.children[columnIndex];
+
+        const aVal = aCell.dataset.sort ?? aCell.innerText.trim();
+        const bVal = bCell.dataset.sort ?? bCell.innerText.trim();
+
+        const aNum = Number(aVal);
+        const bNum = Number(bVal);
+
+        let result;
+
+        if (!isNaN(aNum) && !isNaN(bNum)) {
+            result = aNum - bNum;
+        } else {
+            result = aVal.localeCompare(bVal);
+        }
+
+        return sortDirection[columnIndex] ? result : -result;
+    });
+
+    rows.forEach(row => tbody.appendChild(row));
+}
+</script>
+
 {% endblock %}

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -63,137 +63,175 @@ th.sortable {
 }
 </style>
 
-<table>
-    <thead>
-        <tr>
-            <th class="sortable" onclick="sortTable(0, this)">
-                Created <span class="sort-indicator"></span>
-            </th>
+<form method="post" action="{% url 'admin:files_reingest_selected' %}">
+    {% csrf_token %}
 
-            <th>
-                File
-            </th>
+    <button type="submit">
+        Reingest selected files
+    </button>
 
-            <th class="sortable" onclick="sortTable(4, this)">
-                Ingestion <span class="sort-indicator"></span>
-            </th>
+    <table>
+        <thead>
+            <tr>
+                <th>
+                    <input type="checkbox" id="select-all">
+                </th>
 
-            <th>
-                Chunk Resolutions
-            </th>
+                <th class="sortable" onclick="sortTable(1, this)">
+                    Created <span class="sort-indicator"></span>
+                </th>
 
-            <th class="sortable" onclick="sortTable(5, this)">
-                Chunk Status <span class="sort-indicator"></span>
-            </th>
+                <th>
+                    File
+                </th>
 
-            <th>
-                Error
-            </th>
+                <th class="sortable" onclick="sortTable(3, this)">
+                    Ingestion <span class="sort-indicator"></span>
+                </th>
 
-            <th class="sortable" onclick="sortTable(6, this)">
-                Overall <span class="sort-indicator"></span>
-            </th>
-        </tr>
-    </thead>
+                <th>
+                    Chunk Resolutions
+                </th>
 
-    <tbody>
-    {% for result in results %}
-        <tr>
-            <td data-sort="{{ result.created_at_ts }}">
-                {{ result.created_at }}
-            </td>
+                <th class="sortable" onclick="sortTable(5, this)">
+                    Chunk Status <span class="sort-indicator"></span>
+                </th>
 
-            <td class="file-cell">
-                <div class="file-user">
-                    {{ result.user }}
-                </div>
+                <th>
+                    Error
+                </th>
 
-                <div>
-                    <a href="/admin/redbox_core/file/{{ result.file_id }}/change/">
-                        {{ result.file_name }}
-                    </a>
-                </div>
+                <th class="sortable" onclick="sortTable(7, this)">
+                    Overall <span class="sort-indicator"></span>
+                </th>
 
-                <div class="file-stored-name">
-                    {% if result.stored_name %}
-                        {{ result.stored_name }}
+                <th>Actions</th>
+            </tr>
+        </thead>
+
+        <tbody>
+        {% for result in results %}
+            <tr>
+                <td>
+                    {% if not result.overall_ok %}
+                        <input
+                            type="checkbox"
+                            name="file_ids"
+                            value="{{ result.file_id }}"
+                        >
+                    {% endif %}
+                </td>
+
+                <td data-sort="{{ result.created_at_ts }}">
+                    {{ result.created_at }}
+                </td>
+
+                <td class="file-cell">
+                    <div class="file-user">
+                        {{ result.user }}
+                    </div>
+
+                    <div>
+                        <a href="/admin/redbox_core/file/{{ result.file_id }}/change/">
+                            {{ result.file_name }}
+                        </a>
+                    </div>
+
+                    <div class="file-stored-name">
+                        {% if result.stored_name %}
+                            {{ result.stored_name }}
+                        {% else %}
+                            —
+                        {% endif %}
+                    </div>
+                </td>
+
+                <td data-sort="{% if result.status == 'complete' %}1{% else %}0{% endif %}">
+                    {% if result.status == "complete" %}
+                        <span style="color: green; font-weight: bold;">
+                            {{ result.status }}
+                        </span>
+                    {% else %}
+                        <span style="color: red; font-weight: bold;">
+                            {{ result.status }}
+                        </span>
+                    {% endif %}
+                </td>
+
+                <td>
+                    {% if result.resolutions %}
+                        <div class="resolution-list">
+                            {% for resolution in result.resolutions %}
+                                <span class="resolution-badge {% if resolution.is_low %}resolution-badge-low{% endif %}">
+                                    <span class="resolution-name">
+                                        {{ resolution.name }}
+                                    </span>
+
+                                    <span>
+                                        {{ resolution.count }}
+                                    </span>
+
+                                    {% if resolution.is_low %}
+                                        <span class="resolution-missing">
+                                            (-{{ resolution.missing }})
+                                        </span>
+                                    {% endif %}
+                                </span>
+                            {% endfor %}
+                        </div>
+                    {% elif not result.error %}
+                        <span style="color:#666">
+                            No chunks found
+                        </span>
                     {% else %}
                         —
                     {% endif %}
-                </div>
-            </td>
+                </td>
 
-            <td data-sort="{% if result.status == 'complete' %}1{% else %}0{% endif %}">
-                {% if result.status == "complete" %}
-                    <span style="color: green; font-weight: bold;">
-                        {{ result.status }}
-                    </span>
-                {% else %}
-                    <span style="color: red; font-weight: bold;">
-                        {{ result.status }}
-                    </span>
-                {% endif %}
-            </td>
+                <td data-sort="{% if result.healthy %}1{% else %}0{% endif %}">
+                    {% if result.healthy %}
+                        <span style="color: green; font-weight: bold;">✓</span>
+                    {% else %}
+                        <span style="color: red; font-weight: bold;">✗</span>
+                    {% endif %}
+                </td>
 
-            <td>
-                {% if result.resolutions %}
-                    <div class="resolution-list">
-                        {% for resolution in result.resolutions %}
-                            <span class="resolution-badge {% if resolution.is_low %}resolution-badge-low{% endif %}">
-                                <span class="resolution-name">
-                                    {{ resolution.name }}
-                                </span>
+                <td>
+                    {% if result.error %}
+                        <span style="color:red">
+                            {{ result.error }}
+                        </span>
+                    {% else %}
+                        —
+                    {% endif %}
+                </td>
 
-                                <span>
-                                    {{ resolution.count }}
-                                </span>
+                <td data-sort="{% if result.overall_ok %}1{% else %}0{% endif %}">
+                    {% if result.overall_ok %}
+                        <span style="color: green; font-weight: bold;">✓</span>
+                    {% else %}
+                        <span style="color: red; font-weight: bold;">✗</span>
+                    {% endif %}
+                </td>
 
-                                {% if resolution.is_low %}
-                                    <span class="resolution-missing">
-                                        (-{{ resolution.missing }})
-                                    </span>
-                                {% endif %}
-                            </span>
-                        {% endfor %}
-                    </div>
-                {% elif not result.error %}
-                    <span style="color:#666">
-                        No chunks found
-                    </span>
-                {% else %}
-                    —
-                {% endif %}
-            </td>
-
-            <td data-sort="{% if result.healthy %}1{% else %}0{% endif %}">
-                {% if result.healthy %}
-                    <span style="color: green; font-weight: bold;">✓</span>
-                {% else %}
-                    <span style="color: red; font-weight: bold;">✗</span>
-                {% endif %}
-            </td>
-
-            <td>
-                {% if result.error %}
-                    <span style="color:red">
-                        {{ result.error }}
-                    </span>
-                {% else %}
-                    —
-                {% endif %}
-            </td>
-
-            <td data-sort="{% if result.overall_ok %}1{% else %}0{% endif %}">
-                {% if result.overall_ok %}
-                    <span style="color: green; font-weight: bold;">✓</span>
-                {% else %}
-                    <span style="color: red; font-weight: bold;">✗</span>
-                {% endif %}
-            </td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
+                <td>
+                    {% if not result.overall_ok %}
+                        <button
+                            type="submit"
+                            name="file_ids"
+                            value="{{ result.file_id }}"
+                        >
+                            Reingest
+                        </button>
+                    {% else %}
+                        ✓
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</form>
 
 <p>
     <a href="javascript:history.back()">← Back</a>
@@ -253,6 +291,16 @@ window.addEventListener("load", () => {
 
     sortTable(0, createdHeader);
     sortTable(0, createdHeader);
+});
+
+const selectAll = document.getElementById("select-all");
+
+selectAll.addEventListener("change", () => {
+    document
+        .querySelectorAll('input[name="file_ids"]')
+        .forEach(cb => {
+            cb.checked = selectAll.checked;
+        });
 });
 </script>
 

--- a/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
+++ b/django_app/redbox_app/templates/admin/files/chunk_resolution_report.html
@@ -98,19 +98,21 @@ th.sortable {
                     Error
                 </th>
 
-                <th class="sortable" onclick="sortTable(5, this)">
+                <th class="sortable" onclick="sortTable(6, this)">
                     File OK <span class="sort-indicator"></span>
                 </th>
 
-                <th class="sortable" onclick="sortTable(6, this)">
-                    Chunk OK <span class="sort-indicator"></span>
-                </th>
-
                 <th class="sortable" onclick="sortTable(7, this)">
-                    Overall OK<span class="sort-indicator"></span>
+                    Chunk Resolution OK <span class="sort-indicator"></span>
                 </th>
 
-                <th>Actions</th>
+                <th class="sortable" onclick="sortTable(8, this)">
+                    Chunk Duplicates OK <span class="sort-indicator"></span>
+                </th>
+
+                <th class="sortable" onclick="sortTable(9, this)">
+                    Actions <span class="sort-indicator"></span>
+                </th>
             </tr>
         </thead>
 
@@ -238,15 +240,15 @@ th.sortable {
                     {% endif %}
                 </td>
 
-                <td data-sort="{% if result.overall_ok %}1{% else %}0{% endif %}">
-                    {% if result.overall_ok %}
+                <td data-sort="{% if result.chunk_duplicates_ok %}1{% else %}0{% endif %}">
+                    {% if result.chunk_duplicates_ok %}
                         <span style="color: green; font-weight: bold;">✓</span>
                     {% else %}
                         <span style="color: red; font-weight: bold;">✗</span>
                     {% endif %}
                 </td>
 
-                <td>
+                <td data-sort="{% if not result.overall_ok and result.file_ingestion_ok %}0{% elif not result.file_ingestion_ok %}-1{% else %}1{% endif %}">
                     {% if not result.overall_ok and result.file_ingestion_ok %}
                         <button
                             type="submit"

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from django.core.files.uploadedfile import InMemoryUploadedFile, UploadedFile
 
-from redbox.loader.ingester import ingest_file
+from redbox.loader.ingester import ingest_file, remove_duplicate_chunks
 from redbox.models.settings import get_settings
 from redbox_app.redbox_core.models import InactiveFileError
 
@@ -189,3 +189,9 @@ def ingest(file_id: UUID, es_index: str | None = None) -> None:
         file.status = File.Status.complete
 
     file.save()
+
+
+def deduplicate_chunks(file_uri: str, index_name: str) -> None:
+    logger.info("Removing duplicate chunks for file %s", file_uri)
+    remove_duplicate_chunks(file_uri, index_name)
+    logger.info("Deduplication complete for file %s", file_uri)

--- a/redbox/redbox/admin/ingest.py
+++ b/redbox/redbox/admin/ingest.py
@@ -52,6 +52,17 @@ def _get_resolutions_for_file(file_uri: str, index_name: str) -> list[ChunkResol
     return resolutions.values()
 
 
+def _chunk_dedupe_key(hit: dict) -> tuple:
+    meta = hit["_source"]["metadata"]
+
+    return (
+        meta["uri"],
+        meta["chunk_resolution"],
+        meta["page_number"],
+        hit["_source"]["text"],
+    )
+
+
 def _get_duplicate_chunks(
     file_uri: str,
     index_name: str,
@@ -80,6 +91,7 @@ def _get_duplicate_chunks(
             },
             "_source": [
                 "text",
+                "metadata.uri",
                 "metadata.chunk_resolution",
                 "metadata.page_number",
             ],
@@ -92,24 +104,19 @@ def _get_duplicate_chunks(
     resolution_duplicate_counts: dict[str, int] = defaultdict(int)
 
     for hit in resp["hits"]["hits"]:
-        source = hit["_source"]
-        metadata = source["metadata"]
+        key = _chunk_dedupe_key(hit)
 
-        resolution = metadata["chunk_resolution"]
-        page_number = metadata["page_number"]
-        text = (source.get("text") or "").strip()
-
-        key = (
-            resolution,
-            page_number,
-            text,
-        )
-
-        if key in seen:
-            resolution_duplicate_counts[resolution] += 1
-            resolution_pages[resolution].add(page_number)
-        else:
+        if key not in seen:
             seen.add(key)
+            continue
+
+        meta = hit["_source"]["metadata"]
+
+        resolution = meta["chunk_resolution"]
+        page_number = meta["page_number"]
+
+        resolution_duplicate_counts[resolution] += 1
+        resolution_pages[resolution].add(page_number)
 
     return [
         ChunkDuplicateDetail(

--- a/redbox/redbox/admin/ingest.py
+++ b/redbox/redbox/admin/ingest.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from collections import defaultdict
 
 from redbox.models.settings import get_settings
@@ -6,11 +7,25 @@ from redbox.models.file import ChunkResolution
 env = get_settings()
 
 
+@dataclass
+class ChunkResolutionDetail:
+    name: str
+    count: int
+
+
+@dataclass
+class ChunkDuplicateDetail:
+    name: str
+    avg_duplicates_per_page: float
+    affected_pages: int
+    total_duplicate_chunks: int
+
+
 def _es_client():
     return env.elasticsearch_client()
 
 
-def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
+def _get_resolutions_for_file(file_uri: str, index_name: str) -> list[ChunkResolutionDetail]:
     """Return chunk_resolution -> count for *file_uri* across the main alias index."""
     es = _es_client()
     resp = es.search(
@@ -21,7 +36,10 @@ def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
             "aggs": {"resolutions": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
         },
     )
-    resolutions = {bucket["key"]: bucket["doc_count"] for bucket in resp["aggregations"]["resolutions"]["buckets"]}
+    resolutions = {
+        bucket["key"]: ChunkResolutionDetail(name=bucket["key"], count=bucket["doc_count"])
+        for bucket in resp["aggregations"]["resolutions"]["buckets"]
+    }
 
     is_tabular = file_uri.endswith((".csv", ".tsv", ".xls", ".xlsx"))
     expected_resolutions = (
@@ -29,18 +47,14 @@ def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
     )
     for res in expected_resolutions:
         if res not in resolutions.keys():
-            resolutions[res] = 0
+            resolutions[res] = ChunkResolutionDetail(name=res, count=0)
 
-    return resolutions
+    return resolutions.values()
 
 
-def _get_duplicate_chunks(file_uri: str, index_name: str) -> dict[str, dict]:
+def _get_duplicate_chunks(file_uri: str, index_name: str) -> list[ChunkDuplicateDetail]:
     """
-    Returns per-resolution duplicate summary:
-    {
-        "large": {"avg_duplicates_per_page": 2.5, "affected_pages": 4, "total_duplicate_chunks": 10},
-        ...
-    }
+    Returns per-resolution duplicate summary
     """
     es = _es_client()
     # resolution -> list of per-page doc_counts
@@ -89,10 +103,11 @@ def _get_duplicate_chunks(file_uri: str, index_name: str) -> dict[str, dict]:
             break
 
     return {
-        resolution: {
-            "avg_duplicates_per_page": round(sum(counts) / len(counts), 2),
-            "affected_pages": len(counts),
-            "total_duplicate_chunks": sum(counts),
-        }
+        resolution: ChunkDuplicateDetail(
+            name=resolution,
+            avg_duplicates_per_page=round(sum(counts) / len(counts), 2),
+            affected_pages=len(counts),
+            total_duplicate_chunks=sum(counts),
+        )
         for resolution, counts in resolution_page_counts.items()
-    }
+    }.values()

--- a/redbox/redbox/admin/ingest.py
+++ b/redbox/redbox/admin/ingest.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from redbox.models.settings import get_settings
 from redbox.models.file import ChunkResolution
 
@@ -30,3 +32,67 @@ def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
             resolutions[res] = 0
 
     return resolutions
+
+
+def _get_duplicate_chunks(file_uri: str, index_name: str) -> dict[str, dict]:
+    """
+    Returns per-resolution duplicate summary:
+    {
+        "large": {"avg_duplicates_per_page": 2.5, "affected_pages": 4, "total_duplicate_chunks": 10},
+        ...
+    }
+    """
+    es = _es_client()
+    # resolution -> list of per-page doc_counts
+    resolution_page_counts: dict[str, list[int]] = defaultdict(list)
+    after = None
+
+    while True:
+        composite = {
+            "sources": [
+                {"uri": {"terms": {"field": "metadata.uri.keyword"}}},
+                {"resolution": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
+                {"page_number": {"terms": {"field": "metadata.page_number"}}},
+            ],
+            "size": 1000,
+        }
+        if after:
+            composite["after"] = after
+
+        resp = es.search(
+            index=index_name,
+            body={
+                "size": 0,
+                "query": {"term": {"metadata.uri.keyword": file_uri}},
+                "aggs": {
+                    "duplicate_groups": {
+                        "composite": composite,
+                        "aggs": {
+                            "is_duplicate": {
+                                "bucket_selector": {
+                                    "buckets_path": {"count": "_count"},
+                                    "script": "params.count > 1",
+                                }
+                            }
+                        },
+                    }
+                },
+            },
+        )
+
+        buckets = resp["aggregations"]["duplicate_groups"]["buckets"]
+        for b in buckets:
+            resolution_page_counts[b["key"]["resolution"]].append(b["doc_count"])
+
+        after = resp["aggregations"]["duplicate_groups"].get("after_key")
+        if not after:
+            break
+
+    return {
+        resolution: {
+            "avg_duplicates_per_page": round(sum(counts) / len(counts), 2),
+            "affected_pages": len(counts),
+            "total_duplicate_chunks": sum(counts),
+        }
+        for resolution, counts in resolution_page_counts.items()
+    }

--- a/redbox/redbox/admin/ingest.py
+++ b/redbox/redbox/admin/ingest.py
@@ -52,62 +52,76 @@ def _get_resolutions_for_file(file_uri: str, index_name: str) -> list[ChunkResol
     return resolutions.values()
 
 
-def _get_duplicate_chunks(file_uri: str, index_name: str) -> list[ChunkDuplicateDetail]:
+def _get_duplicate_chunks(
+    file_uri: str,
+    index_name: str,
+) -> list[ChunkDuplicateDetail]:
     """
-    Returns per-resolution duplicate summary
+    Returns per-resolution duplicate summary.
+
+    A duplicate is defined as chunks having the same:
+        (chunk_resolution, page_number, text)
+
+    Metrics:
+        affected_pages         = unique pages containing duplicates
+        total_duplicate_chunks = extra duplicate chunks beyond the first
+        avg_duplicates_per_page = total_duplicate_chunks / affected_pages
     """
     es = _es_client()
-    # resolution -> list of per-page doc_counts
-    resolution_page_counts: dict[str, list[int]] = defaultdict(list)
-    after = None
 
-    while True:
-        composite = {
-            "sources": [
-                {"uri": {"terms": {"field": "metadata.uri.keyword"}}},
-                {"resolution": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
-                {"page_number": {"terms": {"field": "metadata.page_number"}}},
-            ],
-            "size": 1000,
-        }
-        if after:
-            composite["after"] = after
-
-        resp = es.search(
-            index=index_name,
-            body={
-                "size": 0,
-                "query": {"term": {"metadata.uri.keyword": file_uri}},
-                "aggs": {
-                    "duplicate_groups": {
-                        "composite": composite,
-                        "aggs": {
-                            "is_duplicate": {
-                                "bucket_selector": {
-                                    "buckets_path": {"count": "_count"},
-                                    "script": "params.count > 1",
-                                }
-                            }
-                        },
-                    }
-                },
+    resp = es.search(
+        index=index_name,
+        body={
+            "size": 10000,
+            "query": {
+                "term": {
+                    "metadata.uri.keyword": file_uri,
+                }
             },
+            "_source": [
+                "text",
+                "metadata.chunk_resolution",
+                "metadata.page_number",
+            ],
+        },
+    )
+
+    seen: set[tuple[str, int, str]] = set()
+
+    resolution_pages: dict[str, set[int]] = defaultdict(set)
+    resolution_duplicate_counts: dict[str, int] = defaultdict(int)
+
+    for hit in resp["hits"]["hits"]:
+        source = hit["_source"]
+        metadata = source["metadata"]
+
+        resolution = metadata["chunk_resolution"]
+        page_number = metadata["page_number"]
+        text = (source.get("text") or "").strip()
+
+        key = (
+            resolution,
+            page_number,
+            text,
         )
 
-        buckets = resp["aggregations"]["duplicate_groups"]["buckets"]
-        for b in buckets:
-            resolution_page_counts[b["key"]["resolution"]].append(b["doc_count"])
+        if key in seen:
+            resolution_duplicate_counts[resolution] += 1
+            resolution_pages[resolution].add(page_number)
+        else:
+            seen.add(key)
 
-        after = resp["aggregations"]["duplicate_groups"].get("after_key")
-        if not after:
-            break
-
-    return {
-        resolution: ChunkDuplicateDetail(
+    return [
+        ChunkDuplicateDetail(
             name=resolution,
-            avg_duplicates_per_page=round(sum(counts) / len(counts), 2),
-            affected_pages=len(counts),
-            total_duplicate_chunks=sum(counts),
+            affected_pages=len(resolution_pages[resolution]),
+            total_duplicate_chunks=resolution_duplicate_counts[resolution],
+            avg_duplicates_per_page=round(
+                resolution_duplicate_counts[resolution] / len(resolution_pages[resolution]),
+                2,
+            )
+            if resolution_pages[resolution]
+            else 0,
         )
-        for resolution, counts in resolution_page_counts.items()
-    }.values()
+        for resolution in sorted(resolution_duplicate_counts)
+    ]

--- a/redbox/redbox/admin/ingest.py
+++ b/redbox/redbox/admin/ingest.py
@@ -1,0 +1,21 @@
+from redbox.models.settings import get_settings
+
+env = get_settings()
+
+
+def _es_client():
+    return env.elasticsearch_client()
+
+
+def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
+    """Return chunk_resolution -> count for *file_uri* across the main alias index."""
+    es = _es_client()
+    resp = es.search(
+        index=index_name,
+        body={
+            "size": 0,
+            "query": {"term": {"metadata.uri.keyword": file_uri}},
+            "aggs": {"resolutions": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
+        },
+    )
+    return {bucket["key"]: bucket["doc_count"] for bucket in resp["aggregations"]["resolutions"]["buckets"]}

--- a/redbox/redbox/admin/ingest.py
+++ b/redbox/redbox/admin/ingest.py
@@ -1,4 +1,5 @@
 from redbox.models.settings import get_settings
+from redbox.models.file import ChunkResolution
 
 env = get_settings()
 
@@ -18,4 +19,14 @@ def _get_resolutions_for_file(file_uri: str, index_name: str) -> dict[str, int]:
             "aggs": {"resolutions": {"terms": {"field": "metadata.chunk_resolution.keyword"}}},
         },
     )
-    return {bucket["key"]: bucket["doc_count"] for bucket in resp["aggregations"]["resolutions"]["buckets"]}
+    resolutions = {bucket["key"]: bucket["doc_count"] for bucket in resp["aggregations"]["resolutions"]["buckets"]}
+
+    is_tabular = file_uri.endswith((".csv", ".tsv", ".xls", ".xlsx"))
+    expected_resolutions = (
+        [ChunkResolution.tabular] if is_tabular else [ChunkResolution.largest, ChunkResolution.normal]
+    )
+    for res in expected_resolutions:
+        if res not in resolutions.keys():
+            resolutions[res] = 0
+
+    return resolutions

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -16,9 +16,12 @@ class FileChunkResolutionResult:
     file_id: str
     file_name: str
     user: str
-    status: str
-    healthy: bool
+
+    file_ingestion_status: str
+    file_ingestion_ok: bool
+    chunk_resolution_ok: bool
     overall_ok: bool
+
     stored_name: str | None = None
     resolutions: list[ChunkResolutionDetail] | None = None
     error: str | None = None
@@ -26,7 +29,8 @@ class FileChunkResolutionResult:
     @classmethod
     def from_complete_file(cls, file, resolutions: dict[str, int]) -> "FileChunkResolutionResult":
         counts = list(resolutions.values())
-        healthy = len(counts) > 0 and len(set(counts)) == 1
+        chunk_resolution_ok = len(counts) > 0 and len(set(counts)) == 1
+        file_ingestion_ok = file.status == "complete"
         max_count = max(counts) if counts else 0
 
         return cls(
@@ -35,9 +39,10 @@ class FileChunkResolutionResult:
             file_id=str(file.pk),
             file_name=file.file_name,
             user=file.user.email,
-            status=file.status,
-            healthy=healthy,
-            overall_ok=healthy and file.status == "complete",
+            file_ingestion_status=file.status,
+            file_ingestion_ok=file_ingestion_ok,
+            chunk_resolution_ok=chunk_resolution_ok,
+            overall_ok=chunk_resolution_ok and file_ingestion_ok,
             stored_name=file.unique_name,
             resolutions=[
                 ChunkResolutionDetail(
@@ -58,8 +63,9 @@ class FileChunkResolutionResult:
             file_id=str(file.pk),
             file_name=file.file_name,
             user=file.user.email,
-            status=file.status,
-            healthy=False,
+            file_ingestion_status=file.status,
+            file_ingestion_ok=False,
+            chunk_resolution_ok=False,
             overall_ok=False,
         )
 
@@ -71,8 +77,9 @@ class FileChunkResolutionResult:
             file_id=str(file.pk),
             file_name=file.file_name,
             user=file.user.email,
-            status=file.status,
-            healthy=False,
+            file_ingestion_status=file.status,
+            file_ingestion_ok=False,
+            chunk_resolution_ok=False,
             overall_ok=False,
             stored_name=file.unique_name,
             error=str(exc),

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -7,20 +7,6 @@ from redbox.admin.ingest import (
 )
 
 
-# @dataclass
-# class ChunkResolutionDetail:
-#     name: str
-#     count: int
-
-
-# @dataclass
-# class ChunkDuplicateDetail:
-#     name: str
-#     avg_duplicates_per_page: float
-#     affected_pages: int
-#     total_duplicate_chunks: int
-
-
 @dataclass
 class FileChunkResolutionResult:
     created_at_ts: int
@@ -30,9 +16,10 @@ class FileChunkResolutionResult:
     user: str
 
     file_ingestion_status: str
-    file_ingestion_ok: bool
-    chunk_resolution_ok: bool
-    overall_ok: bool
+    file_ingestion_ok: bool = False
+    chunk_resolution_ok: bool = False
+    chunk_duplicates_ok: bool = False
+    overall_ok: bool = False
 
     stored_name: str | None = None
     resolutions: list[ChunkResolutionDetail] | None = None
@@ -53,9 +40,12 @@ class FileChunkResolutionResult:
         counts = [r.count for r in resolutions]
 
         chunk_resolution_ok = len(counts) > 0 and len(set(counts)) == 1
-        # chunk_duplicate_ok =
+        chunk_duplicate_ok = len(duplicates) == 0
+        chunk_ok = chunk_resolution_ok and chunk_duplicate_ok
+
         file_ingestion_ok = file.status == "complete"
-        overall_ok = chunk_resolution_ok and file_ingestion_ok
+
+        overall_ok = chunk_ok and file_ingestion_ok
 
         return cls(
             created_at_ts=int(file.created_at.timestamp()),
@@ -66,6 +56,7 @@ class FileChunkResolutionResult:
             file_ingestion_status=file.status,
             file_ingestion_ok=file_ingestion_ok,
             chunk_resolution_ok=chunk_resolution_ok,
+            chunk_duplicates_ok=chunk_duplicate_ok,
             overall_ok=overall_ok,
             stored_name=file.unique_name,
             resolutions=resolutions,
@@ -81,9 +72,6 @@ class FileChunkResolutionResult:
             file_name=file.file_name,
             user=file.user.email,
             file_ingestion_status=file.status,
-            file_ingestion_ok=False,
-            chunk_resolution_ok=False,
-            overall_ok=False,
         )
 
     @classmethod
@@ -95,9 +83,6 @@ class FileChunkResolutionResult:
             file_name=file.file_name,
             user=file.user.email,
             file_ingestion_status=file.status,
-            file_ingestion_ok=False,
-            chunk_resolution_ok=False,
-            overall_ok=False,
             stored_name=file.unique_name,
             error=str(exc),
         )

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -1,12 +1,19 @@
 from dataclasses import dataclass
+from redbox.admin.ingest import _get_resolutions_for_file, _get_duplicate_chunks
 
 
 @dataclass
 class ChunkResolutionDetail:
     name: str
     count: int
-    is_low: bool
-    missing: int
+
+
+@dataclass
+class ChunkDuplicateDetail:
+    name: str
+    avg_duplicates_per_page: float
+    affected_pages: int
+    total_duplicate_chunks: int
 
 
 @dataclass
@@ -28,11 +35,19 @@ class FileChunkResolutionResult:
     error: str | None = None
 
     @classmethod
-    def from_complete_file(cls, file, resolutions: dict[str, int], duplicates: dict) -> "FileChunkResolutionResult":
+    def from_complete_file(cls, file, index_name: str) -> "FileChunkResolutionResult":
+        resolutions = _get_resolutions_for_file(
+            file_uri=file.unique_name,
+            index_name=index_name,
+        )
+        duplicates = _get_duplicate_chunks(
+            file_uri=file.unique_name,
+            index_name=index_name,
+        )
+
         counts = list(resolutions.values())
         chunk_resolution_ok = len(counts) > 0 and len(set(counts)) == 1
         file_ingestion_ok = file.status == "complete"
-        max_count = max(counts) if counts else 0
 
         return cls(
             created_at_ts=int(file.created_at.timestamp()),
@@ -49,8 +64,6 @@ class FileChunkResolutionResult:
                 ChunkResolutionDetail(
                     name=resolution,
                     count=count,
-                    is_low=count < max_count,
-                    missing=max_count - count,
                 )
                 for resolution, count in sorted(resolutions.items())
             ],

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -1,19 +1,24 @@
 from dataclasses import dataclass
-from redbox.admin.ingest import _get_resolutions_for_file, _get_duplicate_chunks
+from redbox.admin.ingest import (
+    _get_resolutions_for_file,
+    _get_duplicate_chunks,
+    ChunkResolutionDetail,
+    ChunkDuplicateDetail,
+)
 
 
-@dataclass
-class ChunkResolutionDetail:
-    name: str
-    count: int
+# @dataclass
+# class ChunkResolutionDetail:
+#     name: str
+#     count: int
 
 
-@dataclass
-class ChunkDuplicateDetail:
-    name: str
-    avg_duplicates_per_page: float
-    affected_pages: int
-    total_duplicate_chunks: int
+# @dataclass
+# class ChunkDuplicateDetail:
+#     name: str
+#     avg_duplicates_per_page: float
+#     affected_pages: int
+#     total_duplicate_chunks: int
 
 
 @dataclass
@@ -31,7 +36,7 @@ class FileChunkResolutionResult:
 
     stored_name: str | None = None
     resolutions: list[ChunkResolutionDetail] | None = None
-    duplicates: dict | None = None
+    duplicates: list[ChunkDuplicateDetail] | None = None
     error: str | None = None
 
     @classmethod
@@ -45,9 +50,12 @@ class FileChunkResolutionResult:
             index_name=index_name,
         )
 
-        counts = list(resolutions.values())
+        counts = [r.count for r in resolutions]
+
         chunk_resolution_ok = len(counts) > 0 and len(set(counts)) == 1
+        # chunk_duplicate_ok =
         file_ingestion_ok = file.status == "complete"
+        overall_ok = chunk_resolution_ok and file_ingestion_ok
 
         return cls(
             created_at_ts=int(file.created_at.timestamp()),
@@ -58,15 +66,9 @@ class FileChunkResolutionResult:
             file_ingestion_status=file.status,
             file_ingestion_ok=file_ingestion_ok,
             chunk_resolution_ok=chunk_resolution_ok,
-            overall_ok=chunk_resolution_ok and file_ingestion_ok,
+            overall_ok=overall_ok,
             stored_name=file.unique_name,
-            resolutions=[
-                ChunkResolutionDetail(
-                    name=resolution,
-                    count=count,
-                )
-                for resolution, count in sorted(resolutions.items())
-            ],
+            resolutions=resolutions,
             duplicates=duplicates,
         )
 
@@ -104,4 +106,5 @@ class FileChunkResolutionResult:
         return {
             **self.__dict__,
             "resolutions": [r.__dict__ for r in self.resolutions] if self.resolutions else None,
+            "duplicates": [d.__dict__ for d in self.duplicates] if self.duplicates else None,
         }

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ChunkResolutionDetail:
+    name: str
+    count: int
+    is_low: bool
+    missing: int
+
+
+@dataclass
+class FileChunkResolutionResult:
+    created_at_ts: int
+    created_at: str
+    file_id: str
+    file_name: str
+    user: str
+    status: str
+    healthy: bool
+    overall_ok: bool
+    stored_name: str | None = None
+    resolutions: list[ChunkResolutionDetail] | None = None
+    error: str | None = None
+
+    @classmethod
+    def from_complete_file(cls, file, resolutions: dict[str, int]) -> "FileChunkResolutionResult":
+        counts = list(resolutions.values())
+        healthy = len(counts) > 0 and len(set(counts)) == 1
+        max_count = max(counts) if counts else 0
+
+        return cls(
+            created_at_ts=int(file.created_at.timestamp()),
+            created_at=file.created_at.strftime("%d %b %Y %H:%M"),
+            file_id=str(file.pk),
+            file_name=file.file_name,
+            user=file.user.email,
+            status=file.status,
+            healthy=healthy,
+            overall_ok=healthy and file.status == "complete",
+            stored_name=file.unique_name,
+            resolutions=[
+                ChunkResolutionDetail(
+                    name=resolution,
+                    count=count,
+                    is_low=count < max_count,
+                    missing=max_count - count,
+                )
+                for resolution, count in sorted(resolutions.items())
+            ],
+        )
+
+    @classmethod
+    def from_incomplete_file(cls, file) -> "FileChunkResolutionResult":
+        return cls(
+            created_at_ts=int(file.created_at.timestamp()),
+            created_at=file.created_at.strftime("%d %b %Y %H:%M"),
+            file_id=str(file.pk),
+            file_name=file.file_name,
+            user=file.user.email,
+            status=file.status,
+            healthy=False,
+            overall_ok=False,
+        )
+
+    @classmethod
+    def from_error(cls, file, exc: Exception) -> "FileChunkResolutionResult":
+        return cls(
+            created_at_ts=int(file.created_at.timestamp()),
+            created_at=file.created_at.strftime("%d %b %Y %H:%M"),
+            file_id=str(file.pk),
+            file_name=file.file_name,
+            user=file.user.email,
+            status=file.status,
+            healthy=False,
+            overall_ok=False,
+            stored_name=file.unique_name,
+            error=str(exc),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            **self.__dict__,
+            "resolutions": [r.__dict__ for r in self.resolutions] if self.resolutions else None,
+        }

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -25,6 +25,7 @@ class FileChunkResolutionResult:
     resolutions: list[ChunkResolutionDetail] | None = None
     duplicates: list[ChunkDuplicateDetail] | None = None
     error: str | None = None
+    reingestion_queued: bool | None = None
 
     @classmethod
     def from_complete_file(cls, file, index_name: str) -> "FileChunkResolutionResult":

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -24,10 +24,11 @@ class FileChunkResolutionResult:
 
     stored_name: str | None = None
     resolutions: list[ChunkResolutionDetail] | None = None
+    duplicates: dict | None = None
     error: str | None = None
 
     @classmethod
-    def from_complete_file(cls, file, resolutions: dict[str, int]) -> "FileChunkResolutionResult":
+    def from_complete_file(cls, file, resolutions: dict[str, int], duplicates: dict) -> "FileChunkResolutionResult":
         counts = list(resolutions.values())
         chunk_resolution_ok = len(counts) > 0 and len(set(counts)) == 1
         file_ingestion_ok = file.status == "complete"
@@ -53,6 +54,7 @@ class FileChunkResolutionResult:
                 )
                 for resolution, count in sorted(resolutions.items())
             ],
+            duplicates=duplicates,
         )
 
     @classmethod

--- a/redbox/redbox/admin/models.py
+++ b/redbox/redbox/admin/models.py
@@ -40,7 +40,7 @@ class FileChunkResolutionResult:
 
         counts = [r.count for r in resolutions]
 
-        chunk_resolution_ok = len(counts) > 0 and len(set(counts)) == 1
+        chunk_resolution_ok = len(counts) > 0 and 0 not in counts
         chunk_duplicate_ok = len(duplicates) == 0
         chunk_ok = chunk_resolution_ok and chunk_duplicate_ok
 

--- a/redbox/redbox/loader/ingester.py
+++ b/redbox/redbox/loader/ingester.py
@@ -11,6 +11,7 @@ from redbox.chains.components import get_embeddings
 from redbox.chains.ingest import ingest_from_loader
 from redbox.loader.loaders import TextractChunkLoader, MetadataLoader
 from redbox.models.settings import get_settings
+from redbox.models.file import ChunkResolution
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -82,6 +83,7 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
+            chunk_resolution=ChunkResolution.normal,
             bucket=env.bucket_name,
             min_chunk_size=env.worker_ingest_min_chunk_size,
             max_chunk_size=env.worker_ingest_max_chunk_size,
@@ -95,10 +97,11 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     large_chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
+            chunk_resolution=ChunkResolution.largest,
             bucket=env.bucket_name,
-            min_chunk_size=env.worker_ingest_min_chunk_size,
-            max_chunk_size=env.worker_ingest_max_chunk_size,
-            overlap_chars=0,
+            min_chunk_size=env.worker_ingest_largest_chunk_size,
+            max_chunk_size=env.worker_ingest_largest_chunk_size,
+            overlap_chars=env.worker_ingest_largest_chunk_overlap,
             metadata=metadata,
         ),
         s3_client=env.s3_client(),
@@ -108,10 +111,11 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     tabular_chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
+            chunk_resolution=ChunkResolution.tabular,
             bucket=env.bucket_name,
-            min_chunk_size=env.worker_ingest_min_chunk_size,
-            max_chunk_size=env.worker_ingest_max_chunk_size,
-            overlap_chars=0,
+            min_chunk_size=env.worker_ingest_largest_chunk_size,
+            max_chunk_size=env.worker_ingest_largest_chunk_size,
+            overlap_chars=env.worker_ingest_largest_chunk_overlap,
             metadata=metadata,
         ),
         s3_client=env.s3_client(),
@@ -121,10 +125,11 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     tabular_schema_chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
+            chunk_resolution=ChunkResolution.tabular,
             bucket=env.bucket_name,
-            min_chunk_size=env.worker_ingest_min_chunk_size,
-            max_chunk_size=env.worker_ingest_max_chunk_size,
-            overlap_chars=0,
+            min_chunk_size=env.worker_ingest_largest_chunk_size,
+            max_chunk_size=env.worker_ingest_largest_chunk_size,
+            overlap_chars=env.worker_ingest_largest_chunk_overlap,
             metadata=metadata,
             include_schema_metadata=True,
         ),

--- a/redbox/redbox/loader/ingester.py
+++ b/redbox/redbox/loader/ingester.py
@@ -186,7 +186,7 @@ def remove_duplicate_chunks(file_uri: str, index_name: str) -> None:
 
     for hit in resp["hits"]["hits"]:
         meta = hit["_source"]["metadata"]
-        key = (meta["uri"], meta["chunk_resolution"], meta["page_number"])
+        key = (meta["uri"], meta["chunk_resolution"], meta["page_number"], hit["_source"]["text"])
         if key in seen:
             ids_to_delete.append(hit["_id"])
         else:

--- a/redbox/redbox/loader/ingester.py
+++ b/redbox/redbox/loader/ingester.py
@@ -166,3 +166,36 @@ def ingest_file(file_name: str, es_index_name: str = alias) -> str | None:
     except Exception:
         logging.exception("Error while processing file [%s]", file_name)
         return traceback.format_exc()
+
+
+def remove_duplicate_chunks(file_uri: str, index_name: str) -> None:
+    es = env.elasticsearch_client()
+    log.info("Using Elasticsearch client: %s", es)
+
+    resp = es.search(
+        index=index_name,
+        body={
+            "size": 1000,
+            "query": {"term": {"metadata.uri.keyword": file_uri}},
+            "sort": [{"metadata.chunk_resolution.keyword": "asc"}, {"metadata.page_number": "asc"}],
+        },
+    )
+
+    seen: set[tuple] = set()
+    ids_to_delete: list[str] = []
+
+    for hit in resp["hits"]["hits"]:
+        meta = hit["_source"]["metadata"]
+        key = (meta["uri"], meta["chunk_resolution"], meta["page_number"])
+        if key in seen:
+            ids_to_delete.append(hit["_id"])
+        else:
+            seen.add(key)
+
+    if not ids_to_delete:
+        log.info("No duplicate chunks found for file %s", file_uri)
+        return
+
+    log.info("Deleting %d duplicate chunks for file %s", len(ids_to_delete), file_uri)
+    for doc_id in ids_to_delete:
+        es.delete(index=index_name, id=doc_id)

--- a/redbox/redbox/loader/ingester.py
+++ b/redbox/redbox/loader/ingester.py
@@ -83,8 +83,8 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
-            chunk_resolution=ChunkResolution.normal,
             bucket=env.bucket_name,
+            chunk_resolution=ChunkResolution.normal,
             min_chunk_size=env.worker_ingest_min_chunk_size,
             max_chunk_size=env.worker_ingest_max_chunk_size,
             overlap_chars=0,
@@ -97,8 +97,8 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     large_chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
-            chunk_resolution=ChunkResolution.largest,
             bucket=env.bucket_name,
+            chunk_resolution=ChunkResolution.largest,
             min_chunk_size=env.worker_ingest_largest_chunk_size,
             max_chunk_size=env.worker_ingest_largest_chunk_size,
             overlap_chars=env.worker_ingest_largest_chunk_overlap,
@@ -111,8 +111,8 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     tabular_chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
-            chunk_resolution=ChunkResolution.tabular,
             bucket=env.bucket_name,
+            chunk_resolution=ChunkResolution.tabular,
             min_chunk_size=env.worker_ingest_largest_chunk_size,
             max_chunk_size=env.worker_ingest_largest_chunk_size,
             overlap_chars=env.worker_ingest_largest_chunk_overlap,
@@ -125,8 +125,8 @@ def _ingest_file(file_name: str, es_index_name: str = alias, enable_metadata_ext
 
     tabular_schema_chunk_ingest_chain = ingest_from_loader(
         loader=TextractChunkLoader(
-            chunk_resolution=ChunkResolution.tabular,
             bucket=env.bucket_name,
+            chunk_resolution=ChunkResolution.tabular,
             min_chunk_size=env.worker_ingest_largest_chunk_size,
             max_chunk_size=env.worker_ingest_largest_chunk_size,
             overlap_chars=env.worker_ingest_largest_chunk_overlap,

--- a/redbox/redbox/loader/ingester.py
+++ b/redbox/redbox/loader/ingester.py
@@ -12,6 +12,7 @@ from redbox.chains.ingest import ingest_from_loader
 from redbox.loader.loaders import TextractChunkLoader, MetadataLoader
 from redbox.models.settings import get_settings
 from redbox.models.file import ChunkResolution
+from redbox.admin.ingest import _chunk_dedupe_key
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -185,8 +186,7 @@ def remove_duplicate_chunks(file_uri: str, index_name: str) -> None:
     ids_to_delete: list[str] = []
 
     for hit in resp["hits"]["hits"]:
-        meta = hit["_source"]["metadata"]
-        key = (meta["uri"], meta["chunk_resolution"], meta["page_number"], hit["_source"]["text"])
+        key = _chunk_dedupe_key(hit)
         if key in seen:
             ids_to_delete.append(hit["_id"])
         else:

--- a/redbox/redbox/loader/loaders.py
+++ b/redbox/redbox/loader/loaders.py
@@ -217,6 +217,7 @@ class TextractChunkLoader:
 
     def __init__(
         self,
+        chunk_resolution: ChunkResolution,
         bucket: str,
         min_chunk_size: int = 500,
         max_chunk_size: int = 2000,
@@ -225,6 +226,7 @@ class TextractChunkLoader:
         metadata: GeneratedMetadata | None = None,
         include_schema_metadata: bool = False,
     ):
+        self.chunk_resolution = chunk_resolution
         self.bucket = bucket
         textract_config = Config(
             retries={"mode": "adaptive", "max_attempts": 10},
@@ -630,7 +632,7 @@ class TextractChunkLoader:
                     page_number=page_num,
                     created_datetime=datetime.now(UTC),
                     token_count=tokeniser(chunk),
-                    chunk_resolution=ChunkResolution.normal,
+                    chunk_resolution=self.chunk_resolution,
                     name=self.metadata.name,
                     description=self.metadata.description,
                     keywords=self.metadata.keywords,
@@ -659,6 +661,7 @@ class MetadataLoader:
         start_time = time.time()
 
         loader = TextractChunkLoader(
+            chunk_resolution=ChunkResolution.normal,
             bucket=self.env.bucket_name,
             min_chunk_size=200,
             max_chunk_size=2000,

--- a/redbox/redbox/loader/loaders.py
+++ b/redbox/redbox/loader/loaders.py
@@ -217,8 +217,8 @@ class TextractChunkLoader:
 
     def __init__(
         self,
-        chunk_resolution: ChunkResolution,
         bucket: str,
+        chunk_resolution: ChunkResolution = ChunkResolution.normal,
         min_chunk_size: int = 500,
         max_chunk_size: int = 2000,
         overlap_chars: int = 200,
@@ -661,8 +661,8 @@ class MetadataLoader:
         start_time = time.time()
 
         loader = TextractChunkLoader(
-            chunk_resolution=ChunkResolution.normal,
             bucket=self.env.bucket_name,
+            chunk_resolution=ChunkResolution.normal,
             min_chunk_size=200,
             max_chunk_size=2000,
             overlap_chars=0,

--- a/redbox/tests/admin/test_ingest.py
+++ b/redbox/tests/admin/test_ingest.py
@@ -1,0 +1,127 @@
+from unittest.mock import Mock, patch
+
+from redbox.admin.ingest import _get_resolutions_for_file, _get_duplicate_chunks
+
+
+@patch("redbox.admin.ingest._es_client")
+def test_get_resolutions_for_file_returns_counts(mock_es_client):
+    es = Mock()
+    mock_es_client.return_value = es
+
+    es.search.return_value = {
+        "aggregations": {
+            "resolutions": {
+                "buckets": [
+                    {"key": "largest", "doc_count": 10},
+                    {"key": "normal", "doc_count": 10},
+                ]
+            }
+        }
+    }
+
+    results = list(
+        _get_resolutions_for_file(
+            "file.pdf",
+            "test-index",
+        )
+    )
+
+    assert len(results) == 2
+
+    assert results[0].name == "largest"
+    assert results[0].count == 10
+
+    assert results[1].name == "normal"
+    assert results[1].count == 10
+
+
+@patch("redbox.admin.ingest._es_client")
+def test_missing_resolution_added(mock_es_client):
+    es = Mock()
+    mock_es_client.return_value = es
+
+    es.search.return_value = {
+        "aggregations": {
+            "resolutions": {
+                "buckets": [
+                    {"key": "largest", "doc_count": 5},
+                ]
+            }
+        }
+    }
+
+    results = {
+        r.name: r.count
+        for r in _get_resolutions_for_file(
+            "file.pdf",
+            "test-index",
+        )
+    }
+
+    assert results == {
+        "largest": 5,
+        "normal": 0,
+    }
+
+
+@patch("redbox.admin.ingest._es_client")
+def test_csv_expects_tabular_resolution(mock_es_client):
+    es = Mock()
+    mock_es_client.return_value = es
+
+    es.search.return_value = {"aggregations": {"resolutions": {"buckets": []}}}
+
+    results = {
+        r.name: r.count
+        for r in _get_resolutions_for_file(
+            "data.csv",
+            "test-index",
+        )
+    }
+
+    assert results == {
+        "tabular": 0,
+    }
+
+
+@patch("redbox.admin.ingest._es_client")
+def test_duplicate_summary(mock_es_client):
+    es = Mock()
+    mock_es_client.return_value = es
+
+    es.search.return_value = {
+        "aggregations": {
+            "duplicate_groups": {
+                "buckets": [
+                    {
+                        "key": {
+                            "resolution": "largest",
+                            "page_number": 1,
+                        },
+                        "doc_count": 3,
+                    },
+                    {
+                        "key": {
+                            "resolution": "largest",
+                            "page_number": 2,
+                        },
+                        "doc_count": 2,
+                    },
+                ]
+            }
+        }
+    }
+
+    results = {
+        r.name: r
+        for r in _get_duplicate_chunks(
+            "file.pdf",
+            "index",
+        )
+    }
+
+    largest = results["largest"]
+
+    assert largest.affected_pages == 2
+    assert largest.total_duplicate_chunks == 5
+    assert largest.avg_duplicates_per_page == 2.5

--- a/redbox/tests/loader/test_ingester.py
+++ b/redbox/tests/loader/test_ingester.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock, patch
+
+from redbox.loader.ingester import remove_duplicate_chunks
+
+
+@patch("redbox.loader.ingester.env.elasticsearch_client")
+def test_remove_duplicate_chunks_deletes_duplicates(
+    mock_client,
+):
+    es = Mock()
+    mock_client.return_value = es
+
+    es.search.return_value = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": "1",
+                    "_source": {
+                        "metadata": {
+                            "uri": "file.pdf",
+                            "chunk_resolution": "largest",
+                            "page_number": 1,
+                        }
+                    },
+                },
+                {
+                    "_id": "2",
+                    "_source": {
+                        "metadata": {
+                            "uri": "file.pdf",
+                            "chunk_resolution": "largest",
+                            "page_number": 1,
+                        }
+                    },
+                },
+            ]
+        }
+    }
+
+    remove_duplicate_chunks(
+        "file.pdf",
+        "index",
+    )
+
+    es.delete.assert_called_once_with(
+        index="index",
+        id="2",
+    )


### PR DESCRIPTION
## Context
Adds action to file page in admin panel to check health of file ingestion. Allowing admins to select files and see if they were properly ingested in OpenSearch, if not or duplicates are found it has a button to reingest the file.

This is only supported for files which are already ingested in DB.

It is important to note health check page does not refresh results on page refresh, you have to redo "go" call in files page to reload results.

## What
- Fixes TextractChunkLoader to take chunk_resolution as input
- Fixes chunk strategy for largest chunks
- Adds action 'File Ingestion Health Check' to Files in admin panel
- Adds page 'File Ingestion Health Check' to view file ingestion health in admin panel, has a button to reingest

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

1. go to admin panel
2. go to "files"
3. select some files and action "File Ingestion Health Check"
4. click "go"
5. should be redirected to page with results from files
6. identify problematic files and click reingest
7. click back
8. click "go" again in files page
9. reingested file should be all green

## Relevant links
