### PR TITLE
chore: Add file status filter and display to FileTool model in django admin

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -284,12 +284,16 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
 
 
 class FileToolAdmin(ExportMixin, admin.ModelAdmin):
-    list_display = ["file", "tool", "file_type", "created_at"]
-    list_filter = ["tool", "file_type"]
+    list_display = ["file", "tool", "file_type", "created_at", "file_status_display"]
+    list_filter = ["tool", "file_type", "file__status"]
     date_hierarchy = "created_at"
     search_fields = ("file__original_file_name", "tool__name")
     raw_id_fields = ["file"]
     actions = [reingest]
+
+    @admin.display(ordering="file__status", description="File Status")
+    def file_status_display(self, obj):
+        return obj.file.status if obj.file else "No File"
 
 
 class UserToolAdmin(ExportMixin, admin.ModelAdmin):

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -284,8 +284,15 @@ class FileAdmin(ExportMixin, admin.ModelAdmin):
 
 
 class FileToolAdmin(ExportMixin, admin.ModelAdmin):
-    list_display = ["file", "tool", "file_type", "created_at", "file_status_display"]
-    list_filter = ["tool", "file_type", "file__status"]
+    list_display = [
+        "file",
+        "tool",
+        "file_type",
+        "created_at",
+        "file_ingested_at_display",
+        "file_status_display",
+    ]
+    list_filter = ["tool", "file_type", "file__status", "file__ingested_at"]
     date_hierarchy = "created_at"
     search_fields = ("file__original_file_name", "tool__name")
     raw_id_fields = ["file"]
@@ -294,6 +301,10 @@ class FileToolAdmin(ExportMixin, admin.ModelAdmin):
     @admin.display(ordering="file__status", description="File Status")
     def file_status_display(self, obj):
         return obj.file.status if obj.file else "No File"
+
+    @admin.display(ordering="file__ingested_at", description="File Ingested at")
+    def file_ingested_at_display(self, obj):
+        return obj.file.ingested_at if obj.file else "No File"
 
 
 class UserToolAdmin(ExportMixin, admin.ModelAdmin):


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## Context

<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->
This PR improves the UX for the Django admin FileTool model page when re-ingesting files.

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->

- Add file status to list_display to monitor ingestion status from FileTool model page
- Added file status filter to FileTool model page.
- Also added ingested_at filter/display for easier debugging in the case of multiple re-ingest attempts.

## Have you written unit tests?
- [ ] Yes
- [x] No (add why you have not)

Admin

## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [x] Yes (if so provide more detail)
- [ ] No

Check file status display and filter are visible in the django admin page for FileTool

## Relevant links
<img width="1525" height="859" alt="image" src="https://github.com/user-attachments/assets/beb86ae0-9bc6-435e-9c6d-afa8c74d5698" />
