### PR TITLE
feat: Add re-ingest action to FileTool model in django admin

### DIFF
--- a/django_app/redbox_app/redbox_core/actions.py
+++ b/django_app/redbox_app/redbox_core/actions.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 
-from redbox_app.redbox_core.models import File
+from redbox_app.redbox_core.models import File, FileTool
 from redbox_app.redbox_core.services.documents import reingest_file
 
 logger = logging.getLogger(__name__)
@@ -15,8 +15,13 @@ def reingest(self, request, queryset):
     if not (file_count := len(queryset)):
         return logger.error("No files selected for re-ingestion")
 
-    for file in queryset:
-        reingest_file(file)
+    if self.model == FileTool:
+        for file_tool in queryset:
+            reingest_file(file_tool.file)
+
+    else:
+        for file in queryset:
+            reingest_file(file)
 
     msg = f"Re-ingesting {file_count} files"
 

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -289,6 +289,7 @@ class FileToolAdmin(ExportMixin, admin.ModelAdmin):
     date_hierarchy = "created_at"
     search_fields = ("file__original_file_name", "tool__name")
     raw_id_fields = ["file"]
+    actions = [reingest]
 
 
 class UserToolAdmin(ExportMixin, admin.ModelAdmin):

--- a/django_app/tests/test_actions.py
+++ b/django_app/tests/test_actions.py
@@ -59,7 +59,7 @@ def test_reingest_action_triggers_reingest_file(client, alice):
 
     queryset = File.objects.filter(id__in=[file1.id, file2.id])
 
-    mock_admin = SimpleNamespace(message_user=lambda *_args, **_kwargs: None)
+    mock_admin = SimpleNamespace(model=File, message_user=lambda *_args, **_kwargs: None)
     request = RequestFactory().get("/admin/")
 
     # When

--- a/django_app/tests/test_actions.py
+++ b/django_app/tests/test_actions.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.test import Client, RequestFactory
 
 from redbox_app.redbox_core.actions import backfill_original_file_names, reingest
-from redbox_app.redbox_core.models import File
+from redbox_app.redbox_core.models import File, FileTool, Tool
 
 User = get_user_model()
 
@@ -44,7 +44,7 @@ def test_backfill_original_file_names_action(client: Client, alice: User):
 
 
 @pytest.mark.django_db
-def test_reingest_action_triggers_reingest_file(client, alice):
+def test_reingest_action_triggers_reingest_file_for_file(client: Client, alice: User):
     # Given
     client.force_login(alice)
 
@@ -60,6 +60,39 @@ def test_reingest_action_triggers_reingest_file(client, alice):
     queryset = File.objects.filter(id__in=[file1.id, file2.id])
 
     mock_admin = SimpleNamespace(model=File, message_user=lambda *_args, **_kwargs: None)
+    request = RequestFactory().get("/admin/")
+
+    # When
+    with patch("redbox_app.redbox_core.actions.reingest_file") as mock_reingest_file:
+        reingest(mock_admin, request, queryset)
+
+    # Then
+    assert mock_reingest_file.call_count == 2
+
+    mock_reingest_file.assert_any_call(file1)
+    mock_reingest_file.assert_any_call(file2)
+
+
+@pytest.mark.django_db
+def test_reingest_action_triggers_reingest_file_for_file_tool(client: Client, alice: User, default_tool: Tool):
+    # Given
+    client.force_login(alice)
+
+    file1 = File.objects.create(
+        user=alice,
+        original_file="alice/test1.pdf",
+    )
+    file2 = File.objects.create(
+        user=alice,
+        original_file="alice/test2.pdf",
+    )
+
+    file_tool1 = FileTool.objects.create(file=file1, tool=default_tool, file_type=FileTool.FileType.ADMIN)
+    file_tool2 = FileTool.objects.create(file=file2, tool=default_tool, file_type=FileTool.FileType.ADMIN)
+
+    queryset = FileTool.objects.filter(id__in=[file_tool1.id, file_tool2.id])
+
+    mock_admin = SimpleNamespace(model=FileTool, message_user=lambda *_args, **_kwargs: None)
     request = RequestFactory().get("/admin/")
 
     # When


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context
This PR adds the re-ingest action to the FileTool model to make reingesting Knowledge base files easier.

## What
- Added the re-ingest action to the FileTool model
- Updated re-ingest action to be context-aware of the model in order to select the correct attribute

## Have you written unit tests?
- [x] Yes
- [x] No (add why you have not)

Updated existing test

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

###

- Confirm re-ingest action is present on the FileTool model in django admin

## Relevant links
[ASSIST-1594](https://uktrade.atlassian.net/jira/software/projects/ASSIST/boards/558?selectedIssue=ASSIST-1594)
https://github.com/uktrade/redbox/pull/1205
<img width="492" height="457" alt="image" src="https://github.com/user-attachments/assets/ebe9ab5c-4d2e-4570-be7f-799401adca47" />


[ASSIST-1594]: https://uktrade.atlassian.net/browse/ASSIST-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ