### PR TITLE
feature/ASSIST-1594-add-reingestion-command

### DIFF
--- a/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
+++ b/django_app/redbox_app/redbox_core/management/commands/reingest_files.py
@@ -1,31 +1,12 @@
+import datetime
 import logging
-import time
 
 from django.core.management import BaseCommand
-from django_q.tasks import async_task
 
-from redbox.models.settings import get_settings
-from redbox_app.redbox_core.models import File
-from redbox_app.worker import ingest
+from redbox_app.redbox_core.models import File, FileTool
+from redbox_app.redbox_core.services.documents import reingest_file
 
 logger = logging.getLogger(__name__)
-
-env = get_settings()
-
-es_client = env.elasticsearch_client()
-
-
-def switch_aliases(alias, new_index):
-    try:
-        response = es_client.indices.get_alias(name=alias)
-        indices_to_remove = list(response)
-    except Exception as e:
-        logger.exception("Error fetching alias", exc_info=e)
-
-    actions = [{"remove": {"index": index, "alias": alias}} for index in indices_to_remove]
-    actions.append({"add": {"index": new_index, "alias": alias}})
-
-    es_client.indices.update_aliases(body={"actions": actions})
 
 
 class Command(BaseCommand):
@@ -35,21 +16,26 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """sync only to be used for testing"""
-        parser.add_argument("sync", nargs="?", type=bool, default=False)
+        parser.add_argument("start_date", type=datetime.date.fromisoformat)
+        parser.add_argument("end_date", type=datetime.date.fromisoformat)
 
-    def handle(self, *_args, **kwargs):
-        self.stdout.write(self.style.NOTICE("Reingesting active files from Django"))
+    def handle(self, **options):
+        start_date = options["start_date"]
+        end_date = options["end_date"]
+        end_datetime = end_date.strftime("%Y-%m-%d 23:59:59")
 
-        new_index = f"{env.elastic_root_index}-chunk-{int(time.time())}"
+        logger.debug("Reingesting files between '%s' and '%s'", start_date, end_datetime)
 
-        for file in File.objects.exclude(status__in=File.INACTIVE_STATUSES):
-            logger.debug("Reingesting file object %s", file)
-            async_task(
-                ingest,
-                file.id,
-                new_index,
-                task_name=file.file_name,
-                group="re-ingest",
-                sync=kwargs["sync"],
-            )
-        async_task(switch_aliases, env.elastic_chunk_alias, new_index, task_name="switch_aliases")
+        queryset = (
+            File.objects.filter(status=File.Status.complete)
+            .exclude(created_at__gt=end_datetime)
+            .exclude(created_at__lt=start_date)
+            .exclude(id__in=FileTool.objects.filter(file_type=FileTool.FileType.ADMIN).values("file__id"))
+        )
+
+        if queryset.count() == 0:
+            logger.debug("No files found between '%s' and '%s'", start_date, end_datetime)
+            return
+
+        for file in queryset:
+            reingest_file(file)

--- a/django_app/tests/management/test_reingest_files.py
+++ b/django_app/tests/management/test_reingest_files.py
@@ -1,0 +1,142 @@
+from datetime import datetime, timedelta
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+import pytz
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from freezegun import freeze_time
+
+from redbox_app.redbox_core.models import File, FileTool, Tool
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestMigrateToMockSSO:
+    def test_reingest_files_throws_expected_error_when_no_args_are_provided(self):
+        with pytest.raises(CommandError):
+            call_command("reingest_files")
+
+    def test_reingest_files_throws_expected_error_when_only_start_date_is_provided(self):
+        with pytest.raises(CommandError):
+            call_command("reingest_files", "2026-06-06")
+
+    def test_reingest_files_throws_expected_error_when_start_date_is_an_invalid_format(self):
+        with pytest.raises(CommandError):
+            call_command("reingest_files", "200-06-06")
+
+    def test_reingest_files_throws_expected_error_when_end_date_is_an_invalid_format(self):
+        with pytest.raises(CommandError):
+            call_command("reingest_files", "2026-06-06", "abc")
+
+    @pytest.mark.parametrize("file_status", [File.Status.deleted, File.Status.errored, File.Status.processing])
+    def test_reingest_files_excludes_file_with_invalid_status_from_async_task(self, alice: User, file_status):
+        test_date = datetime(2026, 6, 4, 0, 0, 0, tzinfo=pytz.UTC)
+
+        with (
+            patch("redbox_app.redbox_core.management.commands.reingest_files.reingest_file") as mock_reingest_file,
+            freeze_time(test_date),
+        ):
+            complete_file = File.objects.create(
+                status=File.Status.complete,
+                original_file="complete.json",
+                user=alice,
+            )
+            File.objects.create(
+                status=file_status,
+                original_file="invalid.json",
+                user=alice,
+            )
+            call_command("reingest_files", (test_date.strftime("%Y-%m-%d")), (test_date.strftime("%Y-%m-%d")))
+
+            mock_reingest_file.assert_has_calls([mock.call(complete_file)])
+
+    def test_reingest_files_excludes_tool_files_from_admin(self, alice: User):
+        with patch("redbox_app.redbox_core.management.commands.reingest_files.reingest_file") as mock_reingest_file:
+            test_date = datetime(2026, 6, 4, 0, 0, 0, tzinfo=pytz.UTC)
+            with freeze_time(test_date + timedelta(hours=10)):
+                included_file_1 = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="complete_1.json",
+                    user=alice,
+                )
+
+                tool = Tool.objects.create(name="test tool")
+                member_file = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="member_tool.json",
+                    user=alice,
+                )
+                FileTool.objects.create(file=member_file, tool=tool, file_type=FileTool.FileType.MEMBER)
+
+                admin_file = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="admin_tool.json",
+                    user=alice,
+                )
+                FileTool.objects.create(file=admin_file, tool=tool, file_type=FileTool.FileType.ADMIN)
+
+                call_command("reingest_files", "2026-06-04", "2026-06-05")
+
+            mock_reingest_file.assert_has_calls(
+                [
+                    mock.call(included_file_1),
+                    mock.call(member_file),
+                ],
+            )
+            assert mock_reingest_file.call_count == 2
+
+    def test_reingest_files_calls_async_task_with_only_files_inside_date_range(self, alice: User):
+        with patch("redbox_app.redbox_core.management.commands.reingest_files.reingest_file") as mock_reingest_file:
+            test_date = datetime(2026, 6, 4, 0, 0, 0, tzinfo=pytz.UTC)
+            with freeze_time(test_date + timedelta(hours=10)):
+                included_file_1 = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="complete_1.json",
+                    user=alice,
+                )
+            with freeze_time(test_date):
+                included_file_2 = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="complete_2.json",
+                    user=alice,
+                )
+            with freeze_time(test_date + timedelta(hours=48) + timedelta(seconds=-1)):
+                included_file_3 = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="complete_3.json",
+                    user=alice,
+                )
+            with freeze_time(test_date + timedelta(hours=24)):
+                included_file_4 = File.objects.create(
+                    status=File.Status.complete,
+                    original_file="complete_4.json",
+                    user=alice,
+                )
+            with freeze_time(test_date + timedelta(seconds=-1)):
+                File.objects.create(
+                    status=File.Status.complete,
+                    original_file="excluded_1.json",
+                    user=alice,
+                )
+            with freeze_time(test_date + timedelta(hours=48)):
+                File.objects.create(
+                    status=File.Status.complete,
+                    original_file="excluded_2.json",
+                    user=alice,
+                )
+
+            call_command("reingest_files", "2026-06-04", "2026-06-05")
+
+            mock_reingest_file.assert_has_calls(
+                [
+                    mock.call(included_file_1),
+                    mock.call(included_file_2),
+                    mock.call(included_file_3),
+                    mock.call(included_file_4),
+                ],
+            )
+            assert mock_reingest_file.call_count == 4

--- a/redbox/redbox/loader/ingester.py
+++ b/redbox/redbox/loader/ingester.py
@@ -2,21 +2,19 @@ import logging
 import time
 import traceback
 from typing import TYPE_CHECKING
-from pydantic import BaseModel
 
 from langchain_community.vectorstores import OpenSearchVectorSearch
 from langchain_core.embeddings import FakeEmbeddings
 from langchain_core.runnables import RunnableParallel
-
+from pydantic import BaseModel
 from redbox_app.redbox_core.enums import IngestChunkingStrategy, IngestExtractionStrategy
+
 from redbox.chains.components import get_embeddings
+from redbox.chains.ingest import DocumentChunkingService, ingest_chunks, ingest_tabular_chunks
+from redbox.loader.extraction.metadata import MetadataExtraction
+from redbox.loader.extraction.service import DocumentExtractionService, IngestionAlreadyInProgress
 from redbox.models.file import ChunkResolution
 from redbox.models.settings import get_settings
-
-from redbox.loader.extraction.service import DocumentExtractionService, IngestionAlreadyInProgress
-from redbox.loader.extraction.metadata import MetadataExtraction
-from redbox.chains.ingest import ingest_chunks, ingest_tabular_chunks, DocumentChunkingService
-
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client


### PR DESCRIPTION
## Context

Amend the reingest admin command to take a date range as arguments
## What

This command will load all files created within the date range, and requeue them for ingestion.
The queue worker is set to have a concurrent limit of 5, so reingesting potentially thousands of files should be no issue

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
