### PR TITLE
fix: Fallback for Throttling Not working + additional error in subs checker with subgraph

### DIFF
--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -895,6 +895,7 @@ async def test_connect_with_agents_cache(
         await comm2.disconnect()
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_connect_with_agents_update_via_db(agents_list: list, alice: User):
     """
@@ -913,10 +914,7 @@ async def test_connect_with_agents_update_via_db(agents_list: list, alice: User)
 
         assert "Fake_Agent" not in list(ChatConsumer.redbox.agent_configs.keys())
         assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].agents_max_tokens == 100
-        assert (
-            ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name
-            == "anthropic.claude-3-7-sonnet-20250219-v1:0"
-        )
+        assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name == "gpt-4o"
 
 
 @pytest.mark.parametrize(

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -914,7 +914,10 @@ async def test_connect_with_agents_update_via_db(agents_list: list, alice: User)
 
         assert "Fake_Agent" not in list(ChatConsumer.redbox.agent_configs.keys())
         assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].agents_max_tokens == 100
-        assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name == "gpt-4o"
+        assert (
+            ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name
+            == "anthropic.claude-3-7-sonnet-20250219-v1:0"
+        )
 
 
 @pytest.mark.parametrize(

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -913,7 +913,10 @@ async def test_connect_with_agents_update_via_db(agents_list: list, alice: User)
 
         assert "Fake_Agent" not in list(ChatConsumer.redbox.agent_configs.keys())
         assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].agents_max_tokens == 100
-        assert ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name == "gpt-4o"
+        assert (
+            ChatConsumer.redbox.agent_configs["Internal_Retrieval_Agent"].llm_backend.name
+            == "anthropic.claude-3-7-sonnet-20250219-v1:0"
+        )
 
 
 @pytest.mark.parametrize(

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -511,7 +511,7 @@ async def test_chat_consumer_get_ai_settings(
         mock_get.return_value = agents_list
         communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
         communicator.scope["user"] = chat_with_alice.user
-        connected, _ = await communicator.connect()
+        connected, _ = await communicator.connect(timeout=5)
         assert connected
 
         with patch(

--- a/redbox/redbox/chains/components.py
+++ b/redbox/redbox/chains/components.py
@@ -1,11 +1,13 @@
 import logging
 import time
 from functools import cache
+from typing import Any
 
 from botocore.exceptions import ClientError, ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError
 from dotenv import load_dotenv
 from langchain.chat_models import init_chat_model
 from langchain_community.embeddings import BedrockEmbeddings
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.embeddings import Embeddings, FakeEmbeddings
 from langchain_core.runnables import Runnable
 from langchain_core.tools import StructuredTool
@@ -39,6 +41,41 @@ load_dotenv()
 _FALLBACK_CACHE = {}
 
 FALLBACK_COOLDOWN_SECS = 420  # 7 mins feels ok
+
+_THROTTLING_CODES = frozenset(
+    {"ServiceUnavailableException", "ThrottlingException", "RateLimitExceeded", "TooManyRequestsException"}
+)
+
+_CONNECTION_EXCEPTIONS = (TimeoutError, ConnectionError, EndpointConnectionError, ConnectTimeoutError, ReadTimeoutError)
+
+
+def _is_throttling_error(error: Exception) -> bool:
+    if isinstance(error, ClientError):
+        return error.response["Error"].get("Code", "") in _THROTTLING_CODES
+    return isinstance(error, _CONNECTION_EXCEPTIONS)
+
+
+class _FallbackCacheCallback(BaseCallbackHandler):
+    """
+    Updates _FALLBACK_CACHE when the primary LLM fails with a throttling error
+    """
+
+    def __init__(self, model_name: str, fallback_backend: ChatLLMBackend):
+        self._model_name = model_name
+        self._fallback_backend = fallback_backend
+
+    def on_llm_error(self, error: Exception, **kwargs: Any) -> None:
+        if _is_throttling_error(error):
+            logger.warning(
+                "Runtime throttling (%s) with %s - caching fallback for %ds",
+                type(error).__name__,
+                self._model_name,
+                FALLBACK_COOLDOWN_SECS,
+            )
+            _FALLBACK_CACHE[self._model_name] = {
+                "until": time.time() + FALLBACK_COOLDOWN_SECS,
+                "backend": self._fallback_backend,
+            }
 
 
 def get_chat_llm(
@@ -81,43 +118,14 @@ def get_chat_llm(
         )
         return _init_model(cache_entry["backend"])
 
-    try:
-        return _init_model(model)
+    primary = _init_model(model)
+    fallback_llm = _init_model(fallback_backend)
 
-    except ClientError as e:
-        error_code = e.response["Error"].get("Code", "")
-        if error_code in (
-            "ServiceUnavailableException",
-            "ThrottlingException",
-            "RateLimitExceeded",
-            "TooManyRequestsException",
-        ):
-            logger.warning(
-                "Rate/service limit (%s) encountered with %s. Falling back to %s",
-                error_code,
-                model.name,
-                fallback_backend.name,
-            )
-            _FALLBACK_CACHE[model.name] = {
-                "until": time.time() + FALLBACK_COOLDOWN_SECS,
-                "backend": fallback_backend,
-            }
-            return _init_model(fallback_backend)
-        else:
-            raise e
-
-    except (TimeoutError, ConnectionError, EndpointConnectionError, ConnectTimeoutError, ReadTimeoutError) as e:
-        logger.warning(
-            "Connection issue (%s) with %s. Falling back to %s",
-            str(e),
-            model.name,
-            fallback_backend.name,
-        )
-        _FALLBACK_CACHE[model.name] = {
-            "until": time.time() + FALLBACK_COOLDOWN_SECS,
-            "backend": fallback_backend,
-        }
-        return _init_model(fallback_backend)
+    primary_with_cache_callback = primary.with_config(callbacks=[_FallbackCacheCallback(model.name, fallback_backend)])
+    return primary_with_cache_callback.with_fallbacks(
+        [fallback_llm],
+        exceptions_to_handle=(ClientError, *_CONNECTION_EXCEPTIONS),
+    )
 
 
 @cache

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -15,11 +15,12 @@ from uuid import uuid4
 
 import pandas as pd
 from botocore.exceptions import EventStreamError
+from emoji import config
 from langchain.schema import StrOutputParser
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
-from langchain_core.runnables import Runnable, RunnableLambda, RunnableParallel
+from langchain_core.runnables import Runnable, RunnableConfig, RunnableLambda, RunnableParallel
 from langchain_core.tools import StructuredTool
 from langchain_core.vectorstores import VectorStoreRetriever
 from langgraph.types import Command
@@ -44,9 +45,9 @@ from redbox.models.chain import (
 )
 from redbox.models.graph import ROUTE_NAME_TAG, RedboxActivityEvent, RedboxEventType
 from redbox.models.prompts import (
-    USER_FEEDBACK_EVAL_PROMPT,
-    DATAHUB_USER_FEEDBACK,
     DATAHUB_ADD_FOLLOWUP_PROMPT_RECOMMENDATIONS,
+    DATAHUB_USER_FEEDBACK,
+    USER_FEEDBACK_EVAL_PROMPT,
 )
 from redbox.models.settings import ChatLLMBackend
 from redbox.transform import combine_documents, flatten_document_state, join_result_with_token_limit
@@ -82,13 +83,13 @@ def build_chat_pattern(
     If tools are supplied, can also set state["tool_calls"].
     """
 
-    def _chat(state: RedboxState) -> dict[str, Any]:
+    def _chat(state: RedboxState, config: RunnableConfig) -> dict[str, Any]:
         llm = get_chat_llm(state.request.ai_settings.chat_backend, tools=tools)
         return build_llm_chain(
             prompt_set=prompt_set,
             llm=llm,
             final_response_chain=final_response_chain,
-        ).invoke(state)
+        ).invoke(state, config=config)
 
     return _chat
 
@@ -113,7 +114,7 @@ def build_merge_pattern(
     BACKOFF_FACTOR = 1.5
 
     @RunnableLambda
-    def _merge(state: RedboxState) -> dict[str, Any]:
+    def _merge(state: RedboxState, config: RunnableConfig) -> dict[str, Any]:
         llm = get_chat_llm(state.request.ai_settings.chat_backend, tools=tools)
 
         if not state.documents.groups:
@@ -134,7 +135,7 @@ def build_merge_pattern(
             try:
                 merge_response = build_llm_chain(
                     prompt_set=prompt_set, llm=llm, final_response_chain=final_response_chain
-                ).invoke(merge_state)
+                ).invoke(merge_state, config=config)
 
                 # if reaches a successful citation, exit the loop
                 break
@@ -183,7 +184,7 @@ def build_stuff_pattern(
     """
 
     @RunnableLambda
-    def _stuff(state: RedboxState) -> dict[str, Any]:
+    def _stuff(state: RedboxState, config: RunnableConfig) -> dict[str, Any]:
         if model is not None:
             llm = get_chat_llm(model, tools=tools)
         else:
@@ -199,7 +200,7 @@ def build_stuff_pattern(
             summary_multiagent_flag=summary_multiagent_flag,
         )
 
-        events = [event for event in chain.stream(state)]
+        events = [event for event in chain.stream(state, config=config)]
         return sum(events, {})
 
     return _stuff
@@ -831,9 +832,9 @@ def invoke_custom_state(
         activity_node = build_activity_log_node(
             RedboxActivityEvent(message=f"{agent_name} is completing task: {agent_task['task']}")
         )
-        activity_node.invoke(state)
+        activity_node.invoke(state, config=config)
         ## invoke the subgraph
-        response = subgraph.invoke(subgraph_state)  # the LLM response is streamed
+        response = subgraph.invoke(subgraph_state, config=config)  # the LLM response is streamed
         # invoking this subgraph will change original state.question - we correct the state question in subsequent nodes
 
         return response

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -82,7 +82,7 @@ def build_chat_pattern(
     If tools are supplied, can also set state["tool_calls"].
     """
 
-    def _chat(state: RedboxState, config: RunnableConfig) -> dict[str, Any]:
+    def _chat(state: RedboxState, config: RunnableConfig | None = None) -> dict[str, Any]:
         llm = get_chat_llm(state.request.ai_settings.chat_backend, tools=tools)
         return build_llm_chain(
             prompt_set=prompt_set,

--- a/redbox/redbox/graph/nodes/processes.py
+++ b/redbox/redbox/graph/nodes/processes.py
@@ -15,7 +15,6 @@ from uuid import uuid4
 
 import pandas as pd
 from botocore.exceptions import EventStreamError
-from emoji import config
 from langchain.schema import StrOutputParser
 from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.documents import Document
@@ -815,7 +814,7 @@ def invoke_custom_state(
     model: ChatLLMBackend | None = None,
 ):
     @RunnableLambda
-    def _invoke_custom_state(state: RedboxState):
+    def _invoke_custom_state(state: RedboxState, config: RunnableConfig):
         # transform the state to the subgraph state
         subgraph = custom_graph(
             all_chunks_retriever=all_chunks_retriever, use_as_agent=use_as_agent, debug=debug, model=model

--- a/redbox/tests/graph/test_fallback_llm.py
+++ b/redbox/tests/graph/test_fallback_llm.py
@@ -62,6 +62,12 @@ def test_get_chat_llm_fallback_on_throttling(mocker, fake_model_backend, fake_ai
     call_kwargs = primary_mock.with_config.return_value.with_fallbacks.call_args[1]
     assert ClientError in call_kwargs["exceptions_to_handle"]
 
+    callback_list = primary_mock.with_config.call_args[1]["callbacks"]
+    assert any(isinstance(cb, _FallbackCacheCallback) for cb in callback_list)
+
+    fallbacks_arg = primary_mock.with_config.return_value.with_fallbacks.call_args[0][0]
+    assert fallback_mock in fallbacks_arg
+
 
 def test_get_chat_llm_wires_connection_error_fallback(mocker, fake_model_backend, fake_ai_settings):
     primary_mock = MagicMock(name="PrimaryModel")

--- a/redbox/tests/graph/test_fallback_llm.py
+++ b/redbox/tests/graph/test_fallback_llm.py
@@ -1,18 +1,18 @@
 import time
-import pytest
 from unittest.mock import MagicMock
-from botocore.exceptions import ClientError
 
-from redbox.models.chain import ChatLLMBackend, AISettings
-from redbox.chains.components import get_chat_llm, _FALLBACK_CACHE
+import pytest
+from botocore.exceptions import ClientError, ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError
+
+import redbox.chains.components as components
+from redbox.chains.components import _FallbackCacheCallback, get_chat_llm
+from redbox.models.chain import AISettings, ChatLLMBackend
 
 pytestmark = pytest.mark.usefixtures("clear_fallback_cache")
 
 
 @pytest.fixture(autouse=True)
 def clear_fallback_cache():
-    import redbox.chains.components as components
-
     if hasattr(components, "_FALLBACK_CACHE"):
         components._FALLBACK_CACHE.clear()
     yield
@@ -38,42 +38,48 @@ def _make_client_error(code: str):
 
 
 def test_get_chat_llm_primary_success(mocker, fake_model_backend, fake_ai_settings):
-    fake_model = MagicMock(name="FakeChatModel")
-    mocker.patch("redbox.chains.components.init_chat_model", return_value=fake_model)
+    primary_mock = MagicMock(name="PrimaryModel")
+    fallback_mock = MagicMock(name="FallbackModel")
+    mocker.patch("redbox.chains.components.init_chat_model", side_effect=[primary_mock, fallback_mock])
 
-    result = get_chat_llm(fake_model_backend, fake_ai_settings)
+    get_chat_llm(fake_model_backend, fake_ai_settings)
 
-    assert result == fake_model
-    assert fake_model.bind_tools not in (None,)
+    primary_mock.with_config.assert_called_once()
+    primary_mock.with_config.return_value.with_fallbacks.assert_called_once()
+
+    fallbacks_arg = primary_mock.with_config.return_value.with_fallbacks.call_args[0][0]
+
+    assert fallback_mock in fallbacks_arg
 
 
 def test_get_chat_llm_fallback_on_throttling(mocker, fake_model_backend, fake_ai_settings):
-    init_mock = mocker.patch("redbox.chains.components.init_chat_model")
-
-    init_mock.side_effect = [
-        _make_client_error("ThrottlingException"),
-        MagicMock(name="FallbackModel"),
-    ]
+    primary_mock = MagicMock(name="PrimaryModel")
+    fallback_mock = MagicMock(name="FallbackModel")
+    mocker.patch("redbox.chains.components.init_chat_model", side_effect=[primary_mock, fallback_mock])
 
     get_chat_llm(fake_model_backend, fake_ai_settings)
-    assert fake_model_backend.name in _FALLBACK_CACHE
+
+    call_kwargs = primary_mock.with_config.return_value.with_fallbacks.call_args[1]
+    assert ClientError in call_kwargs["exceptions_to_handle"]
 
 
-def test_get_chat_llm_fallback_on_timeout(mocker, fake_model_backend, fake_ai_settings):
-    init_mock = mocker.patch("redbox.chains.components.init_chat_model")
-
-    init_mock.side_effect = [
-        TimeoutError("timed out"),
-        MagicMock(name="FallbackModel"),
-    ]
+def test_get_chat_llm_wires_connection_error_fallback(mocker, fake_model_backend, fake_ai_settings):
+    primary_mock = MagicMock(name="PrimaryModel")
+    fallback_mock = MagicMock(name="FallbackModel")
+    mocker.patch("redbox.chains.components.init_chat_model", side_effect=[primary_mock, fallback_mock])
 
     get_chat_llm(fake_model_backend, fake_ai_settings)
-    assert fake_model_backend.name in _FALLBACK_CACHE
+
+    call_kwargs = primary_mock.with_config.return_value.with_fallbacks.call_args[1]
+    handled = call_kwargs["exceptions_to_handle"]
+
+    assert TimeoutError in handled
+    assert ConnectTimeoutError in handled
+    assert EndpointConnectionError in handled
+    assert ReadTimeoutError in handled
 
 
 def test_get_chat_llm_uses_cached_fallback(mocker, fake_model_backend, fake_ai_settings):
-    import redbox.chains.components as components
-
     fallback_backend = ChatLLMBackend(name="anthropic.fallback", provider="bedrock")
     components._FALLBACK_CACHE[fake_model_backend.name] = {
         "until": time.time() + 60,
@@ -93,14 +99,36 @@ def test_get_chat_llm_uses_cached_fallback(mocker, fake_model_backend, fake_ai_s
 
 
 def test_get_chat_llm_cache_expires_and_returns_to_primary(mocker, fake_model_backend, fake_ai_settings):
-    import redbox.chains.components as components
-
     components._FALLBACK_CACHE[fake_model_backend.name] = {
         "until": time.time() - 1,  # expired
         "backend": ChatLLMBackend(name="anthropic.fallback", provider="bedrock"),
     }
 
-    mocker.patch("redbox.chains.components.init_chat_model", return_value=MagicMock(name="PrimaryModel"))
-
+    init_mock = mocker.patch("redbox.chains.components.init_chat_model", return_value=MagicMock(name="PrimaryModel"))
     get_chat_llm(fake_model_backend, fake_ai_settings)
-    assert components._FALLBACK_CACHE.get(fake_model_backend.name)
+
+    # once the cache has expired; the primary model should be the first call
+    assert init_mock.call_args_list[0].kwargs["model"] == fake_model_backend.name
+
+
+def test_fallback_cache_callback_updates_cache_on_throttling():
+    components._FALLBACK_CACHE.clear()
+    fallback_backend = ChatLLMBackend(name="anthropic.claude-3-7-sonnet-20250219-v1:0", provider="bedrock")
+    cb = _FallbackCacheCallback("primary-model", fallback_backend)
+
+    cb.on_llm_error(_make_client_error("ServiceUnavailableException"))
+
+    assert "primary-model" in components._FALLBACK_CACHE
+    entry = components._FALLBACK_CACHE["primary-model"]
+    assert entry["until"] > time.time()
+    assert entry["backend"] == fallback_backend
+
+
+def test_fallback_cache_callback_ignores_non_throttling_error():
+    components._FALLBACK_CACHE.clear()
+    fallback_backend = ChatLLMBackend(name="anthropic.claude-3-7-sonnet-20250219-v1:0", provider="bedrock")
+    cb = _FallbackCacheCallback("primary-model", fallback_backend)
+
+    cb.on_llm_error(_make_client_error("ValidationException"))
+
+    assert "primary-model" not in components._FALLBACK_CACHE


### PR DESCRIPTION
… works for subraph in submissions checker

## Context

When there is a throttling issue i.e. botocore.errorfactory.ServiceUnavailableException: An error occurred (ServiceUnavailableException) when calling the InvokeModelWithResponseStream operation (reached max retries: 4): Too many connections, please wait before trying again. Assist should be using the fallback model. However, the current logic is not working and the fallback model is not called hence causing app to fail.


## What

Root cause of the issue - the fallback logic in get_chat_llm wrapped init_chat_model in a try/except loop, but the get_chat_llm creates a python wrapper object, and does not many any API calls. So throttling errors surface later on at invocation, where the try/except has already exited and the exception is not caught.

The change here puts the fallback at the model level with langchain with_fallbacks, so fallback errors are caught when they happen.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
