### PR TITLE
feature/ASSIST-1594-add-reingestion-function

### DIFF
--- a/django_app/redbox_app/redbox_core/services/documents.py
+++ b/django_app/redbox_app/redbox_core/services/documents.py
@@ -117,6 +117,20 @@ def ingest_file(uploaded_file: UploadedFile, user: User, tool: Tool | None = Non
         return [], file
 
 
+def reingest_file(file: File):
+    logger.debug("Updating file '%s' to be processing", file)
+    file.status = File.Status.processing
+    file.save()
+
+    logger.debug("Reingesting file '%s'", file)
+    async_task(
+        ingest,
+        file.id,
+        task_name=file.unique_name,
+        group="re-ingest",
+    )
+
+
 @dataclass
 class UploadResult:
     errors: list[str] = field(default_factory=list)

--- a/django_app/redbox_app/worker.py
+++ b/django_app/redbox_app/worker.py
@@ -2,6 +2,7 @@ import logging
 import subprocess
 import tempfile
 import time
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from uuid import UUID
@@ -188,6 +189,7 @@ def ingest(file_id: UUID, es_index: str | None = None) -> None:
         file.ingest_error = error
     else:
         file.status = File.Status.complete
+        file.ingested_at = datetime.now(tz=UTC)
         file.ingest_extraction_strategy_normal = response.normal_extraction_strategy
         file.ingest_chunking_strategy_normal = response.normal_chunking_strategy
         file.ingest_extraction_strategy_largest = response.largest_extraction_strategy

--- a/django_app/tests/services/test_documents_service.py
+++ b/django_app/tests/services/test_documents_service.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -152,3 +153,21 @@ def test_process_uploads_skips_none_file_obj(mock_ingest, alice, original_file: 
     assert result.files == []
     assert result.ingest_errors == ["ingest failed"]
     assert result.errors == []
+
+
+@pytest.mark.django_db
+@patch("redbox_app.redbox_core.services.documents.async_task")
+def test_reingest_file_resets_file_during_reingest(uploaded_file: File):
+    uploaded_file.status = File.Status.complete
+    uploaded_file.save()
+    documents_service.reingest_file(uploaded_file)
+    assert uploaded_file.status is File.Status.processing
+
+
+@pytest.mark.django_db
+@patch("redbox_app.redbox_core.services.documents.async_task")
+def test_reingest_file_calls_async_task_with_expected_args(mock_async_task, uploaded_file: File):
+    documents_service.reingest_file(uploaded_file)
+    mock_async_task.assert_has_calls(
+        [mock.call(mock.ANY, uploaded_file.id, task_name=uploaded_file.unique_name, group="re-ingest")],
+    )


### PR DESCRIPTION
## Context

- Add a new function that can trigger a file to be reingested
- When the worker completes the ingest, set the new ingested_at field

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
