### PR TITLE
bugfix: fix document upload error handling

### DIFF
--- a/django_app/redbox_app/redbox_core/services/documents.py
+++ b/django_app/redbox_app/redbox_core/services/documents.py
@@ -111,7 +111,7 @@ def ingest_file(uploaded_file: UploadedFile, user: User, tool: Tool | None = Non
         ], None
     except Exception as e:
         logger.exception("Unexpected error processing %s.", uploaded_file, exc_info=e)
-        return [str(e)], None
+        raise
     else:
         async_task(ingest, file.id, task_name=file.unique_name, group="ingest")
         return [], file

--- a/django_app/tests/views/test_document_views.py
+++ b/django_app/tests/views/test_document_views.py
@@ -2,7 +2,8 @@ import logging
 import uuid
 from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
@@ -10,6 +11,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import UploadedFile
+from django.db import IntegrityError
 from django.test import Client, RequestFactory
 from django.urls import reverse
 
@@ -693,6 +695,19 @@ def test_upload_invalid_document(alice, client, original_file, default_tool):
     # Then
     assert response.status_code == HTTPStatus.OK
     assert f"Error with {original_file.name}: File type  not supported" in response_content
+
+
+@mock.patch("redbox_app.redbox_core.services.documents.File.objects.create")
+@pytest.mark.django_db
+def test_upload_document_exception(create_file_mock, alice, client, original_file):
+    """
+    Test the API endpoint handles unexpected errors correctly.
+    """
+    client.force_login(alice)
+    create_file_mock.side_effect = IntegrityError("db exploded")
+
+    with pytest.raises(IntegrityError):
+        client.post(reverse("document-upload"), {"file": original_file})
 
 
 @pytest.mark.django_db

--- a/django_app/tests/views/test_document_views.py
+++ b/django_app/tests/views/test_document_views.py
@@ -3,7 +3,7 @@ import uuid
 from http import HTTPStatus
 from pathlib import Path
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from botocore.exceptions import ClientError


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

Attribute error: None type object file has no attribute 'status'

## What

Just raise the error so django handles returning the 500

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)
