### PR TITLE
feature/ASSIST-1556-menu-behaviour

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/collapsible-menu.js
+++ b/django_app/frontend/src/interaction_design_system/ids/components/collapsible-menu.js
@@ -7,7 +7,10 @@ class CollapsibleMenu extends HTMLElement {
         this.onEscapeKey = this.onEscapeKey.bind(this);
         this.onToggle = this.onToggle.bind(this);
     }
+
     connectedCallback() {
+        this.addEventListener("focusout", this.onFocusOut)
+
         this.details = this.querySelector('details');
         if (!this.details) return;
 
@@ -47,6 +50,17 @@ class CollapsibleMenu extends HTMLElement {
 
         // Close if click outside this component
         if (!this.contains(target)) this.details.open = false;
+    }
+
+    /**
+     * Handle focus out events
+     * @param {FocusEvent} event event object
+     */
+    onFocusOut(event){
+        if (!event || !this.details || !this.details.open) return;
+        if (!this.contains(event.relatedTarget)){
+            this.details.open = false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Context

PR to make changes for the Menu behaviour section of the Assist Accessibility report


## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Trigger the onFocusOut event when tabbing through the collapsible menu. When an element outside the menu receives focus, if the menu is still open then close it

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
