### PR TITLE
fix: remove rebase annotation from OECD search agent prompt

### DIFF
--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -485,7 +485,6 @@ OECD_SEARCH_AGENT_DESC = """
 **Oecd_Search_Agent**:
 Purpose: Perform searches across the oecd.org website domain only
 Use when the user wants to search for information or reports on the following topics: Social development, social policy, social issues, education, labour, health, taxation, infrastructure, international development, international cooperation, international equality, international inequality, standards of living, economic development, economic policy, productivity, technology, digital development, geopolitics, environmental issues, sustainability, policy advice on these themes, national policy on these themes, international policy on these themes.
->>>>>>> 0445b352 (WIP - Create OECD search agent.)
 """
 
 WTO_SEARCH_AGENT_DESC = """


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

A comment from the rebase of a feature branch onto dev was accidentaly included in the `OECD_SEARCH_AGENT_DESCRIPTION`.

This PR removes that comment.

## Have you written unit tests?
- [ ] Yes
- [x] No: n/a


## Are there any specific instructions on how to test this change?

- [ ] Yes (if so provide more detail)
- [x] No


## Relevant links
