### PR TITLE
feature/ASSIST-1517-focus-not-obscured

### DIFF
--- a/django_app/frontend/src/styles.scss
+++ b/django_app/frontend/src/styles.scss
@@ -159,3 +159,7 @@ only screen and (min-resolution:192dpi) {
     background-image: url(/static/govuk-frontend/assets/images/govuk-crest-2x.png)
   }
 }
+
+:is(html, body):has(.ids-chat-interaction) {
+  scroll-padding-bottom: 250px;
+}


### PR DESCRIPTION
## Context

PR to make changes for the Focus not observed section of the Assist Accessibility report


## What

When the "Resources that Invest Lens uses" link is clicked, an expanded list of links are shown. Due to the chat text box having a `position:sticky` CSS style, this means the links are expanded behing the text box and not visible or focusable.

This PR adds some padding to the bottom of the text box to cater for the expanding menu above it. Ideally that height would be auto calculated, however this PR solves the immediate issues

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
