### PR TITLE
bugfix/timeout-flaky-errors

### DIFF
--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -503,30 +503,14 @@ async def test_chat_consumer_with_explicit_no_document_selected_error(
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_chat_consumer_get_ai_settings(
-    agents_list: list, chat_with_alice: Chat, mocked_connect_with_explicit_no_document_selected_error: Connect
+    chat_with_alice: Chat,
 ):
-    with (
-        patch("redbox_app.redbox_core.consumers.get_all_agents", new_callable=AsyncMock) as mock_get,
-    ):
-        mock_get.return_value = agents_list
-        communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
-        communicator.scope["user"] = chat_with_alice.user
-        connected, _ = await communicator.connect()
-        assert connected
+    ai_settings = await ChatConsumer.get_ai_settings(chat_with_alice)
 
-        with patch(
-            "redbox_app.redbox_core.consumers.ChatConsumer.redbox.graph",
-            new=mocked_connect_with_explicit_no_document_selected_error,
-        ):
-            ai_settings = await ChatConsumer.get_ai_settings(chat_with_alice)
-
-            assert ai_settings.chat_map_question_prompt == CHAT_MAP_QUESTION_PROMPT
-            assert ai_settings.chat_backend.name == chat_with_alice.chat_backend.name
-            assert ai_settings.chat_backend.provider == chat_with_alice.chat_backend.provider
-            assert not hasattr(ai_settings, "label")
-
-            # Close
-            await communicator.disconnect()
+    assert ai_settings.chat_map_question_prompt == CHAT_MAP_QUESTION_PROMPT
+    assert ai_settings.chat_backend.name == chat_with_alice.chat_backend.name
+    assert ai_settings.chat_backend.provider == chat_with_alice.chat_backend.provider
+    assert not hasattr(ai_settings, "label")
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Context

Remove the chat consumer connect call from a test that does not need it
## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
This test reguarly fails with a TimeoutError. As the test has no dependancies on the ChatConsumer being connected, that setup call can be removed

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
