### PR TITLE
feature/ASSIST-1554-gov-uk-link-styling

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/header.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/components/header.scss
@@ -5,22 +5,6 @@
     &[aria-expanded="true"]:after {
         display: none;
     }
-    &:focus {
-        background-color: transparent;
-        box-shadow: none;
-        outline:none;
-    }
-    .button-content{
-      line-height: 0;
-    }
-    &:focus > .button-content {
-        outline: 3px solid var(--color-focus);
-        outline-offset: 0;
-        background-color: var(--color-focus);
-    }
-    &:hover > .button-content {
-        background-color: transparent;
-        box-shadow: none;
-        outline:none;
-    }
+    line-height: 0px;
+
 }

--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -4,7 +4,7 @@ class CopyText extends HTMLElement {
   connectedCallback() {
     const messageId = this.dataset.id
     this.innerHTML = `
-        <button class="ids-copy-button" type="button">
+        <button class="ids-copy-button focusable" type="button">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_690_405)">
           <path d="M21 7.5V21H7.5V7.5H21ZM21 6H7.5C7.10218 6 6.72064 6.15804 6.43934 6.43934C6.15804 6.72064 6 7.10218 6 7.5V21C6 21.3978 6.15804 21.7794 6.43934 22.0607C6.72064 22.342 7.10218 22.5 7.5 22.5H21C21.3978 22.5 21.7794 22.342 22.0607 22.0607C22.342 21.7794 22.5 21.3978 22.5 21V7.5C22.5 7.10218 22.342 6.72064 22.0607 6.43934C21.7794 6.15804 21.3978 6 21 6Z" fill="#1D70B8"/>

--- a/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
+++ b/django_app/frontend/src/js/web-components/chats/feedback-buttons.js
@@ -25,10 +25,10 @@ export class FeedbackButtons extends HTMLElement {
     <fieldset class="feedback-container feedback-container--1" tabindex="-1">
       <legend class="feedback__heading">Is this response useful?</legend>
       <div class="feedback-button-container">
-      <button class="thumb_feedback-btn thumb_feedback-btn--up" type="button">
+      <button class="thumb_feedback-btn thumb_feedback-btn--up focusable" type="button">
         <img src="/static/icons/thumbs-up.svg" alt="Yes" />
       </button>
-      <button class="thumb_feedback-btn thumb_feedback-btn--down" type="button">
+      <button class="thumb_feedback-btn thumb_feedback-btn--down focusable" type="button">
         <img src="/static/icons/thumbs-down.svg" alt="No" />
       </button>
       </div>

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -37,6 +37,9 @@ button,
   border-radius: 0px !important; // make the element have square borders when focussed
   &:focus{
     @include govuk-focused-text;
+    &.dark{
+        box-shadow: 0 -2px var(--color-focus), 0 4px var(--color-background-white)!important;
+    }
   }
 }
 

--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -33,6 +33,13 @@ button,
   border-bottom-right-radius: var(--border-bottom-right-radius, var(--border-radius)) !important;
 }
 
+.focusable {
+  border-radius: 0px !important; // make the element have square borders when focussed
+  &:focus{
+    @include govuk-focused-text;
+  }
+}
+
 input,
 select,
 textarea {

--- a/django_app/redbox_app/templates/chat/cta.html
+++ b/django_app/redbox_app/templates/chat/cta.html
@@ -1,13 +1,10 @@
 {% from "macros/icon.html" import ids_icon %}
-
 <div id="chat-cta" class="ids-chat-cta {% if not tool and not current_chat %}ids-chat-cta--centered{% endif %}" hx-swap-oob="outerHTML">
     <div class="ids-chat-cta__toggle">
         <ids-side-panel-toggle>
-            <button slot="toggle-side-panel" class="ids-side-panel__toggle ids-icon-button ids-header__menu-button govuk-!-padding-left-0" type="button">
-                <div class="button-content">
-                  {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="") }}
-                  <span class="govuk-visually-hidden">Open the menu</span>
-                </div>
+            <button slot="toggle-side-panel" class="ids-side-panel__toggle ids-icon-button ids-header__menu-button govuk-!-padding-0 focusable" type="button">
+                {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="") }}
+                <span class="govuk-visually-hidden">Open the menu</span>
             </button>
         </ids-side-panel-toggle>
     </div>

--- a/django_app/redbox_app/templates/chat/cta.html
+++ b/django_app/redbox_app/templates/chat/cta.html
@@ -2,7 +2,9 @@
 <div id="chat-cta" class="ids-chat-cta {% if not tool and not current_chat %}ids-chat-cta--centered{% endif %}" hx-swap-oob="outerHTML">
     <div class="ids-chat-cta__toggle">
         <ids-side-panel-toggle>
-            <button slot="toggle-side-panel" class="ids-side-panel__toggle ids-icon-button ids-header__menu-button govuk-!-padding-0 focusable" type="button">
+            <button slot="toggle-side-panel"
+                    class="ids-side-panel__toggle ids-icon-button ids-header__menu-button govuk-!-padding-0 focusable"
+                    type="button">
                 {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="") }}
                 <span class="govuk-visually-hidden">Open the menu</span>
             </button>

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -15,7 +15,7 @@
       <li>If no document(s) selected, {{ productName }} defaults to using ‘chat’, which gets answers from the model's training data</li>
       <li>When document(s) selected, {{ productName }} will default to searching for information based on your prompt</li>
       <li>If you request a summary of one or more documents, {{ productName }} will do that rather than search</li>
-      <li>{{ productName }} can use external search tools for <a href="https://www.gov.uk">GOV.UK</a> and <a href="https://www.wikipedia.org">Wikipedia</a></li>
+      <li>{{ productName }} can use external search tools for <a class="govuk-link" href="https://www.gov.uk">GOV.UK</a> and <a class="govuk-link" href="https://www.wikipedia.org">Wikipedia</a></li>
       <li>When your request/prompt might best be answered by using two or more tools at the same time, {{ productName }} will provide you with its proposed plan, which you can agree to, modify or cancel</li>
       <li>The knowledge that {{ productName }} has access to is cut off in November 2024, so ensure that if you need up to date information you ask for {{ productName }} to find additional online sources</li>
     </ul>

--- a/django_app/redbox_app/templates/side_panel/header.html
+++ b/django_app/redbox_app/templates/side_panel/header.html
@@ -14,13 +14,11 @@
                 <ids-side-panel-toggle>
                     <button slot="toggle-side-panel"
                             type="button"
-                            class="govuk-header__menu-button ids-header__menu-button ids-side-panel__toggle ids-icon-button"
+                            class="govuk-header__menu-button ids-header__menu-button ids-side-panel__toggle ids-icon-button focusable govuk-!-padding-0 govuk-!-margin-right-2"
                             aria-controls="navigation"
                             aria-label="Close the menu">
-                            <div class="button-content">
                               {{ ids_icon(icon_name="left-panel-close.svg", icon_classes="dark") }}
                               <span class="govuk-visually-hidden">Close the menu</span>
-                            </div>
                     </button>
                 </ids-side-panel-toggle>
 

--- a/django_app/redbox_app/templates/side_panel/header.html
+++ b/django_app/redbox_app/templates/side_panel/header.html
@@ -14,7 +14,7 @@
                 <ids-side-panel-toggle>
                     <button slot="toggle-side-panel"
                             type="button"
-                            class="govuk-header__menu-button ids-header__menu-button ids-side-panel__toggle ids-icon-button focusable govuk-!-padding-0 govuk-!-margin-right-2"
+                            class="govuk-header__menu-button ids-header__menu-button ids-side-panel__toggle ids-icon-button focusable dark govuk-!-padding-0 govuk-!-margin-right-2"
                             aria-controls="navigation"
                             aria-label="Close the menu">
                               {{ ids_icon(icon_name="left-panel-close.svg", icon_classes="dark") }}

--- a/django_app/redbox_app/templates/side_panel/side_panel.html
+++ b/django_app/redbox_app/templates/side_panel/side_panel.html
@@ -6,7 +6,7 @@
             <ids-side-panel-toggle>
                 <button slot="toggle-side-panel"
                         type="button"
-                        class="ids-side-panel--collapsed__content ids-side-panel__toggle ids-icon-button"
+                        class="ids-side-panel--collapsed__content ids-side-panel__toggle ids-icon-button focusable govuk-!-padding-0 govuk-!-margin-2"
                         aria-controls="navigation"
                         aria-label="Open the menu">
                           {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="dark") }}

--- a/django_app/redbox_app/templates/side_panel/side_panel.html
+++ b/django_app/redbox_app/templates/side_panel/side_panel.html
@@ -6,7 +6,7 @@
             <ids-side-panel-toggle>
                 <button slot="toggle-side-panel"
                         type="button"
-                        class="ids-side-panel--collapsed__content ids-side-panel__toggle ids-icon-button focusable govuk-!-padding-0 govuk-!-margin-2"
+                        class="ids-side-panel--collapsed__content ids-side-panel__toggle ids-icon-button focusable dark govuk-!-padding-0 govuk-!-margin-2"
                         aria-controls="navigation"
                         aria-label="Open the menu">
                           {{ ids_icon(icon_name="left-panel-open.svg", icon_classes="dark") }}


### PR DESCRIPTION
## Context
PR to make changes for the GOV uk styling section of the Assist Accessibility report

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
### Add the correct govuk styling link to the links in the explanation paragraph

<img width="737" height="268" alt="image" src="https://github.com/user-attachments/assets/8441c141-b3ed-4acf-b899-c6c57ebf733b" />

### Add a new styling that extends govuk to add focus styling to icon buttons<img width="365" height="53" alt="image" src="https://github.com/user-attachments/assets/bf75cb2c-c03e-4050-ac0b-c496af62d18c" />

### New styling on xs collapsed 
<img width="417" height="67" alt="image" src="https://github.com/user-attachments/assets/a2bd239b-39e2-4245-b068-7027c7774760" />

### New styling on greater than xs collapsed 
<img width="197" height="88" alt="image" src="https://github.com/user-attachments/assets/f2832d02-bd6f-4867-8458-a2d7ed28a88d" />


### New styling on expanded
<img width="281" height="149" alt="image" src="https://github.com/user-attachments/assets/88d6fbf5-541c-475b-8064-9eda539a107c" />


## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
