### PR TITLE
improve security of update chat title

### DIFF
--- a/django_app/redbox_app/redbox_core/views/chat_views.py
+++ b/django_app/redbox_app/redbox_core/views/chat_views.py
@@ -50,7 +50,7 @@ class ChatsTitleView(View):
 
     @method_decorator(login_required)
     def post(self, request: HttpRequest, chat_id: uuid.UUID) -> HttpResponse:
-        chat: Chat = get_object_or_404(Chat, id=chat_id)
+        chat: Chat = get_object_or_404(Chat, id=chat_id, user=self.request.user)
         request_body = ChatsTitleView.Title.schema().loads(request.body)
 
         chat.name = request_body.value

--- a/django_app/tests/views/test_chat_views.py
+++ b/django_app/tests/views/test_chat_views.py
@@ -116,6 +116,25 @@ def test_post_chat_title_with_naughty_string(alice: User, chat: Chat, client: Cl
     assert chat.name == "New chat name \ufffd"
 
 
+def test_post_chat_title_cannot_rename_another_users_chat(client: Client, bob: User, chat_with_alice: Chat):
+    # Given
+    client.force_login(bob)
+    url = reverse("chat-titles", kwargs={"chat_id": chat_with_alice.id})
+
+    # When
+    response = client.post(
+        url,
+        data='{"value": "Hacked name"}',
+        content_type="application/json",
+    )
+    original_name = chat_with_alice.name
+    chat_with_alice.refresh_from_db()
+
+    # Then
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert chat_with_alice.name == original_name
+
+
 @pytest.mark.django_db
 def test_staff_user_can_see_route(chat_with_files: Chat, client: Client):
     # Given


### PR DESCRIPTION
## Context

Fix small security issue in the rename chat endpoint

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


