### PR TITLE
feat: add local db setup cmd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         name: Detect sensitive data (passwords, keys, etc.)
 
   - repo: https://github.com/uktrade/github-standards
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
       - id: validate-security-scan
       - id: run-security-scan
@@ -81,4 +81,4 @@ repos:
         entry: '\.(docx|doc|pdf|xlsx|csv|txt|log)$'
         language: fail
         description: Prevent committing data files (.docx, .pdf, .xlsx, .csv, .txt, .log)
-        exclude: '\.(txt|md|png|gif|woff|woff2|ico|baseline|lock|toml|py|js|css|scss|html|sh|ipynb|svg|env|example|yml|yaml|gitkeep|env\.notebook|jsonl)$|^(Make|Proc)file$|^\.vscode/|^(unstructured|django_app)/Dockerfile$|^tests/|^django_app/tests/|^(redbox|django_app)/.vscode/|^django_app/(frontend|static|files)/.*\.(json|lottie|parcelrc|pdf)$|devcontainer.json$|^notebooks/evaluation/data_results/.*\.json$|^\.editorconfig$|^\.gitattributes$|^\.gitignore$|^\.tool-versions$|^LICENCE$|^CODEOWNERS'
+        exclude: '\.(txt|md|png|gif|woff|woff2|ico|baseline|lock|toml|py|js|css|scss|html|sh|ipynb|svg|env|example|yml|yaml|gitkeep|env\.notebook|jsonl)$|^(Make|Proc)file$|^\.vscode/|^(unstructured|django_app)/Dockerfile$|^tests/|^django_app/tests/|^(redbox|django_app)/.vscode/|^django_app/(frontend|static|files)/.*\.(json|lottie|parcelrc|pdf)$|devcontainer.json$|^notebooks/evaluation/data_results/.*\.json$|^\.editorconfig$|^\.gitattributes$|^\.gitignore$|^\.tool-versions$|^LICENCE$|^CODEOWNERS|^django_app\/redbox_app\/redbox_core\/fixtures.*\.json$'

--- a/Makefile
+++ b/Makefile
@@ -303,3 +303,7 @@ aws-login: # Login to AWS
 .PHONY: shell
 shell: # Launch python shell
 	cd django_app && python manage.py shell
+
+.PHONY: local_db_init
+local_db_init: # Run initial set up of the db in local
+	cd django_app && poetry run python manage.py local_db_init

--- a/django_app/redbox_app/redbox_core/fixtures/agents.json
+++ b/django_app/redbox_app/redbox_core/fixtures/agents.json
@@ -1,0 +1,15 @@
+[
+    {
+        "model": "redbox_core.agent",
+        "pk": "60b7e4cc-26e1-48ac-a6f6-a0d563ba89b9",
+        "fields": {
+            "created_at": "2026-05-21T12:14:49.897Z",
+            "modified_at": "2026-05-21T12:14:49.897Z",
+            "name": "Submission_Checker_Agent",
+            "description": "**Submission_Checker_Agent**:\r\nPurpose: Evaluate and check user's uploaded submission\r\nUse when the user wants to:\r\n- Evaluate and check their submission",
+            "agents_max_tokens": 5000,
+            "prompt": "You are Submission_Checker_Agent designed to help DBT civil servants evaluate the quality of ministerial submissions as part of their professional roles. Your goal is to complete the task <Task>{task}</Task> with the expected output: <Expected_Output>{expected_output}</Expected_Output> using the most efficient approach possible.\r\n\r\n## Step 1: Check the existing information\r\n- Check the document input\r\n- Carefully evalute information in <previous_chat_history>\r\n\r\n## Step 2: Retrieve Knowledge Base\r\nAfter handling any document input from Step 1:\r\n- Retrieve Ministerial Submission Template Guidance, evaluation criteria, and preferred evaluation response format from knowledge base.\r\n\r\nGuidelines for Tool Usage:\r\n1. Carefully evaluate the existing information first\r\n2. Please use the available tools to perform multiple parallel tool calls to gather all necessary information.\r\n\r\nExisting information:\r\n<previous_chat_history>{chat_history}</previous_chat_history>\r\n<user_question>{question}</user_question>\r\n<document_metadata>{metadata}</document_metadata>\r\n<previous_tool_error>{previous_tool_error}</previous_tool_error>\r\n<previous_tool_results>{previous_tool_results}</previous_tool_results>\r\n\r\n## Response format:\r\nYour results must include a score and a brief and succinct rationale for your decision based on the given criteria.",
+            "llm_backend": null
+        }
+    }
+]

--- a/django_app/redbox_app/redbox_core/fixtures/tool_settings.json
+++ b/django_app/redbox_app/redbox_core/fixtures/tool_settings.json
@@ -1,0 +1,22 @@
+[
+    {
+        "model": "redbox_core.toolsettings",
+        "pk": "0827537b-77a5-4341-abc0-845a9d9032a2",
+        "fields": {
+            "created_at": "2026-05-21T12:23:33.496Z",
+            "modified_at": "2026-05-21T12:23:33.496Z",
+            "tool": "370c09fa-30a8-43a1-9c3d-701d51857097",
+            "deselect_documents_on_load": false
+        }
+    },
+    {
+        "model": "redbox_core.toolsettings",
+        "pk": "1a51f1b0-e2ee-4d6a-a505-742b866bfb94",
+        "fields": {
+            "created_at": "2026-05-22T08:58:32.679Z",
+            "modified_at": "2026-05-22T08:58:32.679Z",
+            "tool": "3fd68cdd-16ae-4175-a026-ad50a2426517",
+            "deselect_documents_on_load": false
+        }
+    }
+]

--- a/django_app/redbox_app/redbox_core/fixtures/tools.json
+++ b/django_app/redbox_app/redbox_core/fixtures/tools.json
@@ -1,0 +1,26 @@
+[
+    {
+        "model": "redbox_core.tool",
+        "pk": "370c09fa-30a8-43a1-9c3d-701d51857097",
+        "fields": {
+            "created_at": "2026-05-21T12:13:14.052Z",
+            "modified_at": "2026-05-21T12:13:14.052Z",
+            "name": "Invest Lens",
+            "description": "Create investment briefings and company overviews from Data Hub information and external sources.",
+            "slug": "invest-lens",
+            "is_public": true
+        }
+    },
+    {
+        "model": "redbox_core.tool",
+        "pk": "3fd68cdd-16ae-4175-a026-ad50a2426517",
+        "fields": {
+            "created_at": "2026-05-21T12:13:29.090Z",
+            "modified_at": "2026-05-21T12:13:29.090Z",
+            "name": "Submissions Checker",
+            "description": "Get feedback on the quality of your ministerial submission draft, with clear explanations and scores to help you improve it.",
+            "slug": "submissions-checker",
+            "is_public": true
+        }
+    }
+]

--- a/django_app/redbox_app/redbox_core/management/commands/local_db_init.py
+++ b/django_app/redbox_app/redbox_core/management/commands/local_db_init.py
@@ -1,0 +1,32 @@
+from django.core.management import BaseCommand, call_command
+
+from redbox_app.setting_enums import Environment
+
+
+class NotLocalError(OSError):
+    pass
+
+
+class Command(BaseCommand):
+    help = "Initialise db with data from fixtures"
+
+    def handle(self, *_args, **_options):
+        if not Environment.is_local:
+            raise NotLocalError
+
+        self.stdout.write("Making migrations...")
+        call_command("makemigrations")
+
+        self.stdout.write("Running migrations...")
+        call_command("migrate")
+
+        self.stdout.write("Loading tools...")
+        call_command("loaddata", "tools")
+
+        self.stdout.write("Loading tool settings...")
+        call_command("loaddata", "tool_settings")
+
+        self.stdout.write("Loading tool settings...")
+        call_command("loaddata", "agents")
+
+        self.stdout.write(self.style.SUCCESS("Local db ready!"))

--- a/django_app/tests/management/test_local_db_init.py
+++ b/django_app/tests/management/test_local_db_init.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from redbox_app.redbox_core.management.commands.local_db_init import NotLocalError
+from redbox_app.redbox_core.models import Agent, Tool, ToolSettings
+from redbox_app.setting_enums import Environment
+
+
+@pytest.fixture(autouse=True)
+def mock_local_env():
+    with patch.object(Environment, "is_local", new=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_migrations():
+    "Don't run the migrations at the start of the command to reduce test time"
+
+    with patch("django.core.management.call_command") as mock:
+
+        def side_effect(command, *args, **kwargs) -> str | None:
+            if command == "loaddata":
+                return call_command(command, *args, **kwargs)
+
+            return None
+
+        mock.side_effect = side_effect
+        yield mock
+
+
+@pytest.mark.django_db
+class TestInitialiseDbLoadsData:
+    def test_tools_are_created(self):
+        call_command("local_db_init")
+        assert Tool.objects.count() > 0
+        assert ToolSettings.objects.count() > 0
+        assert Agent.objects.count() > 0
+
+    def test_running_twice_does_not_duplicate_tools(self):
+        call_command("local_db_init")
+        initial_count = Tool.objects.count()
+        call_command("local_db_init")
+        second_count = Tool.objects.count()
+
+        assert initial_count == second_count
+
+    def test_raises_if_not_local_environment(self):
+        with patch.object(Environment, "is_local", new=False), pytest.raises(NotLocalError):
+            call_command("local_db_init")

--- a/docs/installation/running-django-locally.md
+++ b/docs/installation/running-django-locally.md
@@ -22,9 +22,8 @@ Ensure you have a postgress database named `redbox-core` owned by a user called 
 
 ## Running the server
 
-Run any migrations
-`poetry run python manage.py make migrations`
-`poetry run python manage.py make migrate`
+Initialise the db, this will apply migrations and add some initial objects.
+`make local_db_init`
 
 Run the server
 `poetry run python manage.py runserver 8091`


### PR DESCRIPTION
## Context

create an easy way to automatically set up required objects in the db

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

Delete these objects from your db and use the cmd to recreate


## Relevant links
