### PR TITLE
feat: fix datadog llm observability related bug

### DIFF
--- a/redbox/redbox/graph/agents/configs.py
+++ b/redbox/redbox/graph/agents/configs.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from redbox.chains.parser import BaseCumulativeTransformOutputParser, ClaudeParser
 from redbox.models import prompts
@@ -188,6 +188,8 @@ prompt_configs: Dict[str, PromptConfig] = {
 
 
 class AgentConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     name: str = Field(description="Name of agent")
     description: str = Field(description="Agent desciption used for planning", default="")
     prompt: PromptConfig = Field(description="Prompts used for this agent")
@@ -204,6 +206,17 @@ class AgentConfig(BaseModel):
         exclude=True,
     )
     default_agent: bool = Field(description="Is this a default redbox worker agents", default=False)
+
+    def model_dump(self, *args, **kwargs):
+        exclude = kwargs.pop("exclude", None)
+        if exclude is None:
+            exclude = {"parser"}
+        elif isinstance(exclude, set):
+            exclude = exclude | {"parser"}
+        elif isinstance(exclude, dict):
+            exclude = dict(exclude)
+            exclude["parser"] = True
+        return super().model_dump(*args, **kwargs, exclude=exclude)
 
 
 # This dict is for storing agent configs for all the agents.

--- a/redbox/redbox/graph/agents/configs.py
+++ b/redbox/redbox/graph/agents/configs.py
@@ -210,7 +210,20 @@ class AgentConfig(BaseModel):
 
     @field_serializer("parser", when_used="json")
     def serialize_parser(self, value, info):
-        return None
+        if value is None:
+            return None
+        try:
+            cls_name = value.__class__.__name__
+            pydantic_obj = getattr(value, "pydantic_object", None)
+            pydantic_name = None
+            if pydantic_obj is not None:
+                pydantic_name = getattr(pydantic_obj, "__name__", str(pydantic_obj))
+            summary = {"type": cls_name}
+            if pydantic_name:
+                summary["pydantic_object"] = pydantic_name
+            return summary
+        except Exception:
+            return {"type": value.__class__.__name__}
 
     def model_dump(self, *args, **kwargs):
         exclude = kwargs.pop("exclude", None)

--- a/redbox/redbox/graph/agents/configs.py
+++ b/redbox/redbox/graph/agents/configs.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 from redbox.chains.parser import BaseCumulativeTransformOutputParser, ClaudeParser
 from redbox.models import prompts
@@ -204,8 +204,13 @@ class AgentConfig(BaseModel):
         description="Parser for structured output",
         default=None,
         exclude=True,
+        repr=False,
     )
     default_agent: bool = Field(description="Is this a default redbox worker agents", default=False)
+
+    @field_serializer("parser", when_used="json")
+    def serialize_parser(self, value, info):
+        return None
 
     def model_dump(self, *args, **kwargs):
         exclude = kwargs.pop("exclude", None)

--- a/redbox/redbox/graph/agents/configs.py
+++ b/redbox/redbox/graph/agents/configs.py
@@ -198,7 +198,11 @@ class AgentConfig(BaseModel):
     llm_backend: ChatLLMBackend | None = Field(
         description="The LLM backend model used by the agent. Use None for default model", default=None
     )
-    parser: BaseCumulativeTransformOutputParser | None = Field(description="Parser for structured output", default=None)
+    parser: BaseCumulativeTransformOutputParser | None = Field(
+        description="Parser for structured output",
+        default=None,
+        exclude=True,
+    )
     default_agent: bool = Field(description="Is this a default redbox worker agents", default=False)
 
 

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -131,7 +131,10 @@ class AISettings(BaseModel):
     def replanner_prompt(self):
         return f"{prompts.REPLAN_PROMPT}\n\n{self.get_agent_workers_prompt}\n\n{prompts.PLANNER_FORMAT_PROMPT}\n\n{prompts.PLANNER_QUESTION_PROMPT}"
 
-    planner_system_prompt: str = planner_prompt
+    @property
+    def planner_system_prompt(self) -> str:
+        return self.planner_prompt
+
     planner_question_prompt: str = prompts.PLANNER_QUESTION_PROMPT
     planner_format_prompt: str = prompts.PLANNER_FORMAT_PROMPT
 

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -136,6 +136,9 @@ class AISettings(BaseModel):
 
     @property
     def planner_system_prompt(self) -> str:
+        """Computed property composing the planner prompt from worker agent description.
+        The reason for it is to provide a stable json serialisable string for observability and tracing.
+        """
         return self.planner_prompt
 
     planner_question_prompt: str = prompts.PLANNER_QUESTION_PROMPT

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -109,7 +109,9 @@ class AISettings(BaseModel):
     tool_govuk_returned_results: int = 5
 
     # agents reporting to planner agent
-    worker_agents: List[AgentConfig] = [agent for agent in agent_configs.values() if agent.default_agent]
+    worker_agents: List[AgentConfig] = Field(
+        default_factory=lambda: [agent for agent in agent_configs.values() if agent.default_agent]
+    )
 
     @property
     def get_worker_agents_options(self) -> Dict[str, str]:

--- a/redbox/redbox/models/chain.py
+++ b/redbox/redbox/models/chain.py
@@ -110,7 +110,8 @@ class AISettings(BaseModel):
 
     # agents reporting to planner agent
     worker_agents: List[AgentConfig] = Field(
-        default_factory=lambda: [agent for agent in agent_configs.values() if agent.default_agent]
+        default_factory=lambda: [agent for agent in agent_configs.values() if agent.default_agent],
+        exclude=True,
     )
 
     @property

--- a/redbox/tests/models/conftest.py
+++ b/redbox/tests/models/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_index():
+    yield

--- a/redbox/tests/models/test_chain.py
+++ b/redbox/tests/models/test_chain.py
@@ -3,7 +3,7 @@ from typing import List, Type
 from enum import Enum
 from pydantic import BaseModel, Field, create_model
 
-from redbox.models.chain import TaskStatus, AgentTaskBase, MultiAgentPlanBase, agent_plan_reducer
+from redbox.models.chain import AISettings, TaskStatus, AgentTaskBase, MultiAgentPlanBase, agent_plan_reducer
 
 AgentEnum = Enum("AgentEnum", {"None": {"None"}})
 
@@ -53,6 +53,15 @@ def make_plan(*task: AgentTaskBase) -> MultiAgentPlanBase:
 
 
 class TestAgentPlanReducer:
+    def test_ai_settings_json_serialization_works_for_observability(self):
+        settings = AISettings()
+
+        payload = settings.model_dump(mode="json")
+
+        assert "planner_system_prompt" not in payload
+        assert settings.planner_system_prompt == settings.planner_prompt
+        assert isinstance(payload["planner_question_prompt"], str)
+
     def test_on_none_plans(self):
         assert agent_plan_reducer(None, None) is None
 


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
Datadog LLM observability was failing when tracing Pydantic models because one of the model attributes was defined in a way that Pydantic could not serialise safely during JSON export. This appeared as a PydanticSerializationError in the ddtrace LLM observability path


## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
Wrapped planner_system_prompt as a property rather than a non serialisable default, which allows the model to be safely serialised for tracing and observability. Added a regression test to cover this change.

## Have you written unit tests?
- [X] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
