### PR TITLE
bugfix/fix-agent-flaky-test

### DIFF
--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -876,7 +876,10 @@ async def test_connect_with_agents_cache(
     staff_user: User,
 ):
     ChatConsumer.redbox = None
-    with patch("redbox_app.redbox_core.consumers.get_all_agents", new_callable=AsyncMock) as mock_get:
+    with (
+        patch("redbox_app.redbox_core.consumers.get_all_agents", new_callable=AsyncMock) as mock_get,
+        patch("redbox_app.redbox_core.consumers.Redbox"),
+    ):
         mock_get.return_value = agents_list
 
         # First connection - should call get_all_agents


### PR DESCRIPTION
## Context
The `test_connect_with_agents_cache` test regularly fails with a timeout error in the CI pipeline
<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
The failing test is checking agents are cached between calls to the chat consumer connection logic. The code being tested initialises an instance of the `Redbox` class, which as part of it's `__init__` call makes external connections to OpenSearch. No OpenSearch logic is required for this test, so instead this change mocks out the Redbox class and allows the test to avoid the external connections 

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
