### PR TITLE
fix: prompts not sending / 'stuck'

### DIFF
--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -93,6 +93,35 @@ async def test_chat_consumer_with_new_session(
         await refresh_from_db(uploaded_file)
 
 
+@pytest.mark.django(transaction=True)
+@pytest.mark.asyncio
+async def test_chat_consumer_existing_session_files_with_no_prior_messages(
+    alice: User, uploaded_file: File, agents_list, mocked_content
+):
+    # create session with no messages
+    session = await Chat.objects.acreate(name="empty session", user=alice)
+
+    with patch("redbox_app.redbox_core.consumers.get_all_agents", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = agents_list
+        communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
+        communicator.scope["user"] = alice
+        connected, _ = await communicator.connect(timeout=5)
+        assert connected
+
+        # now send with no prior messages but with a sessionID and Selected files
+        with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox.graph", new=mocked_content):
+            await communicator.send_json_to(
+                {
+                    "message": "Hello World",
+                    "sessionId": str(session.id),
+                    "selectedFiles": [str(uploaded_file.id)],
+                }
+            )
+            # should not get error, but a session id as response
+            response = await communicator.receive_json_from(timeout=5)
+            assert response["type"] != "error"
+
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_chat_consumer_staff_user(agents_list: list, staff_user: User, mocked_connect: Connect):


### PR DESCRIPTION
## Context

When a user is in a chat, and the user has pressed enter or the green arrow to send their prompt, the green arrow stays in the ‘sending’ state, but the prompt is not sending. Prompt can then still be edited. (see image below) 

## What

Replicating this issue then implementing the fix: 

The issue looks as if the send button is being almost blocked/disabled, as the enableSubmit in message-input.js used when loading the page, so I think this button is not re enabled in the circumstance with selecting files. Sorry if explaining badly - thought good to update to give someone a head start on it if useful.
If this is the problem then possible fix could be to call enableSubmit dynamically, so always gets fresh instance, and to add an else to consumers.py around if latest_,message, for the case when it is none

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
