### PR TITLE
feature: add new chat to side pannel

### DIFF
--- a/django_app/frontend/src/interaction_design_system/ids/components/card.scss
+++ b/django_app/frontend/src/interaction_design_system/ids/components/card.scss
@@ -57,6 +57,13 @@
   gap: 10px;
 }
 
+.ids-card__item--selected {
+  border-left: 4px solid;
+  border-color: var(--dbt-light-blue);
+  padding-left: 3px;
+  font-weight: 700;
+}
+
 /* Item internals (generic helpers) */
 .ids-item-label {
   flex: 1;

--- a/django_app/redbox_app/templates/side_panel/conversations.html
+++ b/django_app/redbox_app/templates/side_panel/conversations.html
@@ -2,6 +2,43 @@
 {% from "ids/components/show-more.html" import show_more %}
 {% from "macros/icon.html" import ids_icon %}
 
+{% if enable_chats_redesign %}
+<section id="conversations" class="ids-card ids-card--no-border">
+  <nav class="govuk-!-margin-bottom-0" aria-label="Chats">
+    <div class="ids-card__header">
+      <h2 class="side-panel-heading__text govuk-heading-s govuk-!-margin-bottom-0">Chats</h2>
+    </div>
+    <div class="ids-card__content">
+      <ul class="ids-card__list">
+        {% set active_chat_id = request.resolver_match.kwargs.get('chat_id') %}
+        {% for chat in chats[:5] %}
+        <li class="ids-card__item {{ 'ids-card__item--selected' if chat.id == active_chat_id }}" data-chatid="{{ chat.id }}">
+            <span class="item-text-container ids-text-ellipses">
+                <a class="item-link govuk-link govuk-link--no-visited-state govuk-link--no-underline display title-text"
+                    href="{{ chat.url }}"
+                    {{ 'aria-current="page"'|safe if chat.id == active_chat_id }}
+                    title="{{ chat.name }}">
+                    <span class="govuk-visually-hidden">Chat: </span>{{ chat.name }}
+                </a>
+            </span>
+        </li>
+        {% endfor %}
+        {% set active_all_chats = request.resolver_match.url_name == 'all-chats' %}
+        <li class="ids-card__item {{ 'ids-card__item--selected' if active_all_chats }}">
+            <span class="item-text-container ids-text-ellipses">
+                <a class="item-link govuk-link govuk-link--no-visited-state govuk-link--no-underline display title-text"
+                    href="{{ url('all-chats') }}"
+                    {{ 'aria-current="page"'|safe if active_all_chats }}
+                    >
+                    All chats
+                </a>
+            </span>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</section>
+{% else %}
 <section id="conversations" class="ids-card ids-card--no-border" hx-swap-oob="outerHTML">
     <div class="ids-card__content">
         <chat-history class="ids-width--full">
@@ -26,3 +63,4 @@
         </chat-history>
     </div>
 </section>
+{% endif %}

--- a/django_app/redbox_app/templates/side_panel/new_chat.html
+++ b/django_app/redbox_app/templates/side_panel/new_chat.html
@@ -1,0 +1,18 @@
+{% set active_new_chat = request.resolver_match.url_name == 'chats' and not request.resolver_match.kwargs %}
+<section class="ids-card ids-card--no-border">
+    <div class="ids-card__content">
+        <div class="ids-card__item {{ 'ids-card__item--selected' if active_new_chat }}">
+            <a class="ids_item-link govuk-link govuk-link--no-visited-state govuk-link--no-underline display title-text"
+            href="{{ url('chats') }}"
+            {{ 'aria-current="page"'|safe if active_new_chat }}
+            >
+                <svg width="16" height="16" viewBox="0 0 16 16"
+                    fill="none" stroke="currentColor" stroke-width="2"
+                    aria-hidden="true" focusable="false">
+                    <path d="M8 3v10M3 8h10"/>
+                </svg>
+                New chat
+            </a>
+        </div>
+    </div>
+</section>

--- a/django_app/redbox_app/templates/side_panel/side_panel.html
+++ b/django_app/redbox_app/templates/side_panel/side_panel.html
@@ -17,6 +17,7 @@
             {% include "side_panel/header.html" %}
 
             <div class="ids-side-panel__content ids-scrollable">
+                {% include "side_panel/new_chat.html" %}
                 {% include "side_panel/conversations.html" %}
                 {% include "side_panel/model_selector.html" %}
                 {% include "side_panel/your_documents.html" %}

--- a/django_app/tests/views/test_side_panel.py
+++ b/django_app/tests/views/test_side_panel.py
@@ -1,0 +1,68 @@
+from collections.abc import Callable, Sequence
+from datetime import datetime
+from http import HTTPStatus
+from zoneinfo import ZoneInfo
+
+import pytest
+from bs4 import BeautifulSoup
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from waffle.testutils import override_flag
+
+from redbox_app.redbox_core.models import (
+    Chat,
+)
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@override_flag("enable_chats_redesign", active=True)
+def test_sidebar_renders_five_most_recent_chats(
+    user_with_chats_with_messages_over_time: User, make_chat_with_message_at_specific_time: Callable, client: Client
+):
+    # Given
+    user = user_with_chats_with_messages_over_time
+
+    utc = ZoneInfo("UTC")
+    # pad chats to test 5 chat cap
+    for i in range(6):
+        make_chat_with_message_at_specific_time(f"pad-chat-{i}", datetime(1900, 1, 1, tzinfo=utc), user)
+
+    client.force_login(user)
+    chats: Sequence[Chat] = Chat.get_ordered_by_last_message_date(user)
+    expected_names = [chat.name for chat in chats[:5]]
+    expected_names.append("All chats")
+    url = reverse("chats")
+
+    # When
+    response = client.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    chat_links = soup.select("ul.ids-card__list li.ids-card__item .item-link")
+    rendered_names = [link.get_text(strip=True).removeprefix("Chat:").strip() for link in chat_links]
+    assert rendered_names == expected_names
+    assert len(chat_links) == 6
+
+
+@pytest.mark.django_db
+@override_flag("enable_chats_redesign", active=True)
+def test_active_chat_is_marked_selected(user_with_chats_with_messages_over_time: User, client: Client):
+    # Given
+    user = user_with_chats_with_messages_over_time
+    client.force_login(user)
+    chat = Chat.get_ordered_by_last_message_date(user)[0]
+    url = reverse("chats", kwargs={"chat_id": chat.id})  # adjust name to your detail route
+
+    # When
+    response = client.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Then
+    selected = soup.select("li.ids-card__item--selected")
+    assert len(selected) == 1
+    assert selected[0]["data-chatid"] == str(chat.id)
+    assert selected[0].select_one(".item-link")["aria-current"] == "page"


### PR DESCRIPTION
* feature: add all chats page

---------

Signed-off-by: DBT pre-commit check

## Context

Part of the redesign work

## What

Adds new chat link
adds 5 most recent chats to side panel along with the pre-existing 'all chats' link
A small amount of css to demo the select funcitonality, full styling will be done later

## Have you written unit tests?
- [x] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

Make sure to set 'enable_chats_redesign' in django waffle to test


## Relevant links
