### PR TITLE
Adding revert option to branch naming convention

### DIFF
--- a/.github/workflows/branch-status-check.yml
+++ b/.github/workflows/branch-status-check.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Checking branch name: $BRANCH_NAME"
 
           # Define allowed naming patterns (Regex for feature, bugfix, etc.)
-          if [[ ! "$BRANCH_NAME" =~ ^(main|feature/.*|chore/.*|bugfix/.*|hotfix/.*|dependabot/.*|security/.*|dev)$ ]]; then
+          if [[ ! "$BRANCH_NAME" =~ ^(main|feature/.*|chore/.*|bugfix/.*|hotfix/.*|dependabot/.*|security/.*|dev|revert.*)$ ]]; then
             echo "Error: Invalid branch name '$BRANCH_NAME'. It must follow one of the following patterns:"
             echo "- main"
             echo "- feature/*"
@@ -40,6 +40,7 @@ jobs:
             echo "- dependabot/*"
             echo "- security/*"
             echo "- dev"
+            echo "- revert*"
             exit 1
           fi
 

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -402,7 +402,7 @@ Consistent branch names help maintain a clean and predictable workflow. CI will 
 - `hotfix/<name>` — Urgent fixes for production issues
 - `dependabot/<name>` — Automated dependency updates
 - `security/<name>` — Security-related changes
-- `bugfix<name>` — For when git creates a branch to revert a PR
+- `revert<name>` — For when git creates a branch to revert a PR
 
 ### Pre-commit hooks
 

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -402,6 +402,7 @@ Consistent branch names help maintain a clean and predictable workflow. CI will 
 - `hotfix/<name>` — Urgent fixes for production issues
 - `dependabot/<name>` — Automated dependency updates
 - `security/<name>` — Security-related changes
+- `bugfix<name>` — For when git creates a branch to revert a PR
 
 ### Pre-commit hooks
 


### PR DESCRIPTION
## Context

Adding revert option to branch naming convention so it does not cause an error when trying to revert a branch because of the name

## What

adding anything that is 'revert*' to be an acceptable branch name, as well as updating this also in the DEVELOPER_SETUP.md

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
