### PR TITLE
fix: prompts not sending / 'stuck'

### DIFF
--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -194,7 +194,7 @@ class FileUpload extends HTMLElement {
             }
         });
 
-        listenEvent(Events.FILE_UPLOADS_PROCESSED, () => this.messageInput?.enableSubmit());
+        listenEvent(Events.FILE_UPLOADS_PROCESSED, this.messageInput?.enableSubmit);
         listenEvent(Events.FILE_UPLOADS_REMOVED, () => {
             if (!this.messageInput?.getValue()) this.messageInput.reset();
             this.messageInput?.enableSubmit();

--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -194,7 +194,7 @@ class FileUpload extends HTMLElement {
             }
         });
 
-        listenEvent(Events.FILE_UPLOADS_PROCESSED, this.messageInput?.enableSubmit);
+        listenEvent(Events.FILE_UPLOADS_PROCESSED, () => this.messageInput?.enableSubmit);
         listenEvent(Events.FILE_UPLOADS_REMOVED, () => {
             if (!this.messageInput?.getValue()) this.messageInput.reset();
             this.messageInput?.enableSubmit();

--- a/django_app/frontend/src/js/web-components/documents/file-upload.js
+++ b/django_app/frontend/src/js/web-components/documents/file-upload.js
@@ -194,7 +194,7 @@ class FileUpload extends HTMLElement {
             }
         });
 
-        listenEvent(Events.FILE_UPLOADS_PROCESSED, () => this.messageInput?.enableSubmit);
+        listenEvent(Events.FILE_UPLOADS_PROCESSED, () => this.messageInput?.enableSubmit());
         listenEvent(Events.FILE_UPLOADS_REMOVED, () => {
             if (!this.messageInput?.getValue()) this.messageInput.reset();
             this.messageInput?.enableSubmit();

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -129,9 +129,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 if latest_message:
                     latest_files = latest_message.selected_files.all()
                     previous_selected_files = [file async for file in latest_files]
-                else:
-                    previous_selected_files = []
-
             else:
                 previous_selected_files = []
         else:

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -129,6 +129,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 if latest_message:
                     latest_files = latest_message.selected_files.all()
                     previous_selected_files = [file async for file in latest_files]
+                else:
+                    previous_selected_files = []
 
             else:
                 previous_selected_files = []

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -944,7 +944,10 @@ async def test_connect_with_agents_update_via_db(agents_list: list, alice: User)
 
         assert "Fake_Agent" not in list(ChatConsumer.redbox.agent_configs.keys())
         assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].agents_max_tokens == 100
-        assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name == "gpt-4o"
+        assert (
+            ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name
+            == "anthropic.claude-3-7-sonnet-20250219-v1:0"
+        )
 
 
 @pytest.mark.parametrize(

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -93,7 +93,7 @@ async def test_chat_consumer_with_new_session(
         await refresh_from_db(uploaded_file)
 
 
-@pytest.mark.django(transaction=True)
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_chat_consumer_existing_session_files_with_no_prior_messages(
     alice: User, uploaded_file: File, agents_list, mocked_content

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -898,6 +898,7 @@ def refresh_from_db(obj: Model) -> None:
     obj.refresh_from_db()
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_connect_with_agents_cache(
     agents_list: list,
@@ -911,7 +912,7 @@ async def test_connect_with_agents_cache(
         # First connection - should call get_all_agents
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = alice
-        await communicator.connect()
+        await communicator.connect(timeout=5)
         assert mock_get.call_count == 1
 
         # Second connection - should use cache
@@ -924,6 +925,7 @@ async def test_connect_with_agents_cache(
         await comm2.disconnect()
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_connect_with_agents_update_via_db(agents_list: list, alice: User):
     """

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -540,7 +540,7 @@ async def test_chat_consumer_get_ai_settings(
         mock_get.return_value = agents_list
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = chat_with_alice.user
-        connected, _ = await communicator.connect()
+        connected, _ = await communicator.connect(timeout=5)
         assert connected
 
         with patch(

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -96,7 +96,7 @@ async def test_chat_consumer_with_new_session(
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_chat_consumer_existing_session_files_with_no_prior_messages(
-    alice: User, uploaded_file: File, agents_list, mocked_content
+    alice: User, uploaded_file: File, agents_list, mocked_connect
 ):
     # create session with no messages
     session = await Chat.objects.acreate(name="empty session", user=alice)
@@ -109,7 +109,7 @@ async def test_chat_consumer_existing_session_files_with_no_prior_messages(
         assert connected
 
         # now send with no prior messages but with a sessionID and Selected files
-        with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox.graph", new=mocked_content):
+        with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox.graph", new=mocked_connect):
             await communicator.send_json_to(
                 {
                     "message": "Hello World",

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -93,6 +93,35 @@ async def test_chat_consumer_with_new_session(
         await refresh_from_db(uploaded_file)
 
 
+@pytest.mark.django(transaction=True)
+@pytest.mark.asyncio
+async def test_chat_consumer_existing_session_files_with_no_prior_messages(
+    alice: User, uploaded_file: File, agents_list, mocked_content
+):
+    # create session with no messages
+    session = await Chat.objects.acreate(name="empty session", user=alice)
+
+    with patch("redbox_app.redbox_core.consumers.get_all_agents", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = agents_list
+        communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
+        communicator.scope["user"] = alice
+        connected, _ = await communicator.connect(timeout=5)
+        assert connected
+
+        # now send with no prior messages but with a sessionID and Selected files
+        with patch("redbox_app.redbox_core.consumers.ChatConsumer.redbox.graph", new=mocked_content):
+            await communicator.send_json_to(
+                {
+                    "message": "Hello World",
+                    "sessionId": str(session.id),
+                    "selectedFiles": [str(uploaded_file.id)],
+                }
+            )
+            # should not get error, but a session id as response
+            response = await communicator.receive_json_from(timeout=5)
+            assert response["type"] != "error"
+
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_chat_consumer_staff_user(agents_list: list, staff_user: User, mocked_connect: Connect):


### PR DESCRIPTION
## Context

When a user is in a chat, and the user has pressed enter or the green arrow to send their prompt, the green arrow stays in the ‘sending’ state, but the prompt is not sending. Prompt can then still be edited. (see image below)

## What

Replicating this issue then implementing the fix:

The issue looks as if the send button is being almost blocked/disabled, as the enableSubmit in message-input.js used when loading the page, so I think this button is not re enabled in the circumstance with selecting files. Sorry if explaining badly - thought good to update to give someone a head start on it if useful.
If this is the problem then possible fix could be to call enableSubmit dynamically, so always gets fresh instance, and to add an else to consumers.py around if latest_,message, for the case when it is none

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [x] No


## Relevant links
