### PR TITLE
feat: idempotent chunk ingestion - add chunk removal before chunk add

### DIFF
--- a/redbox/redbox/chains/ingest.py
+++ b/redbox/redbox/chains/ingest.py
@@ -31,8 +31,39 @@ def log_chunks(chunks: list[Document]):
     return chunks
 
 
+def _delete_existing_chunks(vectorstore: VectorStore, uri: str) -> None:
+    """Delete previously ingested chunks for this file from the vectorstore's index.
+
+    Prevents duplicate chunks from accumulating when a file is reingested.
+    Matches on metadata.uri.keyword, which identifies chunks as originating
+    from the same source file. Uses the underlying ES client directly since
+    ElasticsearchStore.delete() only supports deletion by id, not by
+    arbitrary metadata filter.
+    """
+    es_client = vectorstore.client
+    index_name = vectorstore.index_name
+
+    try:
+        response = es_client.delete_by_query(
+            index=index_name,
+            body={"query": {"term": {"metadata.uri.keyword": uri}}},
+            conflicts="proceed",
+            refresh=False,
+        )
+        log.warning(
+            "Deleted %s existing chunks for uri=%s from index=%s",
+            response.get("deleted", 0),
+            uri,
+            index_name,
+        )
+    except Exception:
+        log.exception("Failed to delete existing chunks for uri=%s from index=%s", uri, index_name)
+        raise
+
+
 def chunk_loader(
     chunker: DocumentChunkingService,
+    vectorstore: VectorStore,
     elements: list[str] | list[Element] | list[dict[str, str]],
     metadata: GeneratedMetadata,
     chunks_overlap_pages: bool,
@@ -41,6 +72,8 @@ def chunk_loader(
     def wrapped(file_name: str) -> tuple[IngestChunkingStrategy, Iterator[Document]]:
         try:
             log.info("wrapped START: %s", file_name)
+
+            _delete_existing_chunks(vectorstore, file_name)
 
             strategy, raw_docs = chunker.chunks(
                 s3_key=file_name,
@@ -65,6 +98,7 @@ def chunk_loader(
 
 def chunk_loader_tabular(
     chunker: DocumentChunkingService,
+    vectorstore: VectorStore,
     tabular_elements: list[dict[str, str]],
     metadata: GeneratedMetadata,
     include_schema_metadata: bool,
@@ -73,6 +107,8 @@ def chunk_loader_tabular(
     def wrapped(file_name: str) -> tuple[IngestChunkingStrategy, Iterator[Document]]:
         try:
             log.info("wrapped START: %s", file_name)
+
+            _delete_existing_chunks(vectorstore, file_name)
 
             strategy, raw_docs = chunker.tabular_chunks(
                 s3_key=file_name,
@@ -112,6 +148,7 @@ def ingest_chunks(
 
     loader = chunk_loader(
         chunker=chunker,
+        vectorstore=vectorstore,
         elements=elements,
         metadata=metadata,
         chunks_overlap_pages=chunks_overlap_pages,
@@ -143,6 +180,7 @@ def ingest_tabular_chunks(
 ) -> Runnable:
     loader = chunk_loader_tabular(
         chunker=chunker,
+        vectorstore=vectorstore,
         tabular_elements=tabular_elements,
         metadata=metadata,
         include_schema_metadata=include_schema_metadata,

--- a/redbox/redbox/chains/ingest.py
+++ b/redbox/redbox/chains/ingest.py
@@ -5,6 +5,7 @@ from typing import Iterator
 from langchain.vectorstores import VectorStore
 from langchain_core.documents.base import Document
 from langchain_core.runnables import Runnable, RunnableLambda, chain, RunnableParallel
+from redbox.models.file import ChunkResolution
 from unstructured.documents.elements import Element
 
 from redbox_app.redbox_core.enums import IngestChunkingStrategy
@@ -31,14 +32,16 @@ def log_chunks(chunks: list[Document]):
     return chunks
 
 
-def _delete_existing_chunks(vectorstore: VectorStore, uri: str) -> None:
-    """Delete previously ingested chunks for this file from the vectorstore's index.
+def _delete_existing_chunks(
+    vectorstore: VectorStore,
+    uri: str,
+    chunk_resolution: ChunkResolution,
+) -> None:
+    """Delete previously ingested chunks for this file and chunk resolution.
 
     Prevents duplicate chunks from accumulating when a file is reingested.
-    Matches on metadata.uri.keyword, which identifies chunks as originating
-    from the same source file. Uses the underlying ES client directly since
-    ElasticsearchStore.delete() only supports deletion by id, not by
-    arbitrary metadata filter.
+    Matches on both metadata.uri.keyword and
+    metadata.chunk_resolution.keyword.
     """
     es_client = vectorstore.client
     index_name = vectorstore.index_name
@@ -46,18 +49,33 @@ def _delete_existing_chunks(vectorstore: VectorStore, uri: str) -> None:
     try:
         response = es_client.delete_by_query(
             index=index_name,
-            body={"query": {"term": {"metadata.uri.keyword": uri}}},
+            body={
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"term": {"metadata.uri.keyword": uri}},
+                            {"term": {"metadata.chunk_resolution.keyword": chunk_resolution.value}},
+                        ]
+                    }
+                }
+            },
             conflicts="proceed",
             refresh=False,
         )
         log.warning(
-            "Deleted %s existing chunks for uri=%s from index=%s",
+            "Deleted %s existing chunks for uri=%s, chunk_resolution=%s from index=%s",
             response.get("deleted", 0),
             uri,
+            chunk_resolution,
             index_name,
         )
     except Exception:
-        log.exception("Failed to delete existing chunks for uri=%s from index=%s", uri, index_name)
+        log.exception(
+            "Failed to delete existing chunks for uri=%s, chunk_resolution=%s from index=%s",
+            uri,
+            chunk_resolution,
+            index_name,
+        )
         raise
 
 
@@ -73,7 +91,7 @@ def chunk_loader(
         try:
             log.info("wrapped START: %s", file_name)
 
-            _delete_existing_chunks(vectorstore, file_name)
+            _delete_existing_chunks(vectorstore, file_name, chunker.chunk_resolution)
 
             strategy, raw_docs = chunker.chunks(
                 s3_key=file_name,
@@ -108,7 +126,7 @@ def chunk_loader_tabular(
         try:
             log.info("wrapped START: %s", file_name)
 
-            _delete_existing_chunks(vectorstore, file_name)
+            _delete_existing_chunks(vectorstore, file_name, chunker.chunk_resolution)
 
             strategy, raw_docs = chunker.tabular_chunks(
                 s3_key=file_name,

--- a/redbox/redbox/loader/chunking/service.py
+++ b/redbox/redbox/loader/chunking/service.py
@@ -64,6 +64,11 @@ class DocumentChunkingService:
         max_chunk_size: int = 2000,
         overlap_chars: int = 200,
     ):
+        self.chunk_resolution = chunk_resolution
+        self.min_chunk_size = min_chunk_size
+        self.max_chunk_size = max_chunk_size
+        self.overlap_chars = overlap_chars
+
         self.chunker_page_by_page = PageByPageDocumentChunker(
             chunk_resolution=chunk_resolution,
             min_chunk_size=min_chunk_size,
@@ -91,10 +96,10 @@ class DocumentChunkingService:
         logger.warning(
             "%s Initialised DocumentChunkingService (chunk_resolution=%s, min_chunk_size=%s, max_chunk_size=%s, overlap_chars=%s)",
             self.log_stub,
-            chunk_resolution,
-            min_chunk_size,
-            max_chunk_size,
-            overlap_chars,
+            self.chunk_resolution,
+            self.min_chunk_size,
+            self.max_chunk_size,
+            self.overlap_chars,
         )
 
     def tabular_chunks(


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context
So that when files are reingested we do not get duplicate/conflicting chunks. Given the current implementation only adds new chunks it does not check for any pre-existing ones to replace/remove.

## What
Adds new function `_delete_existing_chunks` which deletes pre-existing chunks by querying `metadata.uri.keyword` and `metadata.chunk_resolution.keyword` on the respective ES client before adding the new chunks.

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
