### PR TITLE
News search agent is not a default agent

### DIFF
--- a/redbox/redbox/graph/agents/configs.py
+++ b/redbox/redbox/graph/agents/configs.py
@@ -241,7 +241,7 @@ agent_configs: Dict[str, AgentConfig] = {
         description=prompts.NEWS_SEARCH_AGENT_DESC,
         prompt=prompt_configs["News_Search_Agent"],
         parser=None,
-        default_agent=True,
+        default_agent=False,
         agents_max_tokens=10000,
     ),
     "Summarisation_Agent": AgentConfig(


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

News search agent is intended for use only in Negotiation Planner.
However it's currently configured as a default agent, so it is available to Assist when no skill is selected.
This PR makes it not a default agent.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No

## Relevant links
