### PR TITLE
feat: Planner agent explicitly states information sources in Negotiation Planner

### DIFF
--- a/redbox/redbox/models/prompts.py
+++ b/redbox/redbox/models/prompts.py
@@ -472,7 +472,7 @@ Use when the user wants to:
 
 IMF_SEARCH_AGENT_DESC = """
 **Imf_Search_Agent**:
-Purpose: Perform searches across the imf.org website domain only
+Purpose: Retrieve information published by the International Monetary Fund (IMF) by performing searches across the imf.org website domain only
 Use when the user wants to search for information or reports on the following topics:
 - Country economic information including GDP, GDP growth, inflation, exchange rates, fiscal balances, current account balances, public debt, foreign reserves
 - Country and international trade including trade trends, tarriff and non-tarrif barriers, global supply chains, trade disruptions, export competitiveness, trade in services, digital trade and climate policies
@@ -483,13 +483,13 @@ Use when the user wants to search for information or reports on the following to
 
 OECD_SEARCH_AGENT_DESC = """
 **Oecd_Search_Agent**:
-Purpose: Perform searches across the oecd.org website domain only
+Purpose: Retrieve information published by the Organisation for Economic Co-operation and Development (OECD) by performing searches across the oecd.org website domain only
 Use when the user wants to search for information or reports on the following topics: Social development, social policy, social issues, education, labour, health, taxation, infrastructure, international development, international cooperation, international equality, international inequality, standards of living, economic development, economic policy, productivity, technology, digital development, geopolitics, environmental issues, sustainability, policy advice on these themes, national policy on these themes, international policy on these themes.
 """
 
 WTO_SEARCH_AGENT_DESC = """
 **Wto_Search_Agent**:
-Purpose: Perform searches across the wto.org website domain only
+Purpose: Retrieve information published by the World Trade Organisation (WTO) by performing searches across the wto.org website domain only
 Use when the user wants to search for information or reports on the following topics: International trade, trade policy, trade agreements, trade rules, trade disputes, legal information related to trade, barriers to trade, enablement of trade, trade tariffs, non-tariff measures, trade subsidies, trade statistics, trade of goods, trade of services, digital trade, geopolitics.
 """
 
@@ -571,8 +571,7 @@ Operational Framework
 - Identify dependencies between sub-tasks
 - Select the most appropriate agent for each sub-task from the available agent pool
 - Prioritise internal reasoning (pre-trained knowledge or provided documents); avoid external retrieval/web search unless strictly necessary, factoring in cost and latency.
-- Create a structured execution plan with clear success criteria for each step
-
+- Create a structured execution plan with clear success criteria for each step. In each step of the execution plan name the type of source or capability that will be used.
 """
 
 PLANNER_PROMPT_BOTTOM = """


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

Ticket: [A3P-192](https://uktrade.atlassian.net/browse/A3P-192)

Plans generated by the planner agent don't always clearly state information sources used in each step. An example is in the ticket description.

This change updates the planner agent prompt and the descriptions of some agents used by Negotiation Planner, so that the planner agent generates plans that clearly state the information source or capability used in each step.

## What

1. Update [PLANNER_AGENT_PROMPT](https://github.com/uktrade/redbox/pull/1199/changes#diff-e38ee943f078515f45d74ec89d7bebbf4aab58e1cf6a7a8cd92c8f4b9cd657cbR574) to clearly state the information source or capability used in each step.
2. Update the descriptions of the [WTO](https://github.com/uktrade/redbox/pull/1199/changes#diff-e38ee943f078515f45d74ec89d7bebbf4aab58e1cf6a7a8cd92c8f4b9cd657cbR492), [IMF](https://github.com/uktrade/redbox/pull/1199/changes#diff-e38ee943f078515f45d74ec89d7bebbf4aab58e1cf6a7a8cd92c8f4b9cd657cbL574) and [OECD](https://github.com/uktrade/redbox/pull/1199/changes#diff-e38ee943f078515f45d74ec89d7bebbf4aab58e1cf6a7a8cd92c8f4b9cd657cbR486) agents to more clearly state the information sources they use.

## Have you written unit tests?
- [ ] Yes
- [x] No: Changes do not impact unit testable components.


## Are there any specific instructions on how to test this change?
- [X] Yes: [See this section of the ticket](https://uktrade.atlassian.net/browse/A3P-192#:~:text=other%20Assist%20skills-,Testing%20Guidance,-1.%20Changes%20to).
- [ ] No


## Relevant links


[A3P-192]: https://uktrade.atlassian.net/browse/A3P-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ