### PR TITLE
feat: Add re-ingest action

### DIFF
--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -2,20 +2,26 @@ import logging
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
-from django_q.tasks import async_task
 
 from redbox_app.redbox_core.models import File
-from redbox_app.worker import ingest
+from redbox_app.redbox_core.services.documents import reingest_file
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def reupload(_self, _request, queryset):
+@admin.action(description="Re-ingest files")
+def reingest(self, request, queryset):
+    if not (file_count := len(queryset)):
+        return logger.error("No files selected for re-ingestion")
+
     for file in queryset:
-        logger.info("Re-uploading file to core-api: %s", file)
-        async_task(ingest, file.id)
-        logger.info("Successfully reuploaded file %s.", file)
+        reingest_file(file)
+
+    msg = f"Re-ingesting {file_count} files"
+
+    logger.info(msg)
+    return self.message_user(request, msg)
 
 
 @admin.action(description="Backfill original file names")
@@ -31,7 +37,7 @@ def backfill_original_file_names(self, request, queryset):
 
     File.objects.bulk_update(files, ["original_file_name"])
 
-    self.message_user(
+    return self.message_user(
         request,
         f"Updated {updated} files.",
     )

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 from django.shortcuts import render
 from import_export.admin import ExportMixin, ImportExportMixin
 
-from redbox_app.redbox_core.actions import backfill_original_file_names, reupload
+from redbox_app.redbox_core.actions import backfill_original_file_names, reingest
 
 from . import models
 from .serializers import UserSerializer
@@ -279,7 +279,7 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
     ]
     list_filter = ["user", "status", "ingested_at"]
     date_hierarchy = "created_at"
-    actions = [reupload, backfill_original_file_names]
+    actions = [reingest, backfill_original_file_names]
     search_fields = ["user__email", "original_file_name"]
 
 

--- a/django_app/tests/test_actions.py
+++ b/django_app/tests/test_actions.py
@@ -44,7 +44,7 @@ def test_backfill_original_file_names_action(client: Client, alice: User):
 
 
 @pytest.mark.django_db
-def test_reingest_action_triggers_async_task(client, alice):
+def test_reingest_action_triggers_reingest_file(client, alice):
     # Given
     client.force_login(alice)
 

--- a/django_app/tests/test_actions.py
+++ b/django_app/tests/test_actions.py
@@ -6,9 +6,8 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client, RequestFactory
 
-from redbox_app.redbox_core.actions import backfill_original_file_names, reupload
+from redbox_app.redbox_core.actions import backfill_original_file_names, reingest
 from redbox_app.redbox_core.models import File
-from redbox_app.worker import ingest
 
 User = get_user_model()
 
@@ -45,7 +44,7 @@ def test_backfill_original_file_names_action(client: Client, alice: User):
 
 
 @pytest.mark.django_db
-def test_reupload_action_triggers_async_task(client, alice):
+def test_reingest_action_triggers_async_task(client, alice):
     # Given
     client.force_login(alice)
 
@@ -64,11 +63,11 @@ def test_reupload_action_triggers_async_task(client, alice):
     request = RequestFactory().get("/admin/")
 
     # When
-    with patch("redbox_app.redbox_core.actions.async_task") as mock_async_task:
-        reupload(mock_admin, request, queryset)
+    with patch("redbox_app.redbox_core.actions.reingest_file") as mock_reingest_file:
+        reingest(mock_admin, request, queryset)
 
     # Then
-    assert mock_async_task.call_count == 2
+    assert mock_reingest_file.call_count == 2
 
-    mock_async_task.assert_any_call(ingest, file1.id)
-    mock_async_task.assert_any_call(ingest, file2.id)
+    mock_reingest_file.assert_any_call(file1)
+    mock_reingest_file.assert_any_call(file2)


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR adds the re-ingest action for the File model in django-admin.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Added re-ingest action

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Updated existing

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Optional: Can check if ingested_at is updated when the action is run, otherwise test in dev where historic files exist

## Relevant links
[ASSIST-1594](https://uktrade.atlassian.net/jira/software/projects/ASSIST/boards/558?selectedIssue=ASSIST-1594)
<img width="563" height="479" alt="image" src="https://github.com/user-attachments/assets/be64e447-53fa-4ec6-b171-4ebf3d11f392" />


[ASSIST-1594]: https://uktrade.atlassian.net/browse/ASSIST-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ