### PR TITLE
fix: add unstructured tesseract to path

### DIFF
--- a/django_app/Dockerfile
+++ b/django_app/Dockerfile
@@ -51,9 +51,10 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN which tesseract && tesseract --version
-
 WORKDIR /usr/src/app
+
+RUN libreoffice --version
+RUN tesseract --version
 
 COPY README.md .
 COPY redbox/ .
@@ -70,7 +71,5 @@ EXPOSE 8080
 
 RUN chmod +x start.sh
 RUN chmod +x health.sh
-
-RUN libreoffice --version
 
 CMD ["/bin/sh", "./start.sh"]

--- a/django_app/Dockerfile
+++ b/django_app/Dockerfile
@@ -44,10 +44,14 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y \
     libreoffice \
     libreoffice-writer \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    libpq-dev \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install --yes libpq-dev curl > /dev/null
+RUN which tesseract && tesseract --version
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Context
Adds unstructured tesseract binary to docker to fix files that fallback to unstructured partition (ie. anything that is not normal file suffix ie. not pdf, docx, pptx, xlsx, csv, md, or html)

## What
Adds binary.

This has not been tested yet due to limitations on getting a docker build on local. I suggest testing this on test env before merging.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
