### PR TITLE
bugfix/stop-root-account-errors-in-the-postgres-container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready", "-U", "redbox-core", "-d", "db_prod" ]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
       interval: 5s
       timeout: 30s
       retries: 24


### PR DESCRIPTION
## Context
Remove the error message that appears in the postgres logs when running integration tests
<!-- Why are you making this change? What might surprise someone about it? What problem does this PR solve?-->

## What

<!-- What is this PR doing? What is being accomplished by this change in the code? -->
When running integration tests the healthcheck causes the below message to appear inside the postgres container
` FATAL:  role "root" does not exist`. This change uses the env vars instead of a hardcoded username and database

## Have you written unit tests?
- [ ] Yes
- [ ] No (add why you have not)


## Are there any specific instructions on how to test this change?

<!-- Are there any specific ways you want this code to be tested? Provide as much detail as possible. -->
- [ ] Yes (if so provide more detail)
- [ ] No


## Relevant links
