### PR TITLE
feature/auto-create-minio-bucket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,10 +95,15 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
+    entrypoint: sh
     environment:
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin
-    command: server --console-address ":9001" /data
+    command:
+      - -c
+      - |
+        mkdir -p data/${BUCKET_NAME}
+        minio server --console-address ":9001" /data
     networks:
       - redbox-app-network
     volumes:


### PR DESCRIPTION
## Context

Create a bucket with the `BUCKET_NAME` env var inside minio when container starts
## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
When the app starts, if you haven't already created the bucket in minio you will see bucket not found errors in the logs.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
