### PR TITLE
Feature: Negotiation planner search agent

### DIFF
--- a/redbox/redbox/app.py
+++ b/redbox/redbox/app.py
@@ -18,6 +18,7 @@ from redbox.graph.nodes.tools import (
     build_document_from_prompt_tool,
     build_govuk_search_tool,
     build_legislation_search_tool,
+    build_negotiation_planner_search_tool,
     build_query_tabular_file_tool,
     build_retrieve_document_full_text,
     build_retrieve_knowledge_base,
@@ -117,6 +118,7 @@ class Redbox:
         search_govuk = build_govuk_search_tool()
         web_search = build_web_search_tool()
         legislation_search = build_legislation_search_tool()
+        negotiation_planner_search = build_negotiation_planner_search_tool()
         doc_from_prompt = build_document_from_prompt_tool(loop=True)
 
         self.agent_configs["Internal_Retrieval_Agent"].tools = [search_documents]
@@ -124,6 +126,7 @@ class Redbox:
         self.agent_configs["Tabular_Agent"].tools = [query_tabular_file]
         self.agent_configs["Web_Search_Agent"].tools = [web_search]
         self.agent_configs["Legislation_Search_Agent"].tools = [legislation_search]
+        self.agent_configs["Negotiation_Planner_Search_Agent"].tools = [negotiation_planner_search]
         self.agent_configs["Submission_Question_Answer_Agent"].tools = [
             retrieve_full_text,
             retrieve_knowledge_base,

--- a/redbox/redbox/graph/agents/configs.py
+++ b/redbox/redbox/graph/agents/configs.py
@@ -97,6 +97,10 @@ prompt_configs: Dict[str, PromptConfig] = {
         system=prompts.LEGISLATION_SEARCH_AGENT_PROMPT + prompts.PREVIOUS_AGENT_RESULTS,
         prompt_vars=PromptVariable(task=True, expected_output=True, previous_agents_results=True),
     ),
+    "Negotiation_Planner_Search_Agent": PromptConfig(
+        system=prompts.NEGOTIATION_PLANNER_SEARCH_AGENT_PROMPT + prompts.PREVIOUS_AGENT_RESULTS,
+        prompt_vars=PromptVariable(task=True, expected_output=True, previous_agents_results=True),
+    ),
     "Summarisation_Agent": PromptConfig(
         system=prompts.CHAT_WITH_DOCS_SYSTEM_PROMPT,
         question=prompts.CHAT_WITH_DOCS_QUESTION_PROMPT,
@@ -228,6 +232,14 @@ agent_configs: Dict[str, AgentConfig] = {
         name="Legislation_Search_Agent",
         description=prompts.LEGISLATION_SEARCH_AGENT_DESC,
         prompt=prompt_configs["Legislation_Search_Agent"],
+        parser=None,
+        default_agent=True,
+        agents_max_tokens=10000,
+    ),
+    "Negotiation_Planner_Search_Agent": AgentConfig(
+        name="Negotiation_Planner_Search_Agent",
+        description=prompts.NEGOTIATION_PLANNER_SEARCH_AGENT_DESC,
+        prompt=prompt_configs["Negotiation_Planner_Search_Agent"],
         parser=None,
         default_agent=True,
         agents_max_tokens=10000,

--- a/redbox/redbox/graph/nodes/tools.py
+++ b/redbox/redbox/graph/nodes/tools.py
@@ -1001,6 +1001,25 @@ def build_legislation_search_tool():
     return _search_legislation
 
 
+def build_negotiation_planner_search_tool():
+    @tool(response_format="content_and_artifact")
+    def _search_negotiation_planner(query: str):
+        """
+        Web search with preference for reputable sources relevant to negotiation planning.
+
+        Args:
+            query (str): The search query to pass to negotiation planning search engine.
+            - Can be natural language, keywords, or phrases
+            - More specific queries yield more precise results
+            - Query length should be 1-500 characters
+        Returns:
+            dict[str, Any]: Collection of matching document snippets with metadata:
+        """
+        return web_search_call(query=query)
+
+    return _search_negotiation_planner
+
+
 async def get_datahub_mcp_tools(sso_token_getter: Callable[[], str] | None = None, agent_loop=True):
     try:
         log.info("get_datahub_mcp_tools - Loading Datahub MCP tools...")

--- a/redbox/redbox/graph/root.py
+++ b/redbox/redbox/graph/root.py
@@ -22,8 +22,8 @@ from redbox.graph.edges import (
 from redbox.graph.nodes.processes import (
     build_activity_log_node,
     build_agent_with_loop,
-    build_datahub_agent_with_loop,
     build_chat_pattern,
+    build_datahub_agent_with_loop,
     build_error_pattern,
     build_merge_pattern,
     build_passthrough_pattern,
@@ -571,6 +571,7 @@ def build_new_route_graph(
     add_agent(builder, agent_configs, "Tabular_Agent")
     add_agent(builder, agent_configs, "Web_Search_Agent")
     add_agent(builder, agent_configs, "Legislation_Search_Agent")
+    add_agent(builder, agent_configs, "Negotiation_Planner_Search_Agent")
     add_agent(
         builder,
         agent_configs,

--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -310,6 +310,57 @@ Always prioritize official, authoritative sources within the specified domain
 
 """
 
+NEGOTIATION_PLANNER_SEARCH_AGENT_PROMPT = """
+You are a specialised NegotiationPlannerSearchAgent, as AI assistant designed to search websites based on user questions.
+Your goal is to complete the task <Task>{task}</Task> with the expected output: <Expected_Output>{expected_output}</Expected_Output> using the most efficient approach possible.
+
+Guidelines for Tool Usage:
+1. Please use the available tools to perform multiple parallel tool calls to gather all necessary information.
+
+Decision-Making Process:
+- Determine the minimal set of tool calls required
+- Prioritize comprehensive yet concise information retrieval
+- Avoid redundant or unnecessary tool interactions
+
+Core Capabilities:
+Query Analysis: Analyse user questions to identify key search terms and information needs.
+Website Navigation: Search within websites or domains to locate relevant information.
+Result Extraction: Extract and present the most pertinent information from search results.
+Source Citation: Always cite your sources with direct URLs when providing information. Include the URL inline in the response text.
+Handling Ambiguity: Request clarification when queries are ambiguous or lack specificity.
+
+Operational Parameters:
+Domains: When a user provides a website or websites to search, only search within those domains unless the user specifies otherwise. If the user doesn't specify a website or asks you to search in websites aside from those provided, then broaden your search to include other reputable information sources. For current events, preferentially search in the websites listed below in REPUTABLE NEWS SOURCES and REPUTABLE NEWS SOURCES WITH ACCESS CHECKS. If relevant information is not available in those locations then broaden your search to include other reputable information sources.
+Reliability of Sources: Always prioritize official, authoritative sources of information. If you use a source that is not an established reputable source of information then your response should clearly state this.
+Diversity of Sources: For politically sensitive or rapidly developing news stories prefer two to three independant sources from different domains.
+Accessibility of Sources: If a source is within the list REPUTABLE NEWS SOURCES WITH ACCESS CHECKS or if it is known to have access restrictions then state that it may require subscription or login.
+Timeframe: If the query requests news or current events then prioritise articles published within the last three months. If the user specifies a timeframe then use that instead.
+Dates: Provide dates of events of possible. Prefer specific dates (day, month and year) or months (month and year).
+
+REPUTABLE NEWS SOURCES:
+- bbc.co.uk/news
+- news.sky.com
+- theguardian.com
+- reuters.com/
+- aljazeera.com
+- apnews.com
+- afp.com
+- dw.com
+- fracne24.com
+- euronews.com
+- japantimes.co.jp
+
+REPUTABLE NEWS SOURCES WITH ACCESS CHECKS:
+- ft.com
+- economist.com
+- nytimes.com
+- washingtonpost.com
+- bloomberg.com
+- foreignpolicy.com
+- foreignaffairs.com
+- scmp.com
+"""
+
 INTERNAL_RETRIEVAL_AGENT_DESC = """
 **Internal_Retrieval_Agent**:
 Purpose: Information retrieval and question answering
@@ -362,6 +413,15 @@ Purpose: Perform searches across the legislation.gov.uk website domain only
 Use when the user wants to:
 - Search for information only from the legislation.gov.uk website
 - ALWAYS use this agent when a user explicitly mentions searching the legislation.gov.uk website domain
+- Use this agent even if the search involves future dates or hypothetical scenarios, as the agent will handle these appropriately
+"""
+
+NEGOTIATION_PLANNER_SEARCH_AGENT_DESC = """
+**Negotiation_Planner_Search_Agent**:
+Purpose: Perform searches with focus on reputable sources relevant to negotiation planning
+Use when the user wants to:
+- Search for information to be used in trade negotiations
+- Search for current international news from reliable sources
 - Use this agent even if the search involves future dates or hypothetical scenarios, as the agent will handle these appropriately
 """
 

--- a/redbox/tests/test_tools.py
+++ b/redbox/tests/test_tools.py
@@ -21,6 +21,7 @@ from redbox.graph.nodes.tools import (
     build_document_from_prompt_tool,
     build_govuk_search_tool,
     build_legislation_search_tool,
+    build_negotiation_planner_search_tool,
     build_query_tabular_file_tool,
     build_retrieve_document_full_text,
     build_retrieve_knowledge_base,
@@ -941,6 +942,41 @@ def test_legislation_search_tool(query, no_search_results):
     for res in response["messages"][0].artifact:
         netloc = urlparse(res.metadata["uri"]).netloc
         assert "www.legislation.gov.uk" == netloc
+
+
+@pytest.mark.parametrize(
+    "query, no_search_results, search_url",
+    [
+        ("Tell me about the CPTPP", 20, None),
+        ("What current events may affect agricultural imports and exports to switzerland", 20, None),
+        (
+            "What are Switzerland's current economic priorities according to the Swiss State Secretariat for Economic Affairs (seco.admin.sh)",
+            20,
+            "www.seco.admin.sh",
+        ),
+    ],
+)
+@pytest.mark.vcr
+@pytest.mark.xfail(reason="calls api")
+def test_negotiation_planner_search_tool(query, no_search_results, search_url):
+    tool = build_negotiation_planner_search_tool()
+    tool_node = ToolNode(tools=[tool])
+    response = tool_node.invoke(
+        [
+            {
+                "name": "_search_negotiation_planner",
+                "args": {"query": query},
+                "id": "1",
+                "type": "tool_call",
+            }
+        ]
+    )
+    assert response["messages"][0].content != ""
+    assert len(response["messages"][0].artifact) <= no_search_results
+    if search_url:
+        for res in response["messages"][0].artifact:
+            netloc = urlparse(res.metadata["uri"]).netloc
+            assert "www.seco.admin.sh" == netloc
 
 
 def test_reduce_chunks_by_tokens_empty_chunks():


### PR DESCRIPTION
## Context

Jira ticket: [A3P-141](https://uktrade.atlassian.net/browse/A3P-141)

Creates a web search agent for Negotiation Planner that aims to:
- prioritise certain types of information source
- impose soft rules around agent decisions and response content

It is based on the existing web search agent, with parameters relevant to negotiation planning.

## Have you written unit tests?
- [X] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

- [ ] Yes (if so provide more detail)
- [X] No

[A3P-141]: https://uktrade.atlassian.net/browse/A3P-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ