### PR TITLE
fix: decrease token budget for tabular chunks

### DIFF
--- a/redbox/redbox/loader/chunking/chunkers/tabular.py
+++ b/redbox/redbox/loader/chunking/chunkers/tabular.py
@@ -8,10 +8,13 @@ from langchain_core.documents import Document
 from redbox.models.chain import GeneratedMetadata
 from redbox.loader.chunking.base import BaseChunker
 from redbox.transform import bedrock_tokeniser
+from redbox.models.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
 tokeniser = bedrock_tokeniser
+
+env = get_settings()
 
 
 class TabularDocumentChunker(BaseChunker):
@@ -19,8 +22,10 @@ class TabularDocumentChunker(BaseChunker):
     Chunker that loads pre-processed tabular elements
     """
 
-    MAX_CHARS = 50_000
-    MAX_TOKENS = 6_000
+    MAX_CHARS = env.embedding_max_chars
+    MAX_TOKENS = (
+        env.embedding_max_tokens - 2_500
+    )  # subtracted 2500 tokens from max for breathing room on tokeniser inconsistencies
 
     def _split_table(self, text: str) -> list[str]:
         """Split a tabular document into chunks whilst preserving the header."""

--- a/redbox/redbox/loader/chunking/chunkers/tabular.py
+++ b/redbox/redbox/loader/chunking/chunkers/tabular.py
@@ -20,7 +20,7 @@ class TabularDocumentChunker(BaseChunker):
     """
 
     MAX_CHARS = 50_000
-    MAX_TOKENS = 8_000
+    MAX_TOKENS = 6_000
 
     def _split_table(self, text: str) -> list[str]:
         """Split a tabular document into chunks whilst preserving the header."""

--- a/redbox/redbox/models/settings.py
+++ b/redbox/redbox/models/settings.py
@@ -98,6 +98,9 @@ class Settings(BaseSettings):
     embedding_max_batch_size: int = 512
     embedding_document_field_name: str = "embedding"
 
+    embedding_max_chars: int = 50_000  # Amazon Titan max embedding chars 50k - https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html
+    embedding_max_tokens: int = 8_192  # Amazon Titan max embedding tokens 8192 - https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html
+
     document_ingest_lock_timeout_seconds: int = os.environ.get("DOCUMENT_INGEST_LOCK_TIMEOUT_SECONDS", 1800)
     document_large_pdf_bytes_threshold: int = os.environ.get("DOCUMENT_LARGE_PDF_BYTES_THRESHOLD", 5 * 1024 * 1024)
     document_large_pdf_timeout: int = os.environ.get("DOCUMENT_LARGE_PDF_TIMEOUT", 900)


### PR DESCRIPTION
## Context
To prevent embedding overflow error on tabular chunks. Token budget is 8192 but still overflowed indicating a deviation in the tokeniser. This serves as a simple fix.

## What
Decreases token quota for tabualr chunks to prevent overflow.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
