### PR TITLE
feature/ASSIST-1555-copy-text-button

### DIFF
--- a/django_app/frontend/src/js/web-components/chats/copy-text.js
+++ b/django_app/frontend/src/js/web-components/chats/copy-text.js
@@ -6,17 +6,17 @@ class CopyText extends HTMLElement {
     this.innerHTML = `
         <button class="ids-copy-button" type="button">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <g clip-path="url(#clip0_690_405)">
-          <path d="M21 7.5V21H7.5V7.5H21ZM21 6H7.5C7.10218 6 6.72064 6.15804 6.43934 6.43934C6.15804 6.72064 6 7.10218 6 7.5V21C6 21.3978 6.15804 21.7794 6.43934 22.0607C6.72064 22.342 7.10218 22.5 7.5 22.5H21C21.3978 22.5 21.7794 22.342 22.0607 22.0607C22.342 21.7794 22.5 21.3978 22.5 21V7.5C22.5 7.10218 22.342 6.72064 22.0607 6.43934C21.7794 6.15804 21.3978 6 21 6Z" fill="#1D70B8"/>
-          <path d="M3 13.5H1.5V3C1.5 2.60218 1.65804 2.22064 1.93934 1.93934C2.22064 1.65804 2.60218 1.5 3 1.5H13.5V3H3V13.5Z" fill="#1D70B8"/>
-          </g>
-          <defs>
-          <clipPath id="clip0_690_405">
-          <rect width="24" height="24" fill="white"/>
-          </clipPath>
-          </defs>
+            <g clip-path="url(#clip0_690_405)">
+            <path d="M21 7.5V21H7.5V7.5H21ZM21 6H7.5C7.10218 6 6.72064 6.15804 6.43934 6.43934C6.15804 6.72064 6 7.10218 6 7.5V21C6 21.3978 6.15804 21.7794 6.43934 22.0607C6.72064 22.342 7.10218 22.5 7.5 22.5H21C21.3978 22.5 21.7794 22.342 22.0607 22.0607C22.342 21.7794 22.5 21.3978 22.5 21V7.5C22.5 7.10218 22.342 6.72064 22.0607 6.43934C21.7794 6.15804 21.3978 6 21 6Z" fill="#1D70B8"/>
+            <path d="M3 13.5H1.5V3C1.5 2.60218 1.65804 2.22064 1.93934 1.93934C2.22064 1.65804 2.60218 1.5 3 1.5H13.5V3H3V13.5Z" fill="#1D70B8"/>
+            </g>
+            <defs>
+              <clipPath id="clip0_690_405">
+              <rect width="24" height="24" fill="white"/>
+            </clipPath>
+            </defs>
           </svg>
-          Copy
+          <span role="status">Copy</span>
           <span class="govuk-visually-hidden"> message content</span>
         </button>
     `;
@@ -37,10 +37,15 @@ class CopyText extends HTMLElement {
       evt.clipboardData.setData("text/html", html);
       evt.clipboardData.setData("text/plain", text);
       evt.preventDefault();
+      const spanMessage = this.querySelector("span");
+      if (spanMessage){
+        spanMessage.innerText = "Copied"
+      }
     };
     document.addEventListener("copy", listener);
     document.execCommand("copy");
     document.removeEventListener("copy", listener);
+
   };
 }
 customElements.define("copy-text", CopyText);


### PR DESCRIPTION
## Context
PR to make changes for the Copy text section of the Assist Accessibility report

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Add logic to the copy button to change the text to "Copied" once the button is clicked. Add the `role=status` to the span so a screen reader can detect the changes

<img width="738" height="173" alt="image" src="https://github.com/user-attachments/assets/1cf433fb-2db6-41d4-b713-767e5c14135c" />


## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
